### PR TITLE
Drop leftover crm_me view exposing auth.users

### DIFF
--- a/supabase/migrations/20260429130000_drop_crm_me_view.sql
+++ b/supabase/migrations/20260429130000_drop_crm_me_view.sql
@@ -1,0 +1,16 @@
+/**
+ * CATALYST - Drop leftover crm_me view
+ *
+ * The AgentCRM codebase pollution (cleaned up in 20260324999999_cleanup_crm_tables.sql)
+ * left behind a SECURITY DEFINER view `public.crm_me` that exposes auth.users data
+ * to the anon role via PostgREST. The earlier cleanup dropped tables with CASCADE
+ * but did not drop standalone views.
+ *
+ * Supabase linter flags this as:
+ *   - auth_users_exposed (ERROR): auth.users exposed to anon
+ *   - security_definer_view (ERROR): view runs with creator's privileges
+ *
+ * This view is not used anywhere in the Geneva codebase.
+ */
+
+DROP VIEW IF EXISTS public.crm_me CASCADE;


### PR DESCRIPTION
## Summary
- Adds migration `20260429130000_drop_crm_me_view.sql` which runs `DROP VIEW IF EXISTS public.crm_me CASCADE;`
- Resolves Supabase linter errors `auth_users_exposed` and `security_definer_view` for `public.crm_me`
- The view was a leftover from the AgentCRM database pollution (cleaned up in `20260324999999_cleanup_crm_tables.sql`); that earlier migration dropped tables with CASCADE but missed standalone views

## Notes
- Migration has already been applied to the remote Supabase project (`vhgtbeimnkitqgekvtrz`) via `supabase db push` — this PR is to record the change in the repo
- `crm_me` is not referenced anywhere in the Geneva codebase, so no app deploy is required

## Test plan
- [x] `supabase migration list` shows `20260429130000` on both local and remote
- [ ] Re-run Supabase linter and confirm both findings on `public.crm_me` are cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)