### PR TITLE
Fix quiz scoring, save errors, and module-completion linkage

### DIFF
--- a/components/lms/quiz-sheet.tsx
+++ b/components/lms/quiz-sheet.tsx
@@ -77,6 +77,7 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
   const [score, setScore] = React.useState(0)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const [lastAnswerCorrect, setLastAnswerCorrect] = React.useState(false)
+  const [submitError, setSubmitError] = React.useState<string | null>(null)
   
   const currentQuestion = questions[currentIndex]
   const totalQuestions = questions.length
@@ -115,27 +116,32 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
     } else {
       // Quiz complete - submit to server
       setIsSubmitting(true)
+      setSubmitError(null)
       try {
-        const quizAnswers: QuizAnswer[] = Object.entries(answers).map(([qId, opt]) => ({
+        // Defensive merge: `answers` already includes the last answer (set in handleSubmit),
+        // but re-spread guards against React state batching edge cases. Same key dedupes naturally.
+        const finalAnswers = { ...answers, [currentQuestion.id]: selectedOption! }
+        const quizAnswers: QuizAnswer[] = Object.entries(finalAnswers).map(([qId, opt]) => ({
           questionId: qId,
           selectedOption: opt,
         }))
-        // Add the last answer
-        quizAnswers.push({
-          questionId: currentQuestion.id,
-          selectedOption: selectedOption!,
-        })
         await submitQuizAttempt(quiz.slug, quizAnswers)
+        setIsSubmitting(false)
+        setState("complete")
+
+        // Notify parent
+        const finalScore = lastAnswerCorrect ? score + 1 : score
+        const passed = (finalScore / totalQuestions) >= (quiz.passing_score / 100)
+        onComplete?.(passed, finalScore, totalQuestions)
       } catch (error) {
         console.error("Failed to save quiz attempt:", error)
+        setIsSubmitting(false)
+        // Stay on feedback screen so the user can retry. Without this, the results
+        // screen would render with no attempt persisted — masking the failure.
+        setSubmitError(
+          error instanceof Error ? error.message : "Couldn't save your results. Please try again."
+        )
       }
-      setIsSubmitting(false)
-      setState("complete")
-      
-      // Notify parent
-      const finalScore = lastAnswerCorrect ? score + 1 : score
-      const passed = (finalScore / totalQuestions) >= (quiz.passing_score / 100)
-      onComplete?.(passed, finalScore, totalQuestions)
     }
   }
   
@@ -146,8 +152,9 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
     setScore(0)
     setState("in-progress")
     setLastAnswerCorrect(false)
+    setSubmitError(null)
   }
-  
+
   const handleClose = () => {
     setOpen(false)
     // Reset state after animation
@@ -158,6 +165,7 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
       setScore(0)
       setState("in-progress")
       setLastAnswerCorrect(false)
+      setSubmitError(null)
     }, 300)
   }
   
@@ -244,6 +252,7 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
               isSubmitting={isSubmitting}
               showFeedback={state === "showing-feedback"}
               isCorrect={lastAnswerCorrect}
+              submitError={submitError}
               onOptionSelect={handleOptionSelect}
               onSubmit={handleSubmit}
               onContinue={handleContinue}
