### PR TITLE
Sort team by title, hide photoless members publicly

### DIFF
--- a/app/(admin)/admin/team/team-client.tsx
+++ b/app/(admin)/admin/team/team-client.tsx
@@ -102,6 +102,23 @@ const ROLE_ITEMS = ROLES.map((role) => ({
   label: ROLE_CONFIG[role].label,
 }))
 
+// Title sort priority — matches recruitment hierarchy.
+// Titles not in this list are sorted after, alphabetically.
+const TITLE_ORDER = [
+  "Associate Director",
+  "Senior Property Consultant",
+  "Property Consultant",
+  "Operations Manager",
+]
+
+function titleRank(title: string | null | undefined): number {
+  if (!title) return TITLE_ORDER.length + 1
+  const idx = TITLE_ORDER.findIndex(
+    (t) => t.toLowerCase() === title.toLowerCase(),
+  )
+  return idx === -1 ? TITLE_ORDER.length : idx
+}
+
 // -----------------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------------
@@ -152,19 +169,32 @@ export function TeamClient({ users, teamProfiles, orphanProfiles }: Props) {
       )
     }
 
-    return result.sort((a, b) => a.fullName.localeCompare(b.fullName))
-  }, [users, search, roleFilter])
+    return result.sort((a, b) => {
+      const titleA = teamProfiles[a.email.toLowerCase()]?.role
+      const titleB = teamProfiles[b.email.toLowerCase()]?.role
+      const rankDiff = titleRank(titleA) - titleRank(titleB)
+      if (rankDiff !== 0) return rankDiff
+      return a.fullName.localeCompare(b.fullName)
+    })
+  }, [users, teamProfiles, search, roleFilter])
 
   // Filtered orphan profiles
   const filteredOrphans = useMemo(() => {
     if (roleFilter !== "all") return [] // Orphans have no system role
-    if (!search.trim()) return orphanProfiles
-    const q = search.toLowerCase()
-    return orphanProfiles.filter(
-      (p) =>
-        p.name.toLowerCase().includes(q) ||
-        (p.email && p.email.toLowerCase().includes(q))
-    )
+    let result = orphanProfiles
+    if (search.trim()) {
+      const q = search.toLowerCase()
+      result = result.filter(
+        (p) =>
+          p.name.toLowerCase().includes(q) ||
+          (p.email && p.email.toLowerCase().includes(q))
+      )
+    }
+    return [...result].sort((a, b) => {
+      const rankDiff = titleRank(a.role) - titleRank(b.role)
+      if (rankDiff !== 0) return rankDiff
+      return a.name.localeCompare(b.name)
+    })
   }, [orphanProfiles, search, roleFilter])
 
   function handleRoleChange(userId: string, name: string, newRole: UserRole) {
@@ -277,6 +307,9 @@ export function TeamClient({ users, teamProfiles, orphanProfiles }: Props) {
                 <TableHead className="px-4 py-3 w-24">
                   <Text size="sm" weight="medium" variant="muted">Role</Text>
                 </TableHead>
+                <TableHead className="px-4 py-3 w-48">
+                  <Text size="sm" weight="medium" variant="muted">Title</Text>
+                </TableHead>
                 <TableHead className="px-4 py-3 w-44">
                   <Text size="sm" weight="medium" variant="muted">Progress</Text>
                 </TableHead>
@@ -303,7 +336,7 @@ export function TeamClient({ users, teamProfiles, orphanProfiles }: Props) {
               {filteredOrphans.length > 0 && (
                 <>
                   <TableRow className="bg-muted/20 hover:bg-muted/20">
-                    <TableCell colSpan={5} className="px-4 py-2">
+                    <TableCell colSpan={6} className="px-4 py-2">
                       <Text size="xs" weight="medium" variant="muted">
                         Public profiles without a user account ({filteredOrphans.length})
                       </Text>
@@ -455,6 +488,15 @@ function UserRow({
         )}
       </TableCell>
 
+      {/* Title */}
+      <TableCell className="px-4 py-3">
+        {teamProfile?.role ? (
+          <Text size="sm" className="truncate">{teamProfile.role}</Text>
+        ) : (
+          <Text size="sm" variant="muted">—</Text>
+        )}
+      </TableCell>
+
       {/* Progress + Status (combined) */}
       <TableCell className="px-4 py-3">
         <Row gap="sm" align="center">
@@ -568,7 +610,7 @@ function OrphanRow({
           <Stack gap="none" className="min-w-0">
             <Text weight="medium" className="truncate">{profile.name}</Text>
             <Text size="xs" variant="muted" className="truncate">
-              {profile.email || "No email"} · {profile.role || "No role"}
+              {profile.email || "No email"}
             </Text>
           </Stack>
         </Row>
@@ -577,6 +619,15 @@ function OrphanRow({
       {/* Role — no system account */}
       <TableCell className="px-4 py-3">
         <Badge variant="outline" className="text-xs text-muted-foreground">No account</Badge>
+      </TableCell>
+
+      {/* Title */}
+      <TableCell className="px-4 py-3">
+        {profile.role ? (
+          <Text size="sm" className="truncate">{profile.role}</Text>
+        ) : (
+          <Text size="sm" variant="muted">—</Text>
+        )}
       </TableCell>
 
       {/* Progress — N/A */}

--- a/app/(web)/team/_components/team-card.tsx
+++ b/app/(web)/team/_components/team-card.tsx
@@ -20,7 +20,6 @@ interface TeamMember {
   email?: string | null
   phone?: string | null
   linkedin?: string | null
-  isFounder?: boolean
 }
 
 export function TeamCard({ member }: { member: TeamMember }) {
@@ -46,13 +45,6 @@ export function TeamCard({ member }: { member: TeamMember }) {
           ) : (
             <div className="absolute inset-0 flex items-center justify-center">
               <UserIcon className="h-20 w-20 text-[var(--web-spruce)]/30" />
-            </div>
-          )}
-          
-          {/* Founder badge */}
-          {member.isFounder && (
-            <div className="absolute top-4 left-4 bg-[var(--web-ash)] text-[var(--web-off-white)] text-[10px] uppercase tracking-wider px-3 py-1 rounded-[2px]">
-              Founder
             </div>
           )}
         </div>

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -396,6 +396,8 @@ async function fetchPublicTeamMembers(): Promise<TeamMember[]> {
       .from("team_members")
       .select("*")
       .eq("published", true)
+      .not("photo", "is", null)
+      .neq("photo", "")
       .order("display_order")
 
     if (error) {
@@ -419,6 +421,8 @@ async function fetchPublicTeamMemberBySlug(slug: string): Promise<TeamMember | n
       .select("*")
       .eq("slug", slug)
       .eq("published", true)
+      .not("photo", "is", null)
+      .neq("photo", "")
       .single()
 
     if (error) {


### PR DESCRIPTION
## Summary
- Admin `/admin/team`: adds a Title column and sorts users (and orphan profiles) by title priority — Associate Director → Senior Property Consultant → Property Consultant → Operations Manager → others — then alphabetically by name.
- Public `/team`: filters out team members without a profile photo in both the list and the `/team/[slug]` lookup so the grid stays visually consistent.
- Removes the "Founder" overlay badge from team cards so founders follow the same pattern as everyone else (their title still renders under the name).

Companion DB changes were applied directly in Supabase (reordered `display_order` for all 32 rows; corrected Jiezelle Claire Clemente's title to Operations Manager; renamed Sourav Umesh Lakhiyani → Lakhyani and updated slug).

## Test plan
- [ ] Visit `/admin/team` and confirm Title column renders, sort order matches the hierarchy, filters/search still work.
- [ ] Visit `/team` (after redeploy — ISR 24h) and confirm only members with photos are shown, in the correct order, with no Founder badge overlay.
- [ ] Visit `/team/sourav-umesh-lakhyani` and confirm the profile renders; old `/team/sourav-umesh-lakhiyani` returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)