### PR TITLE
Point remaining Tahir image refs at new JPG

### DIFF
--- a/app/(web)/sell/page.tsx
+++ b/app/(web)/sell/page.tsx
@@ -306,7 +306,7 @@ function AdvisorSection() {
               {/* Photo */}
               <div className="relative aspect-[3/4] md:aspect-auto bg-[var(--web-ash)]">
                 <Image
-                  src="/images/team/tahir-majithia.png"
+                  src="/images/team/tahir-majithia.jpg"
                   alt="Tahir Majithia, Managing Director of Prime Capital Dubai"
                   fill
                   className="object-cover"

--- a/content/livestreams.ts
+++ b/content/livestreams.ts
@@ -182,7 +182,7 @@ export const LIVESTREAMS: Livestream[] = [
       name: "Tahir Majithia",
       role: "Founder, Prime Capital Dubai",
       bio: "Tahir advises international investors on Dubai property — apartments, villas, branded residences, and off-plan. He's on the ground every day, transacting through every market condition, and known for straight-talk analysis over narrative.",
-      imageUrl: "/images/team/tahir-majithia.png",
+      imageUrl: "/images/team/tahir-majithia.jpg",
       teamSlug: "tahir-majithia",
       quote:
         "The story on the news isn't the story on the ground. People are waiting for a crash that isn't coming — and the gap between what they're seeing and what's actually happening is costing them their best moves.",

--- a/scripts/upload-team-photos.ts
+++ b/scripts/upload-team-photos.ts
@@ -34,7 +34,7 @@ const supabase = createClient(supabaseUrl, supabaseServiceKey)
 // ============================================================================
 const teamPhotos: { slug: string; file: string }[] = [
   // Founders
-  { slug: "tahir-majitia",             file: "tahir-majithia.png" },
+  { slug: "tahir-majithia",            file: "tahir-majithia.jpg" },
   { slug: "shaad-haji",                file: "Shaad Haji .jpeg" },
   { slug: "rohit-saluja",              file: "Rohit-Saluja.jpg" },
   // Associate Directors


### PR DESCRIPTION
## Summary
- Live `/team` page reads from Supabase CMS, not `data/team.json` — uploaded the new JPG to `cms/team/tahir-majitia.jpg` and updated the `team_members.photo` row to point at it (old PNG removed from storage).
- Updated the two remaining static refs that still pointed at the now-deleted `tahir-majithia.png`: `app/(web)/sell/page.tsx`, `content/livestreams.ts`.
- Fixed `scripts/upload-team-photos.ts` to use the correct slug (`tahir-majithia`, not the typo'd `tahir-majitia`) and the new `.jpg` filename.

Why this PR exists: PR #193 only swapped the static image and `data/team.json`, but the `/team` page is CMS-driven, so the live site kept showing the old portrait. Direct DB/storage update is already done; this PR mops up the static refs and triggers a redeploy so the 24h-ISR team page rebuilds with the new image URL.

## Test plan
- [ ] After deploy: hard-refresh `/team` and confirm Tahir's new portrait renders
- [ ] `/sell` page shows the new JPG
- [ ] No 404s for `tahir-majithia.png` in network tab