@@ -268,6 +277,7 @@ interface QuizQuestionViewProps {
   isSubmitting: boolean
   showFeedback: boolean
   isCorrect: boolean
+  submitError: string | null
   onOptionSelect: (index: number) => void
   onSubmit: () => void
   onContinue: () => void
@@ -282,6 +292,7 @@ function QuizQuestionView({
   isSubmitting,
   showFeedback,
   isCorrect,
+  submitError,
   onOptionSelect,
   onSubmit,
   onContinue,
@@ -329,6 +340,21 @@ function QuizQuestionView({
                   {question.explanation}
                 </Text>
               )}
+            </Stack>
+          </div>
+        )}
+
+        {/* Submit Error Banner */}
+        {submitError && (
+          <div className="p-4 rounded-lg flex items-start gap-3 bg-red-500/10 border border-red-500/20">
+            <XCircleIcon className="h-5 w-5 text-red-500 shrink-0 mt-0.5" />
+            <Stack gap="xs">
+              <Text weight="semibold" className="text-red-700 dark:text-red-400">
+                Couldn&apos;t save your results
+              </Text>
+              <Text size="sm" className="text-muted-foreground">
+                {submitError}
+              </Text>
             </Stack>
           </div>
         )}
@@ -390,17 +416,19 @@ function QuizQuestionView({
         
         {/* Action button */}
         {showFeedback ? (
-          <Button 
-            size="lg" 
+          <Button
+            size="lg"
             className="w-full gap-2"
             onClick={onContinue}
             disabled={isSubmitting}
           >
-            {isSubmitting 
-              ? "Saving..." 
-              : currentIndex < totalQuestions - 1 
+            {isSubmitting
+              ? "Saving..."
+              : currentIndex < totalQuestions - 1
                 ? <>Continue <ArrowRightIcon className="h-4 w-4" /></>
-                : "See Results"
+                : submitError
+                  ? "Try Again"
+                  : "See Results"
             }
           </Button>
         ) : (

--- a/lib/actions/learning.ts
+++ b/lib/actions/learning.ts
@@ -192,24 +192,31 @@ export async function submitQuizAttempt(
   }
 
   // Calculate score
+  // Dedupe by questionId (last answer wins) so a buggy client can't inflate scores
+  // by submitting the same question twice. Defense-in-depth — score must never exceed maxScore.
+  const answersByQuestion = new Map<string, number>()
+  for (const answer of answers) {
+    answersByQuestion.set(answer.questionId, answer.selectedOption)
+  }
+
   let score = 0
   const correctAnswers: string[] = []
   const explanations: Record<string, string> = {}
 
-  for (const answer of answers) {
-    const question = questions.find((q) => q.id === answer.questionId)
+  for (const [questionId, selectedIndex] of answersByQuestion) {
+    const question = questions.find((q) => q.id === questionId)
     if (!question) continue
 
     const options = question.options as Array<{ text: string; correct: boolean }>
-    const selectedOption = options[answer.selectedOption]
+    const selectedOption = options[selectedIndex]
 
     if (selectedOption?.correct) {
       score++
-      correctAnswers.push(answer.questionId)
+      correctAnswers.push(questionId)
     }
 
     if (question.explanation) {
-      explanations[answer.questionId] = question.explanation
+      explanations[questionId] = question.explanation
     }
   }
 

--- a/lib/lms/sync.ts
+++ b/lib/lms/sync.ts
@@ -500,10 +500,15 @@ export async function syncQuizzes(): Promise<{ quizzes: number; questions: numbe
     const quizSlug = (frontmatter.slug as string) || filename
 
     // Determine competency slug
-    const competencySlug = 
-      (frontmatter.competency as string) || 
-      folderCompetency || 
+    const competencySlug =
+      (frontmatter.competency as string) ||
+      folderCompetency ||
       quizSlug.split("-").slice(0, -1).join("-")
+
+    // Normalize relatedModule the same way module slugs are normalized in parseMarkdownFile
+    // (strip leading numeric prefix like "0.3-" or "8.7-"). Without this, quiz.related_module
+    // won't match learning_modules.slug and module completion on quiz pass won't fire.
+    const relatedModule = (frontmatter.relatedModule as string)?.replace(/^\d+(\.\d+)?-/, "")
 
     // Parse questions from markdown content first, then fall back to frontmatter
     let questions = parseQuizQuestions(content)
@@ -516,7 +521,7 @@ export async function syncQuizzes(): Promise<{ quizzes: number; questions: numbe
       {
         slug: quizSlug,
         competency_slug: competencySlug,
-        related_module: frontmatter.relatedModule as string,
+        related_module: relatedModule,
         title: (frontmatter.title as string) || quizSlug,
         description: frontmatter.description as string,
         passing_score: (frontmatter.passingScore as number) || 80,
@@ -544,7 +549,7 @@ export async function syncQuizzes(): Promise<{ quizzes: number; questions: numbe
       const { error } = await supabase.from("quiz_questions").insert({
         quiz_slug: quizSlug,
         competency_slug: competencySlug,
-        related_module: frontmatter.relatedModule as string,
+        related_module: relatedModule,
         question_number: index + 1,
         question_text: q.question,
         question: q.question, // Legacy column

--- a/tests/learn/quiz-scoring.test.ts
+++ b/tests/learn/quiz-scoring.test.ts
@@ -235,6 +235,51 @@ describe("Quiz Scoring", () => {
       // 3/5 = 0.6 which is below 0.8
       expect(result.passed).toBe(false)
     })
+
+    it("should dedupe duplicate answers so score never exceeds maxScore", async () => {
+      // Regression test: a buggy client (QuizSheet pre-fix) submitted the last answer
+      // twice. The server must dedupe by questionId so score <= maxScore.
+      const mockQuestions = [
+        { id: "q1", options: [{ text: "A", correct: true }, { text: "B", correct: false }] },
+        { id: "q2", options: [{ text: "A", correct: true }, { text: "B", correct: false }] },
+      ]
+
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === "quiz_questions") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({ data: mockQuestions, error: null }),
+          }
+        }
+        if (table === "quiz_attempts") {
+          return {
+            insert: vi.fn().mockResolvedValue({ error: null }),
+          }
+        }
+        if (table === "learning_progress") {
+          return {
+            upsert: vi.fn().mockResolvedValue({ error: null }),
+          }
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: null }),
+        }
+      })
+
+      const { submitQuizAttempt } = await import("@/lib/actions/learning")
+
+      const result = await submitQuizAttempt("module-uuid-123456789012-123456789012", [
+        { questionId: "q1", selectedOption: 0 }, // Correct
+        { questionId: "q2", selectedOption: 0 }, // Correct
+        { questionId: "q2", selectedOption: 0 }, // Duplicate - must not double-count
+      ])
+
+      expect(result.score).toBe(2)
+      expect(result.maxScore).toBe(2)
+      expect(result.score).toBeLessThanOrEqual(result.maxScore)
+    })
   })
 
   // =============================================================================


### PR DESCRIPTION
## Summary

Resolves user reports of "not being able to complete or answer quiz questions." Audit found three independent bugs combining to break the LMS quiz experience.

- **Score inflation** — `QuizSheet.handleContinue` pushed the last answer to the submit array AND read it from `answers` state where `handleSubmit` had already stored it. Server scored the final answer twice (e.g. 6/5 = 120%). 17 of 34 `foundations-0.1` attempts were affected in production.
- **Silent save failures** — DB save errors were caught with `console.error` and the UI transitioned to the results screen anyway. Users saw "passed" but no attempt was persisted. Now: state only flips to `complete` on success; on error a banner renders and the button reads "Try Again".
- **Module never marked complete** — LMS sync stored `quiz.related_module` verbatim (`"0.3-broker-licensing"`) while module slugs get the numeric prefix stripped at parse time (`"broker-licensing"`). 48% of quizzes (39 of 81) couldn't resolve their module → `markModuleComplete` never fired on pass. Sync now applies the same regex normalization.

Defense-in-depth: `submitQuizAttempt` now dedupes answers by `questionId` server-side so any future client regression can't inflate score > maxScore. Regression test added.

## Live data fix (already applied)

Sync-script fix doesn't self-heal existing rows, so applied via targeted SQL outside this PR:
- 39 `quizzes` + 397 `quiz_questions` had stale `related_module` prefixes stripped
- 54 historical `quiz_attempts.module_id` backfilled
- 37 new `learning_progress` rows inserted for users who passed but never got module credit (status=`completed`, `completed_at = MIN(attempted_at)`)

Five integrity checks on the live DB all return zero rows after the fix.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean on changed files
- [x] `pnpm test:run tests/learn/` — 33 tests pass, including new regression test for server-side dedup
- [ ] Manual: take a quiz on a module page, verify score caps at question count and module shows complete on pass
- [ ] Manual: simulate a network failure mid-submit, verify error banner renders and "Try Again" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)