### PR TITLE
Gate YouTube generator behind a presenter picker

### DIFF
--- a/app/(admin)/admin/youtube/[id]/script-detail-page.tsx
+++ b/app/(admin)/admin/youtube/[id]/script-detail-page.tsx
@@ -587,7 +587,7 @@ export function ScriptDetailPage({
     const result = await deleteYouTubeScript(script.id)
     if (result.success) {
       toast("Script deleted")
-      router.push("/admin/youtube")
+      router.push(`/admin/youtube?profile=${script.profile_slug}`)
     } else {
       toast("Failed to delete", { type: "error" })
       setIsDeleting(false)
@@ -615,7 +615,7 @@ export function ScriptDetailPage({
     <Stack gap="lg">
       {/* Header + back nav */}
       <Row align="start" gap="sm">
-        <Button variant="ghost" size="sm" className="mt-1" render={<Link href="/admin/youtube" />}>
+        <Button variant="ghost" size="sm" className="mt-1" render={<Link href={`/admin/youtube?profile=${script.profile_slug}`} />}>
           <ArrowLeftIcon className="h-4 w-4" />
         </Button>
         <Stack gap="xs" className="flex-1 min-w-0">

--- a/app/(admin)/admin/youtube/new/brainstorm/brainstorm-workflow.tsx
+++ b/app/(admin)/admin/youtube/new/brainstorm/brainstorm-workflow.tsx
@@ -46,8 +46,8 @@ import {
   FORMATS_IN_DISPLAY_ORDER,
   type Format,
 } from "@/lib/youtube/prompts"
-import { DEFAULT_PROFILE_SLUG, type ProfileSlug } from "@/lib/youtube/profiles"
-import { ProfileSelector } from "../../_components/profile-selector"
+import { PROFILES, type ProfileSlug } from "@/lib/youtube/profiles"
+import { ProfileChip } from "../../_components/profile-selector"
 
 // =============================================================================
 // TYPES
@@ -142,7 +142,7 @@ function FormatPill({
 // MAIN COMPONENT
 // =============================================================================
 
-export function BrainstormWorkflow() {
+export function BrainstormWorkflow({ lockedProfile }: { lockedProfile: ProfileSlug }) {
   const router = useRouter()
   const [step, setStep] = React.useState<Step>("input")
   const [input, setInput] = React.useState("")
@@ -154,8 +154,9 @@ export function BrainstormWorkflow() {
   const [isGenerating, setIsGenerating] = React.useState(false)
   const [isSaving, setIsSaving] = React.useState(false)
 
-  // Profile — who every idea in this batch is written for (step 1)
-  const [profileSlug, setProfileSlug] = React.useState<ProfileSlug>(DEFAULT_PROFILE_SLUG)
+  // Profile — every idea in this batch is written for this person.
+  // Locked upstream by the picker so it can't change mid-flow.
+  const profileSlug = lockedProfile
 
   // Format pre-selection (step 1)
   const [selectedFormats, setSelectedFormats] = React.useState<Set<Format>>(new Set())
@@ -455,7 +456,7 @@ export function BrainstormWorkflow() {
       const saved = await saveSelectedIdeas()
       if (saved) {
         toast(`${saved.length} idea${saved.length === 1 ? "" : "s"} added to pipeline`)
-        router.push("/admin/youtube")
+        router.push(`/admin/youtube?profile=${profileSlug}`)
       }
     } catch (err) {
       toast(err instanceof Error ? err.message : "Failed to save ideas", { type: "error" })
@@ -535,8 +536,14 @@ export function BrainstormWorkflow() {
 
       {step === "input" && (
         <Stack gap="lg">
-          {/* Profile — every idea in this batch is written for this person */}
-          <ProfileSelector value={profileSlug} onChange={setProfileSlug} />
+          {/* Locked profile indicator — set by the picker upstream */}
+          <Row align="center" gap="sm">
+            <Text variant="muted" size="sm">Writing for</Text>
+            <ProfileChip slug={profileSlug} />
+            <Text variant="muted" size="sm">
+              · {PROFILES[profileSlug].displayRole}
+            </Text>
+          </Row>
 
           {/* 1. Format pre-selection — leads the page so it informs the market scan and idea generation */}
           <Stack gap="sm">

--- a/app/(admin)/admin/youtube/new/brainstorm/page.tsx
+++ b/app/(admin)/admin/youtube/new/brainstorm/page.tsx
@@ -4,19 +4,33 @@
  * Multi-step workflow that generates 5 format-tagged script ideas from one
  * input. The user reviews the batch, selects which ones to keep, then either
  * saves them to the pipeline or jumps straight into script generation.
+ *
+ * Requires ?profile=tahir|ahmed — bounces back to the picker if absent so the
+ * presenter is always locked-in before a script is generated.
  */
 
+import { redirect } from "next/navigation"
 import { Container } from "@/components/core"
 import { BrainstormWorkflow } from "./brainstorm-workflow"
+import { isProfileSlug } from "@/lib/youtube/profiles"
 
 export const metadata = {
   title: "Brainstorm Ideas | YouTube | Admin",
 }
 
-export default function BrainstormPage() {
+type SearchParams = Promise<{ profile?: string }>
+
+export default async function BrainstormPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  if (!isProfileSlug(params.profile)) redirect("/admin/youtube")
+
   return (
     <Container size="lg" className="py-6">
-      <BrainstormWorkflow />
+      <BrainstormWorkflow lockedProfile={params.profile} />
     </Container>
   )
 }

--- a/app/(admin)/admin/youtube/new/page.tsx
+++ b/app/(admin)/admin/youtube/new/page.tsx
@@ -4,9 +4,14 @@
  * Landing page for `/admin/youtube/new`. The user picks one of three
  * explicit entry modes — Brainstorm, Write One Script, or Review & Rewrite.
  * Each mode owns its own sub-route and workflow.
+ *
+ * Profile context: this route requires ?profile=tahir|ahmed. Without it we
+ * bounce the user back to the picker so a presenter is always chosen before
+ * a script is created.
  */
 
 import Link from "next/link"
+import { redirect } from "next/navigation"
 import { Container, Stack, Row, Text, Title } from "@/components/core"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -17,6 +22,8 @@ import {
   PenLineIcon,
   ShieldCheckIcon,
 } from "lucide-react"
+import { PROFILES, isProfileSlug } from "@/lib/youtube/profiles"
+import { ProfileChip } from "../_components/profile-selector"
 
 export const metadata = {
   title: "New Script | YouTube | Admin",
@@ -77,13 +84,29 @@ const MODES: Mode[] = [
   },
 ]
 
-export default function NewScriptModeChooserPage() {
+type SearchParams = Promise<{ profile?: string }>
+
+export default async function NewScriptModeChooserPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  if (!isProfileSlug(params.profile)) redirect("/admin/youtube")
+  const profile = params.profile
+  const profileMeta = PROFILES[profile]
+  const profileQuery = `?profile=${profile}`
+
   return (
     <Container size="lg" className="py-6">
       <Stack gap="lg">
         {/* Header */}
         <Row align="center" gap="sm">
-          <Button variant="ghost" size="sm" render={<Link href="/admin/youtube" />}>
+          <Button
+            variant="ghost"
+            size="sm"
+            render={<Link href={`/admin/youtube${profileQuery}`} />}
+          >
             <ArrowLeftIcon className="h-4 w-4" />
           </Button>
           <Stack gap="xs" className="flex-1">
@@ -92,7 +115,13 @@ export default function NewScriptModeChooserPage() {
               Pick how you want to start — each mode is purpose-built and explicit.
             </Text>
           </Stack>
+          <ProfileChip slug={profile} />
         </Row>
+
+        <Text variant="muted" size="sm">
+          Writing for <span className="font-medium text-foreground">{profileMeta.displayName}</span>.
+          To switch presenter, go back to the board.
+        </Text>
 
         {/* Mode cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 items-stretch">
@@ -104,7 +133,7 @@ export default function NewScriptModeChooserPage() {
                 className="group relative flex flex-col transition-all hover:border-primary/60 hover:shadow-md"
               >
                 <Link
-                  href={mode.href}
+                  href={`${mode.href}${profileQuery}`}
                   className="absolute inset-0 rounded-lg"
                   aria-label={mode.title}
                 />

--- a/app/(admin)/admin/youtube/new/review/page.tsx
+++ b/app/(admin)/admin/youtube/new/review/page.tsx
@@ -2,19 +2,33 @@
  * CATALYST - Review & Rewrite Page (Mode A)
  *
  * Entry point for the existing-script → validate → rewrite flow.
+ *
+ * Requires ?profile=tahir|ahmed — bounces back to the picker if absent so the
+ * presenter is always locked-in before a script is reviewed.
  */
 
+import { redirect } from "next/navigation"
 import { Container } from "@/components/core"
 import { ReviewScriptWorkflow } from "./review-script-workflow"
+import { isProfileSlug } from "@/lib/youtube/profiles"
 
 export const metadata = {
   title: "Review & Rewrite | YouTube | Admin",
 }
 
-export default function ReviewScriptPage() {
+type SearchParams = Promise<{ profile?: string }>
+
+export default async function ReviewScriptPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  if (!isProfileSlug(params.profile)) redirect("/admin/youtube")
+
   return (
     <Container size="lg" className="py-6">
-      <ReviewScriptWorkflow />
+      <ReviewScriptWorkflow lockedProfile={params.profile} />
     </Container>
   )
 }

--- a/app/(admin)/admin/youtube/new/review/review-script-workflow.tsx
+++ b/app/(admin)/admin/youtube/new/review/review-script-workflow.tsx
@@ -46,8 +46,8 @@ import {
   FORMATS_IN_DISPLAY_ORDER,
   type Format,
 } from "@/lib/youtube/prompts"
-import { DEFAULT_PROFILE_SLUG, type ProfileSlug } from "@/lib/youtube/profiles"
-import { ProfileSelector } from "../../_components/profile-selector"
+import { PROFILES, type ProfileSlug } from "@/lib/youtube/profiles"
+import { ProfileChip } from "../../_components/profile-selector"
 
 // =============================================================================
 // HELPERS
@@ -125,10 +125,10 @@ function wordCount(body: string): number {
 // MAIN COMPONENT
 // =============================================================================
 
-export function ReviewScriptWorkflow() {
+export function ReviewScriptWorkflow({ lockedProfile }: { lockedProfile: ProfileSlug }) {
   const router = useRouter()
   const [scriptBody, setScriptBody] = React.useState("")
-  const [profileSlug, setProfileSlug] = React.useState<ProfileSlug>(DEFAULT_PROFILE_SLUG)
+  const profileSlug = lockedProfile
   const [format, setFormat] = React.useState<Format | null>(null)
   const [title, setTitle] = React.useState("")
   const [titleDirty, setTitleDirty] = React.useState(false)
@@ -235,8 +235,14 @@ export function ReviewScriptWorkflow() {
         </Stack>
       </Row>
 
-      {/* Profile picker — whose voice this script is measured against */}
-      <ProfileSelector value={profileSlug} onChange={setProfileSlug} />
+      {/* Locked profile indicator — set by the picker upstream */}
+      <Row align="center" gap="sm">
+        <Text variant="muted" size="sm">Reviewing against</Text>
+        <ProfileChip slug={profileSlug} />
+        <Text variant="muted" size="sm">
+          · {PROFILES[profileSlug].displayRole}
+        </Text>
+      </Row>
 
       {/* Format — auto-detected; manual pick is an optional override */}
       <Stack gap="sm">

--- a/app/(admin)/admin/youtube/new/single/page.tsx
+++ b/app/(admin)/admin/youtube/new/single/page.tsx
@@ -3,19 +3,33 @@
  *
  * Entry point for the context → single script flow. Hosts the
  * SingleScriptWorkflow component which handles distillation and confirmation.
+ *
+ * Requires ?profile=tahir|ahmed — bounces back to the picker if absent so the
+ * presenter is always locked-in before a script is generated.
  */
 
+import { redirect } from "next/navigation"
 import { Container } from "@/components/core"
 import { SingleScriptWorkflow } from "./single-script-workflow"
+import { isProfileSlug } from "@/lib/youtube/profiles"
 
 export const metadata = {
   title: "Write One Script | YouTube | Admin",
 }
 
-export default function WriteOneScriptPage() {
+type SearchParams = Promise<{ profile?: string }>
+
+export default async function WriteOneScriptPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  if (!isProfileSlug(params.profile)) redirect("/admin/youtube")
+
   return (
     <Container size="lg" className="py-6">
-      <SingleScriptWorkflow />
+      <SingleScriptWorkflow lockedProfile={params.profile} />
     </Container>
   )
 }

--- a/app/(admin)/admin/youtube/new/single/single-script-workflow.tsx
+++ b/app/(admin)/admin/youtube/new/single/single-script-workflow.tsx
@@ -47,8 +47,8 @@ import {
   FORMATS_IN_DISPLAY_ORDER,
   type Format,
 } from "@/lib/youtube/prompts"
-import { DEFAULT_PROFILE_SLUG, type ProfileSlug } from "@/lib/youtube/profiles"
-import { ProfileSelector } from "../../_components/profile-selector"
+import { PROFILES, type ProfileSlug } from "@/lib/youtube/profiles"
+import { ProfileChip } from "../../_components/profile-selector"
 
 // =============================================================================
 // TYPES
@@ -131,11 +131,11 @@ function FormatPill({
 // MAIN COMPONENT
 // =============================================================================
 
-export function SingleScriptWorkflow() {
+export function SingleScriptWorkflow({ lockedProfile }: { lockedProfile: ProfileSlug }) {
   const router = useRouter()
   const [step, setStep] = React.useState<Step>("input")
   const [context, setContext] = React.useState("")
-  const [profileSlug, setProfileSlug] = React.useState<ProfileSlug>(DEFAULT_PROFILE_SLUG)
+  const profileSlug = lockedProfile
   const [format, setFormat] = React.useState<Format | null>(null)
   const [angles, setAngles] = React.useState<DistilledAngle[]>([])
   const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null)
@@ -285,8 +285,14 @@ export function SingleScriptWorkflow() {
 
       {step === "input" && (
         <Stack gap="lg">
-          {/* Profile picker — who the script is written for */}
-          <ProfileSelector value={profileSlug} onChange={setProfileSlug} />
+          {/* Locked profile indicator — set by the picker upstream */}
+          <Row align="center" gap="sm">
+            <Text variant="muted" size="sm">Writing for</Text>
+            <ProfileChip slug={profileSlug} />
+            <Text variant="muted" size="sm">
+              · {PROFILES[profileSlug].displayRole}
+            </Text>
+          </Row>
 
           {/* Format picker — required, sits at top */}
           <Stack gap="sm">

--- a/app/(admin)/admin/youtube/page.tsx
+++ b/app/(admin)/admin/youtube/page.tsx
@@ -1,13 +1,26 @@
 /**
  * CATALYST - YouTube Scripts Admin Page
  *
- * Kanban board for managing YouTube script pipeline:
- * Ideas → Script Ready → Script Recorded → Script Live
+ * Two views on one route, switched by ?profile=:
+ *   - No profile         → Profile picker (which person are you working on?)
+ *   - ?profile=tahir|ahmed → That presenter's Kanban (server-filtered)
+ *
+ * Script detail, new-script flows, and the Kanban itself all consume the
+ * profile via ?profile= so the chosen presenter persists across navigation.
  */
 
-import { Container } from "@/components/core"
+import Link from "next/link"
+import { Container, Stack, Row, Text, Title } from "@/components/core"
+import { Card, CardContent } from "@/components/ui/card"
+import { ArrowRightIcon, UserCircleIcon } from "lucide-react"
 import { YouTubeClient } from "./youtube-client"
 import { getYouTubeScripts } from "@/lib/actions/youtube"
+import {
+  PROFILES,
+  PROFILES_IN_DISPLAY_ORDER,
+  isProfileSlug,
+  type ProfileSlug,
+} from "@/lib/youtube/profiles"
 
 export const metadata = {
   title: "YouTube Scripts | Admin",
@@ -15,8 +28,27 @@ export const metadata = {
 
 export const dynamic = "force-dynamic"
 
-export default async function YouTubeAdminPage() {
-  const result = await getYouTubeScripts()
+type SearchParams = Promise<{ profile?: string }>
+
+export default async function YouTubeAdminPage({
+  searchParams,
+}: {
+  searchParams: SearchParams
+}) {
+  const params = await searchParams
+  const profile: ProfileSlug | null = isProfileSlug(params.profile)
+    ? params.profile
+    : null
+
+  if (!profile) {
+    return (
+      <Container size="lg" className="py-6">
+        <ProfilePicker />
+      </Container>
+    )
+  }
+
+  const result = await getYouTubeScripts({ profileSlug: profile })
   const scripts = result.success ? result.data : []
 
   return (
@@ -26,7 +58,70 @@ export default async function YouTubeAdminPage() {
           Failed to load scripts: {result.error}
         </div>
       )}
-      <YouTubeClient initialScripts={scripts} />
+      <YouTubeClient initialScripts={scripts} profile={profile} />
     </Container>
+  )
+}
+
+// =============================================================================
+// PROFILE PICKER
+// =============================================================================
+
+function ProfilePicker() {
+  return (
+    <Stack gap="lg">
+      <Stack gap="xs">
+        <Title size="h3">YouTube Scripts</Title>
+        <Text variant="muted" size="sm">
+          Pick who you&rsquo;re writing for. Each presenter has their own script board.
+        </Text>
+      </Stack>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-stretch">
+        {PROFILES_IN_DISPLAY_ORDER.map((slug) => {
+          const profile = PROFILES[slug]
+          return (
+            <Card
+              key={slug}
+              className="group relative flex flex-col transition-all hover:border-primary/60 hover:shadow-md"
+            >
+              <Link
+                href={`/admin/youtube?profile=${slug}`}
+                className="absolute inset-0 rounded-lg"
+                aria-label={`Open ${profile.displayName}'s board`}
+              />
+              <CardContent className="relative pointer-events-none flex flex-col gap-4 p-6 h-full">
+                <Row align="center" gap="sm">
+                  <div className="h-10 w-10 shrink-0 rounded-full bg-primary/10 text-primary flex items-center justify-center group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
+                    <UserCircleIcon className="h-5 w-5" />
+                  </div>
+                  <Stack gap="xs" className="min-w-0">
+                    <Title size="h5" className="leading-tight">
+                      {profile.displayName}
+                    </Title>
+                    <Text variant="muted" size="sm" className="leading-tight">
+                      {profile.displayRole}
+                    </Text>
+                  </Stack>
+                </Row>
+
+                <Text variant="muted" size="sm" className="leading-relaxed">
+                  {profile.description}
+                </Text>
+
+                <div className="flex-1" />
+
+                <Row align="center" className="justify-between pt-2 border-t">
+                  <Text size="sm" className="font-medium text-primary">
+                    Open board
+                  </Text>
+                  <ArrowRightIcon className="h-4 w-4 text-primary transition-transform group-hover:translate-x-1" />
+                </Row>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+    </Stack>
   )
 }

--- a/app/(admin)/admin/youtube/youtube-client.tsx
+++ b/app/(admin)/admin/youtube/youtube-client.tsx
@@ -47,6 +47,7 @@ import {
   LightbulbIcon,
   PenLineIcon,
   SparklesIcon,
+  ArrowLeftIcon,
 } from "lucide-react"
 import {
   type YouTubeScript,
@@ -57,6 +58,7 @@ import {
 import { toast } from "@/components/ui/toast"
 import { cn } from "@/lib/utils"
 import { ProfileChip } from "./_components/profile-selector"
+import { PROFILES, type ProfileSlug } from "@/lib/youtube/profiles"
 
 // =============================================================================
 // CONSTANTS
@@ -79,11 +81,18 @@ const COLUMNS: {
 // MAIN COMPONENT
 // =============================================================================
 
-export function YouTubeClient({ initialScripts }: { initialScripts: YouTubeScript[] }) {
+export function YouTubeClient({
+  initialScripts,
+  profile,
+}: {
+  initialScripts: YouTubeScript[]
+  profile: ProfileSlug
+}) {
   const [scripts, setScripts] = React.useState(initialScripts)
   const [deleteTarget, setDeleteTarget] = React.useState<YouTubeScript | null>(null)
   const [isDeleting, setIsDeleting] = React.useState(false)
   const [activeDragId, setActiveDragId] = React.useState<string | null>(null)
+  const profileMeta = PROFILES[profile]
 
   // 8px activation distance so clicks on the card (navigation) still work.
   const sensors = useSensors(
@@ -157,15 +166,23 @@ export function YouTubeClient({ initialScripts }: { initialScripts: YouTubeScrip
 
   return (
     <Stack gap="lg">
+      {/* Back to picker */}
+      <Row align="center" gap="xs">
+        <Button variant="ghost" size="sm" render={<Link href="/admin/youtube" />}>
+          <ArrowLeftIcon className="h-4 w-4 mr-1" />
+          Change person
+        </Button>
+      </Row>
+
       {/* Header */}
       <Row align="center" className="justify-between">
         <Stack gap="xs">
-          <Title size="h3">YouTube Scripts</Title>
+          <Title size="h3">{profileMeta.displayName}&rsquo;s Scripts</Title>
           <Text variant="muted" size="sm">
-            Generate, validate, and track your video script pipeline
+            Generate, validate, and track {profileMeta.displayName}&rsquo;s video script pipeline
           </Text>
         </Stack>
-        <Button render={<Link href="/admin/youtube/new" />}>
+        <Button render={<Link href={`/admin/youtube/new?profile=${profile}`} />}>
           <PlusIcon className="h-4 w-4 mr-2" />
           New Script
         </Button>

--- a/lib/actions/youtube.ts
+++ b/lib/actions/youtube.ts
@@ -141,13 +141,21 @@ export type YouTubeScriptVersion = {
 // READ
 // =============================================================================
 
-export async function getYouTubeScripts(): Promise<ActionResult<YouTubeScript[]>> {
+export async function getYouTubeScripts(
+  options: { profileSlug?: ProfileSlug } = {}
+): Promise<ActionResult<YouTubeScript[]>> {
   try {
     const supabase = await createClient()
-    const { data, error } = await supabase
+    let query = supabase
       .from("youtube_scripts")
       .select("*")
       .order("created_at", { ascending: false })
+
+    if (options.profileSlug) {
+      query = query.eq("profile_slug", options.profileSlug)
+    }
+
+    const { data, error } = await query
 
     if (error) throw error
     return { success: true, data: data as YouTubeScript[] }


### PR DESCRIPTION
## What

Tahir and Ahmed now have separate Script Kanban boards. The single shared board is replaced with a presenter picker gate.

## Flow

`/admin/youtube` → picker (Tahir / Ahmed) → `/admin/youtube?profile=tahir` (that person's board) → "New Script" stays scoped to that person → "Change person" returns to the picker.

## Changes

- **`page.tsx`** — renders the picker when no `?profile=`; renders the profile-filtered Kanban when present
- **`getYouTubeScripts()`** — optional `{ profileSlug }` filter, scripts filtered server-side
- **`youtube-client.tsx`** — removed the tab strip; takes a `profile` prop; "Change person" back link; New Script carries `?profile=` forward
- **New-script routes** (chooser + single/brainstorm/review) — require `?profile=`, redirect to picker if missing
- **Workflow components** — `ProfileSelector` (editable) replaced with a read-only "Writing for [chip]" indicator; presenter cannot change mid-flow
- **Script detail** — back button and post-delete redirect return to the script's own profile board

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm eslint` on all touched files — clean
- `pnpm next build` — compiles successfully

## Note

The picker is a workflow gate, not access control — anyone who can reach `/admin/youtube` can open either board (matches prior `profile_slug` behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)