### PR TITLE
Render Reelly-parsed paste fields on property detail page

### DIFF
--- a/app/(web)/properties/[slug]/page.tsx
+++ b/app/(web)/properties/[slug]/page.tsx
@@ -39,6 +39,9 @@ import {
   CreditCardIcon,
   ImagesIcon,
   FileTextIcon,
+  LayersIcon,
+  UtensilsIcon,
+  SofaIcon,
 } from "lucide-react"
 
 export const revalidate = 300 // Match the CRM Cache-Control max-age
@@ -74,7 +77,7 @@ export async function generateMetadata({ params }: PageProps) {
   }
 
   const heroImage = property.images[0]
-  const description = property.description?.slice(0, 160) ?? ""
+  const description = (property.overview ?? property.description)?.slice(0, 160) ?? ""
 
   return {
     title: property.title,
@@ -111,7 +114,7 @@ export default async function PropertyDetailPage({ params }: PageProps) {
       <JsonLd
         data={propertyJsonLd({
           title: property.title,
-          description: property.description,
+          description: property.overview ?? property.description,
           slug: property.slug,
           cover_image: heroImage ?? null,
           created_at: property.createdAt,
@@ -289,9 +292,27 @@ export default async function PropertyDetailPage({ params }: PageProps) {
                 </SectionCard>
               )}
 
-              {property.description && (
+              {(property.overview ?? property.description) && (
                 <SectionCard title="About This Property" icon={BuildingIcon}>
-                  <PropertyProse content={property.description} />
+                  <PropertyProse content={(property.overview ?? property.description)!} />
+                </SectionCard>
+              )}
+
+              {property.finishingAndMaterials && (
+                <SectionCard title="Finishing & Materials" icon={LayersIcon}>
+                  <PropertyProse content={property.finishingAndMaterials} />
+                </SectionCard>
+              )}
+
+              {property.kitchenAndAppliances && (
+                <SectionCard title="Kitchen & Appliances" icon={UtensilsIcon}>
+                  <PropertyProse content={property.kitchenAndAppliances} />
+                </SectionCard>
+              )}
+
+              {property.furnishings && (
+                <SectionCard title="Furnishings" icon={SofaIcon}>
+                  <PropertyProse content={property.furnishings} />
                 </SectionCard>
               )}
 

--- a/lib/crm/client.ts
+++ b/lib/crm/client.ts
@@ -158,12 +158,16 @@ function mapDetail(row: CrmPropertyDetail): CrmPropertyFull {
     factsheetUrl: row.factsheet_url,
 
     reasonsToInvest: row.reasons_to_invest,
+    overview: row.overview,
     locationAndViews: row.location_and_views,
     aboutDeveloper: row.about_developer,
     paymentPlanDetails: row.payment_plan_details,
     unitsMarkdown: row.units_markdown,
     unitsPricingMarkdown: row.units_pricing_markdown,
     amenitiesMarkdown: row.amenities_markdown,
+    finishingAndMaterials: row.finishing_and_materials,
+    kitchenAndAppliances: row.kitchen_and_appliances,
+    furnishings: row.furnishings,
 
     notes: row.notes ?? [],
   }

--- a/lib/crm/types.ts
+++ b/lib/crm/types.ts
@@ -131,12 +131,22 @@ export interface CrmPropertyDetail extends CrmPropertyListItem {
   factsheet_url: string | null
 
   reasons_to_invest: string | null
+  /** Curator-authored "About this property" body. Falls back on the CRM side
+   *  to the Reelly-parsed paste (project facts) so it's always populated for
+   *  Reelly-sourced listings. Prefer `overview ?? description` in renders —
+   *  the raw description blob may contain H5 headings duplicated by the
+   *  paste cards below. */
+  overview: string | null
   location_and_views: string | null
   about_developer: string | null
   payment_plan_details: string | null
   units_markdown: string | null
   units_pricing_markdown: string | null
   amenities_markdown: string | null
+  // Unit fit-out cards — Reelly paste with curator override.
+  finishing_and_materials: string | null
+  kitchen_and_appliances: string | null
+  furnishings: string | null
 
   notes: CrmNote[]
 
@@ -213,12 +223,19 @@ export interface CrmPropertyFull extends CrmProperty {
   factsheetUrl: string | null
 
   reasonsToInvest: string | null
+  /** Cleaned "About this property" body. Prefer `overview ?? description` in
+   *  renders — `description` is the raw source blob (may contain H5 headings
+   *  duplicated by the paste cards). */
+  overview: string | null
   locationAndViews: string | null
   aboutDeveloper: string | null
   paymentPlanDetails: string | null
   unitsMarkdown: string | null
   unitsPricingMarkdown: string | null
   amenitiesMarkdown: string | null
+  finishingAndMaterials: string | null
+  kitchenAndAppliances: string | null
+  furnishings: string | null
 
   notes: CrmNote[]
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -46,6 +46,10 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "i.ytimg.com",
       },
+      {
+        protocol: "https",
+        hostname: "api.reelly.io",
+      },
     ],
   },
   async redirects() {
@@ -114,7 +118,7 @@ const nextConfig: NextConfig = {
           },
           {
             key: "Content-Security-Policy",
-            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com https://assets.calendly.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://images.unsplash.com https://plus.unsplash.com https://ebirxyrjwaulyqizcbcs.supabase.co https://vhgtbeimnkitqgekvtrz.supabase.co https://uozpalmasfxjsxhfyghn.supabase.co https://api.mapbox.com https://pplx-res.cloudinary.com https://static.propsearch.ae https://skyviewdubai.com https://i.ytimg.com https://purecatamphetamine.github.io; font-src 'self' https://fonts.gstatic.com; media-src 'self' https://vhgtbeimnkitqgekvtrz.supabase.co; connect-src 'self' https://ebirxyrjwaulyqizcbcs.supabase.co https://vhgtbeimnkitqgekvtrz.supabase.co https://api.mapbox.com https://va.vercel-scripts.com https://www.youtube.com https://youtube.com; frame-src https://calendly.com https://crm.primecapitaldubai.com https://www.youtube.com https://www.youtube-nocookie.com;",
+            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com https://assets.calendly.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://images.unsplash.com https://plus.unsplash.com https://ebirxyrjwaulyqizcbcs.supabase.co https://vhgtbeimnkitqgekvtrz.supabase.co https://uozpalmasfxjsxhfyghn.supabase.co https://api.mapbox.com https://pplx-res.cloudinary.com https://static.propsearch.ae https://skyviewdubai.com https://i.ytimg.com https://api.reelly.io https://purecatamphetamine.github.io; font-src 'self' https://fonts.gstatic.com; media-src 'self' https://vhgtbeimnkitqgekvtrz.supabase.co; connect-src 'self' https://ebirxyrjwaulyqizcbcs.supabase.co https://vhgtbeimnkitqgekvtrz.supabase.co https://api.mapbox.com https://va.vercel-scripts.com https://www.youtube.com https://youtube.com; frame-src https://calendly.com https://crm.primecapitaldubai.com https://www.youtube.com https://www.youtube-nocookie.com;",
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Surface 4 new CRM API fields on the PDP: `overview` (preferred over raw `description`), `finishing_and_materials`, `kitchen_and_appliances`, `furnishings`
- All rendered in the existing `SectionCard` pattern with Layers / Utensils / Sofa icons for visual consistency
- Allow `api.reelly.io` as a `next/image` remote host + add to CSP `img-src` (Reelly serves unit renders for off-plan inventory)
- Mapper extends `CrmPropertyDetail` (snake) + `CrmPropertyFull` (camel) with the new optional text fields

Pairs with **agentcrm PR #64** which surfaces these fields on \`/api/public/properties/{slug}\`.

## Why
The CRM (AgentCRM) was syncing rich body content from Reelly into \`data.ai_content\` (overview, finishing & materials, kitchen, furnishings, etc) but the public API was only re-exposing 4 of those fields. PR #64 widens that surface; this PR consumes the new fields here.

For Reelly-sourced off-plan listings, \`property.overview\` is now populated with a curator-cleaned body — fall back to raw \`description\` only when curator hasn't authored.

## Test plan
- [ ] Visit a Reelly-sourced PDP (off-plan, anything with completion date in future) and verify About / Finishing / Kitchen / Furnishings cards render with content
- [ ] Visit a curated secondary listing and verify About still falls back to \`description\` when \`overview\` is null
- [ ] Confirm Reelly image hostnames (\`https://api.reelly.io/...\`) load on the PDP without CSP / next-image errors
- [ ] No regressions on existing SectionCards (Latest Updates, Why Invest, Unit Types, Payment Plan, Location, Developer, Features, Amenities, Gallery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)