### PR TITLE
Route Ahmed funnel leads to Ahmed in the CRM

### DIFF
--- a/app/(web)/ahmed-ashfaq/_components/ahmed-funnel.tsx
+++ b/app/(web)/ahmed-ashfaq/_components/ahmed-funnel.tsx
@@ -15,6 +15,13 @@ import { CheckIcon, LanguagesIcon, ShieldCheckIcon } from "lucide-react"
 
 export const AHMED_STRATEGY_KIT_PREFILL_KEY = "ahmed:strategy-kit:lead-prefill"
 
+/**
+ * Slug used to route Ahmed's leads to ahmed@primecapitaldubai.com in the CRM.
+ * Matches the entry in `KNOWN_AGENT_EMAILS` (app/api/leads/route.ts). Without
+ * this slug on the payload, leads from the Ahmed funnel land unassigned.
+ */
+export const AHMED_TEAM_MEMBER_SLUG = "ahmed-ashfaq"
+
 export const ahmedProfile = {
   name: "Ahmed Ashfaq",
   role: "Dubai-based real estate broker",
@@ -208,6 +215,7 @@ export function AhmedBookCallForm({
         tag={tag}
         calendlyUrl={config.links.ahmedBooking}
         redirectUrl="/ahmed-ashfaq/thank-you"
+        initialData={{ referringTeamMember: AHMED_TEAM_MEMBER_SLUG }}
         prefillKey={
           prefillFromStrategyKit ? AHMED_STRATEGY_KIT_PREFILL_KEY : undefined
         }
@@ -232,6 +240,7 @@ export function AhmedStrategyKitForm() {
         redirectUrl="/ahmed-ashfaq/strategy-kit/thank-you"
         redirectDelay={1000}
         tag="youtube-ahmed-strategy-kit"
+        initialData={{ referringTeamMember: AHMED_TEAM_MEMBER_SLUG }}
         persistKey={AHMED_STRATEGY_KIT_PREFILL_KEY}
         successMessage="Thank you — opening your access page now."
       />

--- a/components/shared/lead-form/use-lead-form.ts
+++ b/components/shared/lead-form/use-lead-form.ts
@@ -153,14 +153,20 @@ export function useLeadForm({
   const submissionIdRef = useRef<string>("")
   if (!submissionIdRef.current) submissionIdRef.current = generateSubmissionId()
 
-  // Read context params from URL (property, team member)
+  // Read context params from URL (property, team member). Omit keys when the
+  // URL doesn't carry them so a missing param can't clobber an initialData
+  // default — e.g. the Ahmed funnel seeds `referringTeamMember: "ahmed-ashfaq"`
+  // via initialData and would otherwise be wiped to undefined here.
   const contextParams = useMemo(() => {
     if (typeof window === "undefined") return {}
     const params = new URLSearchParams(window.location.search)
+    const property = params.get("property") || undefined
+    const teamMember = params.get("teamMember") || undefined
+    const teamMemberEmail = params.get("teamMemberEmail") || undefined
     return {
-      referringProperty: params.get("property") || undefined,
-      referringTeamMember: params.get("teamMember") || undefined,
-      referringTeamMemberEmail: params.get("teamMemberEmail") || undefined,
+      ...(property ? { referringProperty: property } : {}),
+      ...(teamMember ? { referringTeamMember: teamMember } : {}),
+      ...(teamMemberEmail ? { referringTeamMemberEmail: teamMemberEmail } : {}),
     }
   }, [])
 


### PR DESCRIPTION
## Summary
- Both Ahmed forms (`AhmedBookCallForm`, `AhmedStrategyKitForm`) now seed `referringTeamMember: "ahmed-ashfaq"` via `initialData`, so every submission from `/ahmed-ashfaq` carries the slug that resolves to `ahmed@primecapitaldubai.com` in `KNOWN_AGENT_EMAILS`. Direct visitors were previously landing **Unassigned** because the slug only flowed from `?teamMember=` URL params.
- Fix a latent bug in `useLeadForm` where empty URL params spread `{ referringTeamMember: undefined }` over the form state and wiped any default seeded via `initialData`. The hook now omits keys missing from the URL, so an explicit `?teamMember=` still wins but a missing one no longer clobbers the seed.
- New `AHMED_TEAM_MEMBER_SLUG` constant in `ahmed-funnel.tsx` to avoid string drift.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` clean
- [ ] After deploy: submit the Ahmed book-a-call form, confirm AgentCRM shows the lead assigned to Ahmed (not Unassigned)
- [ ] Submit the Ahmed strategy-kit form, confirm same routing
- [ ] Verify a `?teamMember=other-slug` URL param still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)