### PR TITLE
Fix auth callback error handling and harden new user trigger

### DIFF
--- a/app/(auth)/auth/login/page.tsx
+++ b/app/(auth)/auth/login/page.tsx
@@ -29,6 +29,7 @@ interface LoginPageProps {
 const ERROR_MESSAGES: Record<string, string> = {
   invalid_domain: "Only authorized company accounts can sign in.",
   auth_callback_error: "Authentication failed. Please try again.",
+  database_error: "Account setup failed. Please try again or contact support.",
 }
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
@@ -40,7 +41,9 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
 
   // Use ?next param if provided, otherwise fall back to config
   const redirectTo = params.next || authConfig.redirectTo
-  const errorMessage = params.error ? ERROR_MESSAGES[params.error] : null
+  const errorMessage = params.error
+    ? (ERROR_MESSAGES[params.error] || "Authentication failed. Please try again.")
+    : null
 
   // Production supabase mode: Google-only
   const isGoogleOnly = authConfig.mode === "supabase" && !isLocalhost

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -29,14 +29,18 @@ export async function GET(request: NextRequest) {
 
   const supabase = await createClient()
 
-  // Handle error passed from Supabase (e.g., expired link)
+  // Handle error passed from Supabase (e.g., expired link, trigger failure)
   if (errorParam) {
     console.error("[Auth Callback] Supabase error:", errorParam, errorDescription)
     // For email change, redirect to profile with helpful message
     if (type === "email_change") {
       return redirectWithToast(origin, "/admin/profile", "email-link-expired")
     }
-    return NextResponse.redirect(`${origin}/auth/login?error=${errorParam}`)
+    // Map Supabase errors to friendly error codes
+    const errorCode = errorDescription?.includes("Database error")
+      ? "database_error"
+      : "auth_callback_error"
+    return NextResponse.redirect(`${origin}/auth/login?error=${errorCode}`)
   }
 
   // 1. Handle PKCE code exchange (OAuth, magic link, email change)
@@ -97,12 +101,15 @@ export async function GET(request: NextRequest) {
       || "User"
 
     const role = user.email?.endsWith("@launchpathventures.com") ? "admin" : "learner"
-    await supabase.from("user_profiles").insert({
+    const { error: profileError } = await supabase.from("user_profiles").insert({
       id: user.id,
       full_name: fullName,
       role,
       certification_status: "in_progress",
     })
+    if (profileError) {
+      console.error("[Auth Callback] Failed to create user profile:", profileError.message)
+    }
   }
 
   // Determine toast based on context

--- a/supabase/migrations/20260410000000_fix_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260410000000_fix_handle_new_user_trigger.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- Fix handle_new_user() trigger to not block user creation
+-- =============================================================================
+-- The trigger was failing silently and returning "Database error saving new user"
+-- from Supabase GoTrue. This wraps the profile INSERT in an exception handler
+-- so user creation always succeeds — the auth callback has fallback code to
+-- create the profile if the trigger fails.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  user_role TEXT;
+BEGIN
+  -- Only create profiles for allowed domains
+  IF NEW.email IS NOT NULL
+     AND NEW.email NOT LIKE '%@primecapitaldubai.com'
+     AND NEW.email NOT LIKE '%@launchpathventures.com'
+  THEN
+    RETURN NEW;
+  END IF;
+
+  -- Assign role based on domain
+  IF NEW.email LIKE '%@launchpathventures.com' THEN
+    user_role := 'admin';
+  ELSE
+    user_role := 'learner';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.user_profiles (id, full_name, role, certification_status)
+    VALUES (
+      NEW.id,
+      COALESCE(
+        NEW.raw_user_meta_data->>'full_name',
+        NEW.raw_user_meta_data->>'name',
+        split_part(NEW.email, '@', 1)
+      ),
+      user_role,
+      'in_progress'
+    )
+    ON CONFLICT (id) DO NOTHING;
+  EXCEPTION WHEN OTHERS THEN
+    -- Log but don't block user creation — callback handles profile fallback
+    RAISE WARNING 'handle_new_user trigger failed for %: %', NEW.email, SQLERRM;
+  END;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- Map Supabase error descriptions to friendly error codes instead of forwarding raw error params to the login page
- Add a fallback error message for unknown/unmapped error codes
- Capture and log profile creation errors in the auth callback instead of silently ignoring them
- Wrap the `handle_new_user` DB trigger in an exception handler so user creation is never blocked by profile insert failures

## Test plan
- [ ] Sign in with Google OAuth and verify successful redirect
- [ ] Trigger a DB error scenario and verify the "Account setup failed" message appears on the login page
- [ ] Verify an unknown error code shows the generic fallback message
- [ ] Confirm new user profile creation still works when the trigger succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)