### PR TITLE
Gate /properties to curated top_property picks

### DIFF
--- a/app/(web)/page.tsx
+++ b/app/(web)/page.tsx
@@ -91,7 +91,7 @@ export default async function HomePage() {
   }
 
   const [propertiesResult, testimonials, stats] = await Promise.all([
-    getCrmProperties({ limit: 12 }),
+    getCrmProperties({ limit: 12, promotionStatus: "top_property" }),
     getWebTestimonials(),
     getWebStats(),
   ])

--- a/app/(web)/properties/page.tsx
+++ b/app/(web)/properties/page.tsx
@@ -1,8 +1,10 @@
 /**
  * CATALYST - Properties Listing Page
  *
- * Curated portfolio sourced from the AgentCRM public API. The list endpoint
- * is hard-gated to promotion_status=top_property — featured picks only.
+ * Curated portfolio sourced from the AgentCRM public API. We hard-gate to
+ * promotion_status=top_property so this page only ever shows the curated
+ * picks — the CRM's full catalogue is ~1.4k rows and would silently
+ * truncate at 50 otherwise.
  */
 
 import Link from "next/link"
@@ -85,6 +87,7 @@ function parseFilters(
     bedroomsMax: numericParam(params.bedrooms_max),
     priceMin: numericParam(params.price_min),
     priceMax: numericParam(params.price_max),
+    promotionStatus: "top_property",
     sort,
     limit: 50,
   }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -30,7 +30,10 @@ async function primeCapitalSitemap(baseUrl: string): Promise<MetadataRoute.Sitem
   const propertyPages: MetadataRoute.Sitemap = []
   if (config.features.properties) {
     try {
-      const { properties } = await getCrmProperties({ limit: 50 })
+      const { properties } = await getCrmProperties({
+        limit: 50,
+        promotionStatus: "top_property",
+      })
       properties.forEach((property) => {
         propertyPages.push({
           url: `${baseUrl}/properties/${property.slug}`,

--- a/lib/crm/client.ts
+++ b/lib/crm/client.ts
@@ -4,7 +4,9 @@
  * Reads property data from the public CRM API. The CRM is the source of
  * truth for listings, pricing, payment plans, and the inline enquiry widget.
  *
- * - List endpoint is hard-gated to promotion_status=top_property (curated picks).
+ * - List callers should pass promotionStatus="top_property" to surface only
+ *   curated picks (matches the "Selected Properties" framing on the site).
+ *   Without it, the CRM returns the agency's full catalogue (~1.4k rows).
  * - Detail endpoint returns any property regardless of status — UI must show
  *   sold / under-offer / off-market badges from the status field.
  * - All endpoints are public-read with permissive CORS; no auth required.
@@ -48,6 +50,8 @@ function buildListUrl(filters: CrmListFilters | undefined): string {
   if (filters?.priceMin != null) url.searchParams.set("price_min", String(filters.priceMin))
   if (filters?.priceMax != null) url.searchParams.set("price_max", String(filters.priceMax))
   if (filters?.status) url.searchParams.set("status", filters.status)
+  if (filters?.promotionStatus)
+    url.searchParams.set("promotion_status", filters.promotionStatus)
   if (filters?.sort) url.searchParams.set("sort", filters.sort)
   if (filters?.cursor) url.searchParams.set("cursor", filters.cursor)
   if (filters?.limit != null) url.searchParams.set("limit", String(Math.min(filters.limit, 50)))

--- a/lib/crm/types.ts
+++ b/lib/crm/types.ts
@@ -246,6 +246,8 @@ export interface CrmPropertyFull extends CrmProperty {
 
 export type CrmSort = "price_asc" | "price_desc" | "newest" | "oldest"
 
+export type CrmPromotionStatus = "top_property" | "shadow_picks" | "discount" | (string & {})
+
 export interface CrmListFilters {
   listingType?: CrmListingType
   area?: string
@@ -255,6 +257,7 @@ export interface CrmListFilters {
   priceMin?: number
   priceMax?: number
   status?: CrmPropertyStatus
+  promotionStatus?: CrmPromotionStatus
   sort?: CrmSort
   cursor?: string
   /** Default 20, max 50. */


### PR DESCRIPTION
## Summary

- Prime CRM has ~1,400 properties; the marketing /properties index is intentionally a curated \"Selected Properties\" page with only 15 picks (\`promotion_status=top_property\`).
- The list endpoint was never actually gated, so the page silently truncated to whichever 50 properties the CRM returned first.
- Plumb \`promotionStatus\` through \`CrmListFilters\` and have homepage hero, /properties, and sitemap pass \`\"top_property\"\` explicitly.

## Why

The page heading is \"Selected Properties\", the description promises a curated set, and the client doc-comment claims the gate is hard-coded — but the URL builder never set the param. Visitors were seeing an arbitrary 50-row slice of the full catalogue instead of the 15 curated picks.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`pnpm lint\` clean
- [ ] Smoke-test /properties (should show 15 curated picks)
- [ ] Smoke-test / (homepage Featured Properties should be curated)
- [ ] Confirm /sitemap.xml lists only curated PDP URLs