### PR TITLE
Harden AgentCRM public API integration

### DIFF
--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -444,6 +444,8 @@ function buildMessage(data: {
 // VALIDATION SCHEMA
 // =============================================================================
 
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
 const leadSchema = z
   .object({
     // Contact fields (optional for returning leads in property-enquiry mode)
@@ -475,11 +477,11 @@ const leadSchema = z
       "newsletter",
       "event",
     ]),
-    submittedAt: z.string(),
+    submittedAt: z.string().max(40),
     pageUrl: z.string().max(500),
 
     // Optional fields - goals
-    goals: z.array(z.string().max(100)).optional(),
+    goals: z.array(z.string().max(100)).max(10).optional(),
 
     // Optional fields - buyer qualification
     investTimeline: z.string().max(100).optional(),
@@ -547,7 +549,11 @@ const leadSchema = z
 
     // Idempotency + journey
     submissionId: z.string().max(50).optional(),
-    sessionId: z.string().max(50).optional(),
+    sessionId: z
+      .string()
+      .max(50)
+      .regex(UUID_V4_REGEX, "sessionId must be a UUIDv4")
+      .optional(),
 
     // Calendly booking metadata (sent via post-booking follow-up)
     scheduledMeeting: z.boolean().optional(),
@@ -636,6 +642,7 @@ async function enrichProperty(slug: string | undefined): Promise<EnrichedPropert
 
 const AGENTCRM_API_URL = process.env.AGENTCRM_API_URL || "https://crm.primecapitaldubai.com/api/public/enquiry"
 const AGENTCRM_API_KEY = process.env.AGENTCRM_API_KEY
+const AGENTCRM_MAX_BODY_BYTES = 64 * 1024
 
 interface ForwardResult {
   ok: boolean
@@ -794,6 +801,15 @@ async function forwardToAgentCrm(
     )
     return { ok: false, status: 0, destination: "agentcrm" }
   }
+  const body = JSON.stringify(payload)
+  const bodyBytes = Buffer.byteLength(body, "utf8")
+  if (bodyBytes > AGENTCRM_MAX_BODY_BYTES) {
+    console.error(
+      `[Leads API][AgentCRM][VALIDATION] payload too large mode=${formMode} sub=${submissionId} bytes=${bodyBytes} max=${AGENTCRM_MAX_BODY_BYTES}`,
+    )
+    return { ok: false, status: 413, destination: "agentcrm" }
+  }
+
   try {
     const res = await fetch(AGENTCRM_API_URL, {
       method: "POST",
@@ -801,7 +817,7 @@ async function forwardToAgentCrm(
         "Content-Type": "application/json",
         Authorization: `Bearer ${AGENTCRM_API_KEY}`,
       },
-      body: JSON.stringify(payload),
+      body,
     })
     if (!res.ok) {
       const bodyText = await res.text().catch(() => "")

--- a/components/shared/lead-form/schema.ts
+++ b/components/shared/lead-form/schema.ts
@@ -79,6 +79,9 @@ export const nameStepSchema = z.object({
 // E.164: starts with +, country code 1-9, then 7-14 digits.
 // Must include country code so AgentCRM can dedup against existing contacts.
 const e164Regex = /^\+[1-9]\d{6,14}$/
+const shortTextSchema = z.string().max(100)
+const urlTextSchema = z.string().max(500)
+const submittedAtSchema = z.string().max(40)
 
 export const contactStepSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -153,15 +156,15 @@ const baseSchema = z.object({
   email: z.string().email(),
   whatsapp: z.string().regex(e164Regex),
   formMode: formModeSchema,
-  submittedAt: z.string(),
-  pageUrl: z.string(),
+  submittedAt: submittedAtSchema,
+  pageUrl: urlTextSchema,
   
   // UTM params (optional)
-  utmSource: z.string().optional(),
-  utmMedium: z.string().optional(),
-  utmCampaign: z.string().optional(),
-  utmContent: z.string().optional(),
-  utmTerm: z.string().optional(),
+  utmSource: shortTextSchema.optional(),
+  utmMedium: shortTextSchema.optional(),
+  utmCampaign: shortTextSchema.optional(),
+  utmContent: shortTextSchema.optional(),
+  utmTerm: shortTextSchema.optional(),
 })
 
 // Download mode: Just name + contact
@@ -192,7 +195,7 @@ export const contactFormSchema = baseSchema.extend({
 
   // Questions
   hasQuestions: z.boolean().optional(),
-  questionsText: z.string().optional(),
+  questionsText: z.string().max(500).optional(),
 })
 
 // Private mode: Discreet UHNW capture
@@ -222,7 +225,7 @@ export const propertyEnquiryFormSchema = baseSchema.extend({
 
   // Questions
   hasQuestions: z.boolean().optional(),
-  questionsText: z.string().optional(),
+  questionsText: z.string().max(500).optional(),
 
   // Property interest fields
   bitrixLeadId: z.string().max(50).optional(),
@@ -234,18 +237,18 @@ export const propertyEnquiryFormSchema = baseSchema.extend({
 // Returning lead: minimal schema (no name/contact required)
 export const returningLeadFormSchema = z.object({
   formMode: formModeSchema,
-  submittedAt: z.string(),
-  pageUrl: z.string(),
+  submittedAt: submittedAtSchema,
+  pageUrl: urlTextSchema,
   bitrixLeadId: z.string().max(50),
   enquiryIntent: z.array(z.string().max(100)).max(10).optional(),
   propertyAppeals: z.array(z.string().max(100)).max(10).optional(),
   enquiryNotes: z.string().max(1000).optional(),
   referringProperty: z.string().max(500).optional(),
-  utmSource: z.string().optional(),
-  utmMedium: z.string().optional(),
-  utmCampaign: z.string().optional(),
-  utmContent: z.string().optional(),
-  utmTerm: z.string().optional(),
+  utmSource: shortTextSchema.optional(),
+  utmMedium: shortTextSchema.optional(),
+  utmCampaign: shortTextSchema.optional(),
+  utmContent: shortTextSchema.optional(),
+  utmTerm: shortTextSchema.optional(),
 })
 
 // =============================================================================

--- a/lib/crm/client.ts
+++ b/lib/crm/client.ts
@@ -28,6 +28,7 @@ import type {
 } from "./types"
 
 const REVALIDATE_SECONDS = 300 // CRM advertises Cache-Control max-age=300
+const CRM_PARAM_MAX_LENGTH = 200
 
 interface FetchOptions {
   /** Skip the in-memory ISR cache for this request (e.g., previews). */
@@ -35,7 +36,11 @@ interface FetchOptions {
 }
 
 function isCrmConfigured(): boolean {
-  return Boolean(config.crm.baseUrl && config.crm.agencyUuid)
+  return Boolean(
+    config.crm.baseUrl &&
+      config.crm.agencyUuid &&
+      config.crm.agencyUuid.length <= CRM_PARAM_MAX_LENGTH,
+  )
 }
 
 function buildListUrl(filters: CrmListFilters | undefined): string {
@@ -230,6 +235,8 @@ export async function getCrmPropertyBySlug(
   opts?: FetchOptions
 ): Promise<CrmPropertyFull | null> {
   if (!isCrmConfigured()) return null
+  if (!slugOrId || slugOrId.length > CRM_PARAM_MAX_LENGTH) return null
+
   const response = await crmFetch<CrmDetailResponse>(buildDetailUrl(slugOrId), opts)
   if (!response) return null
   const row = "data" in response ? response.data : response

--- a/lib/hooks/use-attribution.ts
+++ b/lib/hooks/use-attribution.ts
@@ -28,6 +28,7 @@ import { captureSessionUtm, readUtmFromSearch } from "@/lib/leads/attribution"
 const FIRST_TOUCH_COOKIE = "pc_first_touch"
 const SESSION_COOKIE = "pc_session_id"
 const COOKIE_MAX_AGE_DAYS = 30
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 interface FirstTouch {
   utmSource?: string
@@ -92,6 +93,10 @@ function generateUUID(): string {
   })
 }
 
+function isUUIDv4(value: string | null): value is string {
+  return Boolean(value && UUID_V4_REGEX.test(value))
+}
+
 /**
  * One-shot capture: reads stored UTM attribution if present, otherwise stores
  * the current utm_* params. Also ensures a sessionId cookie exists and keeps
@@ -108,7 +113,7 @@ export function useAttribution(): AttributionPayload {
 
     // --- Session ---
     let sessionId = readCookie(SESSION_COOKIE)
-    if (!sessionId) {
+    if (!isUUIDv4(sessionId)) {
       sessionId = generateUUID()
       writeCookie(SESSION_COOKIE, sessionId, COOKIE_MAX_AGE_DAYS)
     }

--- a/tests/api/leads.test.ts
+++ b/tests/api/leads.test.ts
@@ -164,6 +164,58 @@ describe("Lead Form API", () => {
       const response = await POST(request as unknown as NextRequest)
       expect(response.status).toBe(400)
     })
+
+    it("should reject unbounded multi-select payloads before forwarding", async () => {
+      const { POST } = await import("@/app/api/leads/route")
+
+      const request = new Request("http://localhost/api/leads", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "192.168.1.51",
+        },
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.com",
+          whatsapp: "+971501234567",
+          formMode: "contact",
+          submittedAt: new Date().toISOString(),
+          pageUrl: "https://example.com/",
+          goals: Array.from({ length: 11 }, (_, i) => `goal-${i}`),
+        }),
+      })
+
+      const response = await POST(request as unknown as NextRequest)
+      expect(response.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("should reject non-UUIDv4 session IDs before forwarding", async () => {
+      const { POST } = await import("@/app/api/leads/route")
+
+      const request = new Request("http://localhost/api/leads", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "192.168.1.52",
+        },
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.com",
+          whatsapp: "+971501234567",
+          formMode: "landing",
+          submittedAt: new Date().toISOString(),
+          pageUrl: "https://example.com/",
+          sessionId: "website-session",
+        }),
+      })
+
+      const response = await POST(request as unknown as NextRequest)
+      expect(response.status).toBe(400)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
   })
 
   // =============================================================================
@@ -230,6 +282,7 @@ describe("Lead Form API", () => {
           source: "legacy-source-param",
           utmSource: "youtube",
           utmCampaign: "test123",
+          sessionId: "6f3fdfb4-8697-4c0a-9f68-3b2c83f8f5c5",
         }),
       })
 
@@ -249,7 +302,90 @@ describe("Lead Form API", () => {
       )
       expect(payload.utmSource).toBe("youtube")
       expect(payload.utmCampaign).toBe("test123")
+      expect(payload.sessionId).toBe("6f3fdfb4-8697-4c0a-9f68-3b2c83f8f5c5")
       expect(payload.source).toBeUndefined()
+    })
+
+    it("keeps accepted AgentCRM enquiry payloads below the 64KB body cap", async () => {
+      const { POST } = await import("@/app/api/leads/route")
+
+      const request = new Request("http://localhost/api/leads", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": "192.168.1.71",
+        },
+        body: JSON.stringify({
+          firstName: "A".repeat(100),
+          lastName: "B".repeat(100),
+          email: "max@example.com",
+          whatsapp: "+971501234567",
+          formMode: "contact",
+          submittedAt: new Date().toISOString(),
+          pageUrl: `https://example.com/${"p".repeat(480)}`,
+          goals: Array.from({ length: 10 }, (_, i) => `goal-${i}`),
+          investTimeline: "12_24_months",
+          budget: "10m-20m",
+          propertyTypes: Array.from({ length: 9 }, (_, i) => `type-${i}`),
+          locations: Array.from({ length: 5 }, (_, i) => `Location ${i} ${"x".repeat(85)}`),
+          bedrooms: 20,
+          propertyLocation: "L".repeat(500),
+          concerns: "C".repeat(2000),
+          propertyType: "apartment",
+          saleTimeline: "flexible",
+          targetPrice: "50m-plus",
+          hasQuestions: true,
+          questionsText: "Q".repeat(500),
+          privateRole: "investor",
+          deploymentRange: "50m-plus",
+          preferredContact: "whatsapp",
+          privateContext: "P".repeat(500),
+          enquiryIntent: Array.from({ length: 10 }, (_, i) => `intent-${i}`),
+          propertyAppeals: Array.from({ length: 10 }, (_, i) => `appeal-${i}`),
+          enquiryNotes: "N".repeat(1000),
+          leadMagnet: "M".repeat(200),
+          leadTag: "T".repeat(100),
+          visitorType: "investor",
+          referringProperty: "R".repeat(500),
+          referringTeamMember: "agent-slug",
+          referringTeamMemberEmail: "agent@primecapitaldubai.com",
+          utmSource: "S".repeat(100),
+          utmMedium: "M".repeat(100),
+          utmCampaign: "C".repeat(100),
+          utmContent: "O".repeat(100),
+          utmTerm: "T".repeat(100),
+          manychat: "Y".repeat(100),
+          referrer: `https://referrer.example/${"r".repeat(475)}`,
+          firstTouchUtmSource: "F".repeat(100),
+          firstTouchUtmMedium: "F".repeat(100),
+          firstTouchUtmCampaign: "F".repeat(100),
+          firstTouchUtmContent: "F".repeat(100),
+          firstTouchUtmTerm: "F".repeat(100),
+          firstTouchReferrer: `https://first.example/${"f".repeat(478)}`,
+          firstTouchLandingPage: `https://landing.example/${"l".repeat(476)}`,
+          firstTouchAt: new Date().toISOString(),
+          submissionId: "29c7c5ac-308d-4d81-95d6-00f5e8316b36",
+          sessionId: "6f3fdfb4-8697-4c0a-9f68-3b2c83f8f5c5",
+          meetingStartTime: new Date().toISOString(),
+          meetingEndTime: new Date().toISOString(),
+          meetingInviteeName: "I".repeat(200),
+          meetingInviteeEmail: "invitee@example.com",
+          meetingEventType: "E".repeat(200),
+          meetingEventUri: `https://calendly.example/${"e".repeat(475)}`,
+          meetingInviteeUri: `https://calendly.example/${"i".repeat(475)}`,
+          meetingRescheduleUrl: `https://calendly.example/${"s".repeat(475)}`,
+          meetingCancelUrl: `https://calendly.example/${"c".repeat(475)}`,
+          website: "",
+        }),
+      })
+
+      const response = await POST(request as unknown as NextRequest)
+      expect(response.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      const [, requestInit] = mockFetch.mock.calls[0]
+      const body = String(requestInit.body)
+      expect(Buffer.byteLength(body, "utf8")).toBeLessThanOrEqual(64 * 1024)
     })
   })
 


### PR DESCRIPTION
## Summary
- cap AgentCRM enquiry payloads at 64KB before forwarding
- enforce UUIDv4 session IDs and rotate stale client session cookies
- cap CRM agency/slug params before public GET calls
- tighten lead form validation and add API contract coverage

## Validation
- pnpm test:run tests/api/leads.test.ts tests/lib/lead-attribution.test.ts
- pnpm lint