### PR TITLE
Persist single-script runs so all 3 angles stay reachable

### DIFF
--- a/app/(admin)/admin/youtube/[id]/script-detail-page.tsx
+++ b/app/(admin)/admin/youtube/[id]/script-detail-page.tsx
@@ -613,12 +613,36 @@ export function ScriptDetailPage({
 
   return (
     <Stack gap="lg">
-      {/* Header + back nav */}
+      {/* Header + back nav. When the script belongs to a run (Mode B "Write
+          One Script"), the back arrow returns to the run workspace so the user
+          can pick a different angle without losing context. */}
       <Row align="start" gap="sm">
-        <Button variant="ghost" size="sm" className="mt-1" render={<Link href={`/admin/youtube?profile=${script.profile_slug}`} />}>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mt-1"
+          render={
+            <Link
+              href={
+                script.run_id
+                  ? `/admin/youtube/runs/${script.run_id}`
+                  : `/admin/youtube?profile=${script.profile_slug}`
+              }
+            />
+          }
+        >
           <ArrowLeftIcon className="h-4 w-4" />
         </Button>
         <Stack gap="xs" className="flex-1 min-w-0">
+          {script.run_id && (
+            <Link
+              href={`/admin/youtube/runs/${script.run_id}`}
+              className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1 w-fit"
+            >
+              <ArrowLeftIcon className="h-3 w-3" />
+              Back to angles
+            </Link>
+          )}
           <Title size="h3" className="line-clamp-2">{script.title}</Title>
           {script.topic && (
             <Text variant="muted" size="sm" className="line-clamp-2">

--- a/app/(admin)/admin/youtube/new/single/single-script-workflow.tsx
+++ b/app/(admin)/admin/youtube/new/single/single-script-workflow.tsx
@@ -1,15 +1,11 @@
 /**
- * CATALYST - Write One Script Workflow (Mode B)
+ * CATALYST - Write One Script — Step 1 (context capture)
  *
- * Three-step flow that goes from a chunk of context straight to a generated
- * script (no idea-batch loop):
- *
- *   Step 1 (input):   user pastes context, picks a format (required), submits
- *   Step 2 (confirm): AI returns 3 distilled angles; user picks one, edits if
- *                     needed, and confirms — guarding the expensive Opus call
- *                     from a wrong distillation
- *   Step 3 (generate): row is created, user is redirected to the detail page
- *                      with ?autoGenerate=1 to kick off script streaming
+ * Single step: pick a format, paste context (optionally append a voice-note
+ * transcript), submit. On success we persist a "run" (context + 3 distilled
+ * angles) and route to /admin/youtube/runs/[runId], where the user can pick
+ * which angle to generate — and come back to try the others without losing
+ * the context or the transcript.
  */
 
 "use client"
@@ -19,27 +15,23 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { Stack, Row, Text, Title } from "@/components/core"
 import { Button } from "@/components/ui/button"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { Textarea } from "@/components/ui/textarea"
-import { Input } from "@/components/ui/input"
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
   Loader2Icon,
   SparklesIcon,
-  CheckCircleIcon,
-  PenLineIcon,
-  AlertTriangleIcon,
   BarChart3Icon,
   AxeIcon,
   FlameIcon,
   UserIcon,
   ListOrderedIcon,
   MessageCircleQuestionIcon,
-  PencilIcon,
 } from "lucide-react"
-import { createYouTubeScript } from "@/lib/actions/youtube"
+import {
+  createYouTubeScriptRun,
+  type DistilledAngle,
+} from "@/lib/actions/youtube"
 import { toast } from "@/components/ui/toast"
 import { cn } from "@/lib/utils"
 import {
@@ -52,20 +44,9 @@ import { ProfileChip } from "../../_components/profile-selector"
 import { useVoiceNote } from "@/lib/hooks"
 import { VoiceNoteButton } from "@/components/shared"
 
-// =============================================================================
-// TYPES
-// =============================================================================
-
-type DistilledAngle = {
-  title: string
-  topic: string
-  why_this_angle: string
-  news_peg: string | null
-  needs_news_peg: boolean
-  target_length: "quick_take" | "standard" | "deep_dive"
-}
-
-type Step = "input" | "confirm"
+// Mirrors the cap in /api/admin/youtube/distill-idea. Anything beyond this is
+// silently truncated before the LLM sees it.
+const CONTEXT_CHAR_CAP = 12_000
 
 // =============================================================================
 // FORMAT ICON
@@ -135,16 +116,10 @@ function FormatPill({
 
 export function SingleScriptWorkflow({ lockedProfile }: { lockedProfile: ProfileSlug }) {
   const router = useRouter()
-  const [step, setStep] = React.useState<Step>("input")
   const [context, setContext] = React.useState("")
   const profileSlug = lockedProfile
   const [format, setFormat] = React.useState<Format | null>(null)
-  const [angles, setAngles] = React.useState<DistilledAngle[]>([])
-  const [selectedIndex, setSelectedIndex] = React.useState<number | null>(null)
-  const [isDistilling, setIsDistilling] = React.useState(false)
-  const [isSaving, setIsSaving] = React.useState(false)
-  const [editingTitle, setEditingTitle] = React.useState(false)
-  const [editingTopic, setEditingTopic] = React.useState(false)
+  const [isWorking, setIsWorking] = React.useState(false)
 
   // Voice note — transcript is appended to the pasted context.
   const { voiceState, recordingDuration, startRecording, stopRecording } =
@@ -153,15 +128,13 @@ export function SingleScriptWorkflow({ lockedProfile }: { lockedProfile: Profile
         setContext((prev) => (prev ? prev + " " + text : text)),
     })
 
-  const selectedAngle = selectedIndex !== null ? angles[selectedIndex] : null
-
   // ---------------------------------------------------------------------------
-  // Distill
+  // Distil → persist run → route to run workspace
   // ---------------------------------------------------------------------------
 
-  async function handleDistill() {
+  async function handleDistilAndCreateRun() {
     if (!context.trim() || !format) return
-    setIsDistilling(true)
+    setIsWorking(true)
     try {
       const res = await fetch("/api/admin/youtube/distill-idea", {
         method: "POST",
@@ -173,69 +146,29 @@ export function SingleScriptWorkflow({ lockedProfile }: { lockedProfile: Profile
         throw new Error(err.error || "Failed to distil context")
       }
       const data = await res.json()
-      const distilled = (data.angles as DistilledAngle[]) ?? []
-      if (distilled.length === 0) {
+      const angles = (data.angles as DistilledAngle[]) ?? []
+      if (angles.length === 0) {
         toast("No usable angles returned — try with more context", { type: "error" })
         return
       }
-      setAngles(distilled)
-      setSelectedIndex(0)
-      setStep("confirm")
+
+      const runResult = await createYouTubeScriptRun({
+        context_text: context.trim(),
+        format,
+        profile_slug: profileSlug,
+        angles,
+      })
+      if (!runResult.success) {
+        throw new Error(runResult.error || "Failed to save run")
+      }
+
+      router.push(`/admin/youtube/runs/${runResult.data.id}`)
     } catch (err) {
       console.error("Distill error:", err)
       toast(err instanceof Error ? err.message : "Failed to distil context", {
         type: "error",
       })
-    } finally {
-      setIsDistilling(false)
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Edit angle (in-place)
-  // ---------------------------------------------------------------------------
-
-  function updateAngleField(field: "title" | "topic", value: string) {
-    if (selectedIndex === null) return
-    setAngles((prev) => {
-      const next = [...prev]
-      next[selectedIndex] = { ...next[selectedIndex], [field]: value }
-      return next
-    })
-  }
-
-  // ---------------------------------------------------------------------------
-  // Save and launch
-  // ---------------------------------------------------------------------------
-
-  async function handleConfirmAndGenerate() {
-    if (!format || !selectedAngle) return
-    if (selectedAngle.needs_news_peg) {
-      toast("This Reaction angle needs a news peg before it can be saved", {
-        type: "error",
-      })
-      return
-    }
-    setIsSaving(true)
-    try {
-      const result = await createYouTubeScript({
-        title: selectedAngle.title,
-        topic: selectedAngle.topic,
-        target_length: selectedAngle.target_length,
-        format,
-        profile_slug: profileSlug,
-        status: "idea",
-        input_text: context.trim() || undefined,
-      })
-      if (!result.success) {
-        throw new Error(result.error || "Failed to save")
-      }
-      // Hand off to the detail page; ?autoGenerate=1 kicks off Opus on mount.
-      router.push(`/admin/youtube/${result.data.id}?autoGenerate=1`)
-    } catch (err) {
-      console.error("Save error:", err)
-      toast(err instanceof Error ? err.message : "Failed to save", { type: "error" })
-      setIsSaving(false)
+      setIsWorking(false)
     }
   }
 
@@ -250,339 +183,116 @@ export function SingleScriptWorkflow({ lockedProfile }: { lockedProfile: Profile
         <Button
           variant="ghost"
           size="sm"
-          render={
-            <Link
-              href={step === "input" ? "/admin/youtube/new" : "#"}
-              onClick={(e) => {
-                if (step !== "input") {
-                  e.preventDefault()
-                  setStep("input")
-                }
-              }}
-            />
-          }
+          render={<Link href="/admin/youtube/new" />}
         >
           <ArrowLeftIcon className="h-4 w-4" />
         </Button>
         <Stack gap="xs" className="flex-1">
           <Title size="h3">Write One Script</Title>
           <Text variant="muted" size="sm">
-            {step === "input"
-              ? "Step 1 — Pick a format and paste your context"
-              : "Step 2 — Confirm the angle, then we'll generate the script"}
+            Pick a format and paste your context — we'll distil it into 3 angles
+            you can choose from
           </Text>
         </Stack>
-        <Row gap="xs" align="center">
-          <div
-            className={cn(
-              "h-2 w-8 rounded-full transition-colors",
-              step === "input" ? "bg-primary" : "bg-primary/40"
-            )}
-          />
-          <div
-            className={cn(
-              "h-2 w-8 rounded-full transition-colors",
-              step === "confirm" ? "bg-primary" : "bg-muted"
-            )}
-          />
-        </Row>
       </Row>
 
-      {/* =================================================================== */}
-      {/* STEP 1: INPUT                                                       */}
-      {/* =================================================================== */}
+      <Stack gap="lg">
+        {/* Locked profile indicator — set by the picker upstream */}
+        <Row align="center" gap="sm">
+          <Text variant="muted" size="sm">Writing for</Text>
+          <ProfileChip slug={profileSlug} />
+          <Text variant="muted" size="sm">
+            · {PROFILES[profileSlug].displayRole}
+          </Text>
+        </Row>
 
-      {step === "input" && (
-        <Stack gap="lg">
-          {/* Locked profile indicator — set by the picker upstream */}
-          <Row align="center" gap="sm">
-            <Text variant="muted" size="sm">Writing for</Text>
-            <ProfileChip slug={profileSlug} />
-            <Text variant="muted" size="sm">
-              · {PROFILES[profileSlug].displayRole}
-            </Text>
-          </Row>
-
-          {/* Format picker — required, sits at top */}
-          <Stack gap="sm">
-            <Stack gap="xs">
-              <Text className="font-medium">
-                Which format are you writing in?{" "}
-                <span className="text-destructive">*</span>
-              </Text>
-              <Text variant="muted" size="sm">
-                Each format has its own structure and CTA pattern. The script
-                will be generated to that spec.
-              </Text>
-            </Stack>
-            <Row gap="xs" wrap>
-              {FORMATS_IN_DISPLAY_ORDER.map((f) => (
-                <FormatPill
-                  key={f}
-                  format={f}
-                  selected={format === f}
-                  onSelect={() => setFormat(f)}
-                />
-              ))}
-            </Row>
-          </Stack>
-
-          {/* Context input */}
-          <Stack gap="sm">
-            <Stack gap="xs">
-              <Text className="font-medium">
-                What's the context? <span className="text-destructive">*</span>
-              </Text>
-              <Text variant="muted" size="sm">
-                Paste notes, a brief, a competitor video transcript, a half-formed
-                thought — or record a voice note. The more concrete the context,
-                the sharper the distilled angles.
-              </Text>
-            </Stack>
-            <Textarea
-              placeholder="e.g. I want to make a video on the new RERA escrow rules announced last week — specifically the 60-day rule on developer payment milestones. I have a client whose off-plan purchase is mid-payment and they're worried about exposure. The new framework actually protects them more than the old one did, but most agents are spinning it the wrong way..."
-              value={context}
-              onChange={(e) => setContext(e.target.value)}
-              className="min-h-56 resize-y text-base leading-relaxed"
-              disabled={voiceState === "transcribing"}
-            />
-            <Row align="center" className="justify-between">
-              <Row gap="sm" align="center">
-                <VoiceNoteButton
-                  voiceState={voiceState}
-                  recordingDuration={recordingDuration}
-                  onStart={startRecording}
-                  onStop={stopRecording}
-                />
-                <Text variant="muted" size="sm">
-                  {context.length > 0
-                    ? `${context.length.toLocaleString()} characters`
-                    : "Empty"}
-                </Text>
-              </Row>
-              <Button
-                onClick={handleDistill}
-                disabled={!context.trim() || !format || isDistilling || voiceState !== "idle"}
-                size="lg"
-              >
-                {isDistilling ? (
-                  <>
-                    <Loader2Icon className="h-4 w-4 animate-spin mr-2" />
-                    Distilling angles...
-                  </>
-                ) : (
-                  <>
-                    <SparklesIcon className="h-4 w-4 mr-2" />
-                    Distil into 3 angles
-                    <ArrowRightIcon className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </Row>
-          </Stack>
-        </Stack>
-      )}
-
-      {/* =================================================================== */}
-      {/* STEP 2: CONFIRM                                                     */}
-      {/* =================================================================== */}
-
-      {step === "confirm" && format && (
-        <Stack gap="lg">
+        {/* Format picker — required, sits at top */}
+        <Stack gap="sm">
           <Stack gap="xs">
             <Text className="font-medium">
-              Three angles distilled from your context — pick one
+              Which format are you writing in?{" "}
+              <span className="text-destructive">*</span>
             </Text>
             <Text variant="muted" size="sm">
-              The selected angle becomes the script's working title and topic.
-              You can edit either before generating.
+              Each format has its own structure and CTA pattern. The script
+              will be generated to that spec.
             </Text>
           </Stack>
-
-          {/* Angle cards */}
-          <Stack gap="sm">
-            {angles.map((angle, i) => {
-              const isSelected = selectedIndex === i
-              const isDisabled = angle.needs_news_peg
-              return (
-                <Card
-                  key={i}
-                  className={cn(
-                    "transition-all cursor-pointer",
-                    isDisabled
-                      ? "opacity-50 border-dashed cursor-not-allowed"
-                      : isSelected
-                        ? "border-primary ring-1 ring-primary/20 bg-primary/5"
-                        : "hover:border-primary/40"
-                  )}
-                  onClick={() => {
-                    if (isDisabled) return
-                    setSelectedIndex(i)
-                    setEditingTitle(false)
-                    setEditingTopic(false)
-                  }}
-                >
-                  <CardContent className="p-4">
-                    <Row align="start" gap="sm">
-                      <div
-                        className={cn(
-                          "h-5 w-5 rounded-full border-2 flex items-center justify-center shrink-0 mt-0.5 transition-colors",
-                          isDisabled
-                            ? "border-muted-foreground/20"
-                            : isSelected
-                              ? "border-primary bg-primary text-primary-foreground"
-                              : "border-muted-foreground/30"
-                        )}
-                      >
-                        {isSelected && <CheckCircleIcon className="h-3.5 w-3.5" />}
-                      </div>
-                      <Stack gap="xs" className="flex-1 min-w-0">
-                        {/* Title — inline editable if selected */}
-                        {isSelected && editingTitle ? (
-                          <Input
-                            autoFocus
-                            value={angle.title}
-                            onChange={(e) => updateAngleField("title", e.target.value)}
-                            onBlur={() => setEditingTitle(false)}
-                            onKeyDown={(e) => {
-                              if (e.key === "Enter" || e.key === "Escape") {
-                                setEditingTitle(false)
-                              }
-                            }}
-                            className="text-base font-medium"
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                        ) : (
-                          <Row align="center" gap="xs">
-                            <Text className="font-medium leading-snug flex-1">
-                              {angle.title}
-                            </Text>
-                            {isSelected && (
-                              <button
-                                type="button"
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  setEditingTitle(true)
-                                }}
-                                className="text-muted-foreground hover:text-foreground shrink-0"
-                                aria-label="Edit title"
-                              >
-                                <PencilIcon className="h-3.5 w-3.5" />
-                              </button>
-                            )}
-                          </Row>
-                        )}
-
-                        {/* Topic — inline editable if selected */}
-                        {isSelected && editingTopic ? (
-                          <Textarea
-                            autoFocus
-                            value={angle.topic}
-                            onChange={(e) => updateAngleField("topic", e.target.value)}
-                            onBlur={() => setEditingTopic(false)}
-                            className="text-sm min-h-20"
-                            onClick={(e) => e.stopPropagation()}
-                          />
-                        ) : (
-                          <Row align="start" gap="xs">
-                            <Text variant="muted" size="sm" className="leading-relaxed flex-1">
-                              {angle.topic}
-                            </Text>
-                            {isSelected && (
-                              <button
-                                type="button"
-                                onClick={(e) => {
-                                  e.stopPropagation()
-                                  setEditingTopic(true)
-                                }}
-                                className="text-muted-foreground hover:text-foreground shrink-0 mt-0.5"
-                                aria-label="Edit topic"
-                              >
-                                <PencilIcon className="h-3.5 w-3.5" />
-                              </button>
-                            )}
-                          </Row>
-                        )}
-
-                        {/* Why this angle */}
-                        {angle.why_this_angle && (
-                          <Text size="sm" className="text-primary/80 italic leading-relaxed">
-                            Why this angle: {angle.why_this_angle}
-                          </Text>
-                        )}
-
-                        {/* News peg / warning */}
-                        {angle.news_peg && (
-                          <Row gap="xs" align="center">
-                            <Badge variant="outline" size="sm">
-                              News peg
-                            </Badge>
-                            <Text variant="muted" size="sm">
-                              {angle.news_peg}
-                            </Text>
-                          </Row>
-                        )}
-                        {isDisabled && (
-                          <Row gap="xs" align="center">
-                            <AlertTriangleIcon className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0" />
-                            <Text size="sm" className="text-amber-700 dark:text-amber-300">
-                              Needs a current news peg from DLD / RERA / Central Bank UAE / Fitch / Moody's / S&P
-                            </Text>
-                          </Row>
-                        )}
-                      </Stack>
-                    </Row>
-                  </CardContent>
-                </Card>
-              )
-            })}
-          </Stack>
-
-          {/* Action bar */}
-          <Row className="justify-between pt-4 border-t" wrap gap="sm">
-            <Row align="center" gap="sm">
-              <Badge variant="outline">
-                <FormatFlagIcon
-                  format={format}
-                  className="h-3 w-3 mr-1"
-                />
-                {FORMAT_META[format].label}
-              </Badge>
-              <Text variant="muted" size="sm">
-                {FORMAT_META[format].minutesLabel} · {FORMAT_META[format].wordsLabel}
-              </Text>
-            </Row>
-            <Row gap="sm">
-              <Button variant="outline" onClick={() => setStep("input")}>
-                <ArrowLeftIcon className="h-4 w-4 mr-2" />
-                Back
-              </Button>
-              <Button
-                onClick={handleConfirmAndGenerate}
-                disabled={
-                  selectedIndex === null ||
-                  isSaving ||
-                  (selectedAngle?.needs_news_peg ?? false)
-                }
-                size="lg"
-              >
-                {isSaving ? (
-                  <>
-                    <Loader2Icon className="h-4 w-4 animate-spin mr-2" />
-                    Launching...
-                  </>
-                ) : (
-                  <>
-                    <PenLineIcon className="h-4 w-4 mr-2" />
-                    Looks good — generate script
-                    <ArrowRightIcon className="h-4 w-4 ml-2" />
-                  </>
-                )}
-              </Button>
-            </Row>
+          <Row gap="xs" wrap>
+            {FORMATS_IN_DISPLAY_ORDER.map((f) => (
+              <FormatPill
+                key={f}
+                format={f}
+                selected={format === f}
+                onSelect={() => setFormat(f)}
+              />
+            ))}
           </Row>
         </Stack>
-      )}
+
+        {/* Context input */}
+        <Stack gap="sm">
+          <Stack gap="xs">
+            <Text className="font-medium">
+              What's the context? <span className="text-destructive">*</span>
+            </Text>
+            <Text variant="muted" size="sm">
+              Paste notes, a brief, a competitor video transcript, a half-formed
+              thought — or record a voice note. The more concrete the context,
+              the sharper the distilled angles.
+            </Text>
+          </Stack>
+          <Textarea
+            placeholder="e.g. I want to make a video on the new RERA escrow rules announced last week — specifically the 60-day rule on developer payment milestones. I have a client whose off-plan purchase is mid-payment and they're worried about exposure. The new framework actually protects them more than the old one did, but most agents are spinning it the wrong way..."
+            value={context}
+            onChange={(e) => setContext(e.target.value)}
+            className="min-h-56 resize-y text-base leading-relaxed"
+            disabled={voiceState === "transcribing"}
+          />
+          <Row align="center" className="justify-between">
+            <Row gap="sm" align="center">
+              <VoiceNoteButton
+                voiceState={voiceState}
+                recordingDuration={recordingDuration}
+                onStart={startRecording}
+                onStop={stopRecording}
+              />
+              <Text
+                variant="muted"
+                size="sm"
+                className={cn(
+                  context.length > CONTEXT_CHAR_CAP &&
+                    "text-amber-700 dark:text-amber-300"
+                )}
+              >
+                {context.length > 0
+                  ? `${context.length.toLocaleString()} characters`
+                  : "Empty"}
+                {context.length > CONTEXT_CHAR_CAP &&
+                  ` · only the first ${CONTEXT_CHAR_CAP.toLocaleString()} reach the LLM`}
+              </Text>
+            </Row>
+            <Button
+              onClick={handleDistilAndCreateRun}
+              disabled={!context.trim() || !format || isWorking || voiceState !== "idle"}
+              size="lg"
+            >
+              {isWorking ? (
+                <>
+                  <Loader2Icon className="h-4 w-4 animate-spin mr-2" />
+                  Distilling angles...
+                </>
+              ) : (
+                <>
+                  <SparklesIcon className="h-4 w-4 mr-2" />
+                  Distil into 3 angles
+                  <ArrowRightIcon className="h-4 w-4 ml-2" />
+                </>
+              )}
+            </Button>
+          </Row>
+        </Stack>
+      </Stack>
     </Stack>
   )
 }

--- a/app/(admin)/admin/youtube/runs/[id]/page.tsx
+++ b/app/(admin)/admin/youtube/runs/[id]/page.tsx
@@ -1,0 +1,48 @@
+/**
+ * CATALYST - Single-Script Run Workspace
+ *
+ * The hub for one "Write One Script" run: editable context (text + voice
+ * transcript), the 3 distilled angles, and per-angle Generate / View buttons
+ * so the user can try any of the angles without losing the others.
+ */
+
+import { notFound } from "next/navigation"
+import { Container } from "@/components/core"
+import {
+  getYouTubeScriptRun,
+  getYouTubeScriptsForRun,
+} from "@/lib/actions/youtube"
+import { RunWorkspace } from "./run-workspace"
+
+export const dynamic = "force-dynamic"
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const run = await getYouTubeScriptRun(id)
+  return {
+    title: run.success ? "Run · Write One Script | YouTube | Admin" : "Run | Admin",
+  }
+}
+
+export default async function YouTubeScriptRunPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const [runResult, scriptsResult] = await Promise.all([
+    getYouTubeScriptRun(id),
+    getYouTubeScriptsForRun(id),
+  ])
+
+  if (!runResult.success) notFound()
+
+  return (
+    <Container size="lg" className="py-6">
+      <RunWorkspace
+        run={runResult.data}
+        initialScripts={scriptsResult.success ? scriptsResult.data : []}
+      />
+    </Container>
+  )
+}

--- a/app/(admin)/admin/youtube/runs/[id]/run-workspace.tsx
+++ b/app/(admin)/admin/youtube/runs/[id]/run-workspace.tsx
@@ -1,0 +1,578 @@
+/**
+ * CATALYST - Run Workspace (client)
+ *
+ * Lets the user choose which of the 3 distilled angles to generate, view the
+ * ones already generated, and refine the context — all without losing the
+ * original input or the other angles.
+ */
+
+"use client"
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { Stack, Row, Text, Title } from "@/components/core"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Textarea } from "@/components/ui/textarea"
+import { Input } from "@/components/ui/input"
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  Loader2Icon,
+  SparklesIcon,
+  AlertTriangleIcon,
+  BarChart3Icon,
+  AxeIcon,
+  FlameIcon,
+  UserIcon,
+  ListOrderedIcon,
+  MessageCircleQuestionIcon,
+  PencilIcon,
+  FileTextIcon,
+  CheckCircleIcon,
+  RefreshCwIcon,
+} from "lucide-react"
+
+// Mirrors the cap in /api/admin/youtube/distill-idea. Stored context can exceed
+// this but the LLM will only see the first 12,000 characters.
+const CONTEXT_CHAR_CAP = 12_000
+import {
+  createYouTubeScript,
+  updateYouTubeScriptRun,
+  type YouTubeScriptRun,
+  type YouTubeScript,
+  type DistilledAngle,
+} from "@/lib/actions/youtube"
+import { toast } from "@/components/ui/toast"
+import { cn } from "@/lib/utils"
+import { FORMAT_META, type Format } from "@/lib/youtube/prompts"
+import { PROFILES } from "@/lib/youtube/profiles"
+import { ProfileChip } from "../../_components/profile-selector"
+import { useVoiceNote } from "@/lib/hooks"
+import { VoiceNoteButton } from "@/components/shared"
+
+// =============================================================================
+// FORMAT ICON
+// =============================================================================
+
+function FormatFlagIcon({ format, className }: { format: Format; className?: string }) {
+  switch (format) {
+    case "authority_analysis":
+      return <BarChart3Icon className={className} />
+    case "myth_buster":
+      return <AxeIcon className={className} />
+    case "reaction":
+      return <FlameIcon className={className} />
+    case "case_study":
+      return <UserIcon className={className} />
+    case "listicle":
+      return <ListOrderedIcon className={className} />
+    case "qa_mailbag":
+      return <MessageCircleQuestionIcon className={className} />
+  }
+}
+
+// =============================================================================
+// MAIN COMPONENT
+// =============================================================================
+
+export function RunWorkspace({
+  run: initial,
+  initialScripts,
+}: {
+  run: YouTubeScriptRun
+  initialScripts: YouTubeScript[]
+}) {
+  const router = useRouter()
+
+  // Local mirror of the run row so context + angle edits feel immediate.
+  const [contextText, setContextText] = React.useState(initial.context_text)
+  // Snapshot of the last persisted context, used to compute the dirty flag.
+  // `initial.context_text` is a prop and never refreshes, so comparing against
+  // it would leave "Save context" stuck visible after every save.
+  const [savedContext, setSavedContext] = React.useState(initial.context_text)
+  const [angles, setAngles] = React.useState<DistilledAngle[]>(initial.angles)
+  const [editingTitle, setEditingTitle] = React.useState<number | null>(null)
+  const [editingTopic, setEditingTopic] = React.useState<number | null>(null)
+  const [isSavingContext, setIsSavingContext] = React.useState(false)
+  const [isRedistilling, setIsRedistilling] = React.useState(false)
+  const [generatingIndex, setGeneratingIndex] = React.useState<number | null>(null)
+
+  const meta = FORMAT_META[initial.format]
+
+  // Map angle_index -> script row, for the per-angle "generate vs view" choice.
+  const scriptsByAngle = React.useMemo(() => {
+    const map = new Map<number, YouTubeScript>()
+    for (const s of initialScripts) {
+      if (s.angle_index !== null) map.set(s.angle_index, s)
+    }
+    return map
+  }, [initialScripts])
+
+  const contextDirty = contextText !== savedContext
+  const contextOverCap = contextText.length > CONTEXT_CHAR_CAP
+
+  // Voice note — transcript appends to the context exactly as in step 1.
+  const { voiceState, recordingDuration, startRecording, stopRecording } =
+    useVoiceNote({
+      onTranscript: (text) =>
+        setContextText((prev) => (prev ? prev + " " + text : text)),
+    })
+
+  // ---------------------------------------------------------------------------
+  // Save context edits
+  // ---------------------------------------------------------------------------
+
+  async function saveContext() {
+    if (!contextDirty) return
+    setIsSavingContext(true)
+    try {
+      const result = await updateYouTubeScriptRun(initial.id, {
+        context_text: contextText,
+      })
+      if (!result.success) throw new Error(result.error || "Failed to save")
+      setSavedContext(result.data.context_text)
+      toast("Context saved", { type: "success" })
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Failed to save", { type: "error" })
+    } finally {
+      setIsSavingContext(false)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Re-distil — only refreshes angles that haven't been generated yet
+  // ---------------------------------------------------------------------------
+
+  async function redistil() {
+    setIsRedistilling(true)
+    try {
+      // Persist any pending context edits first so the LLM sees them.
+      if (contextDirty) {
+        const saved = await updateYouTubeScriptRun(initial.id, {
+          context_text: contextText,
+        })
+        if (!saved.success) throw new Error(saved.error || "Failed to save context")
+        setSavedContext(saved.data.context_text)
+      }
+
+      const res = await fetch("/api/admin/youtube/distill-idea", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          context: contextText.trim(),
+          format: initial.format,
+          profileSlug: initial.profile_slug,
+        }),
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || "Failed to re-distil")
+      }
+      const data = await res.json()
+      const fresh = (data.angles as DistilledAngle[]) ?? []
+      if (fresh.length === 0) {
+        toast("No usable angles returned", { type: "error" })
+        return
+      }
+
+      // Preserve angles that already have a generated script — they're real
+      // work and the user can still view them. Fill the rest from the new
+      // distillation, in order.
+      const next: DistilledAngle[] = []
+      let cursor = 0
+      for (let i = 0; i < 3; i++) {
+        if (scriptsByAngle.has(i) && angles[i]) {
+          next.push(angles[i])
+        } else if (cursor < fresh.length) {
+          next.push(fresh[cursor])
+          cursor++
+        } else if (angles[i]) {
+          next.push(angles[i])
+        }
+      }
+
+      const saved = await updateYouTubeScriptRun(initial.id, { angles: next })
+      if (!saved.success) throw new Error(saved.error || "Failed to save angles")
+      setAngles(next)
+      if (fresh.length < 3) {
+        toast(
+          `Only ${fresh.length} fresh angle${fresh.length === 1 ? "" : "s"} returned — kept previous suggestions in the empty slot${3 - fresh.length === 1 ? "" : "s"}.`,
+          { type: "info" }
+        )
+      } else {
+        toast("Angles refreshed", { type: "success" })
+      }
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Failed to re-distil", {
+        type: "error",
+      })
+    } finally {
+      setIsRedistilling(false)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inline edit angle title/topic — persists on blur
+  // ---------------------------------------------------------------------------
+
+  function updateAngleField(index: number, field: "title" | "topic", value: string) {
+    setAngles((prev) => {
+      const next = [...prev]
+      next[index] = { ...next[index], [field]: value }
+      return next
+    })
+  }
+
+  async function persistAngles(next: DistilledAngle[]) {
+    try {
+      const result = await updateYouTubeScriptRun(initial.id, { angles: next })
+      if (!result.success) throw new Error(result.error || "Failed to save")
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Failed to save", { type: "error" })
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Generate this angle → create script row → detail page autoGenerate
+  // ---------------------------------------------------------------------------
+
+  async function generateAngle(index: number) {
+    const angle = angles[index]
+    if (!angle) return
+    if (angle.needs_news_peg) {
+      toast("This Reaction angle needs a news peg before it can be generated", {
+        type: "error",
+      })
+      return
+    }
+    setGeneratingIndex(index)
+    try {
+      // Persist unsaved context first so the run row and the script row share
+      // the same input — otherwise "Back to angles" would show stale context.
+      if (contextDirty) {
+        const saved = await updateYouTubeScriptRun(initial.id, {
+          context_text: contextText,
+        })
+        if (!saved.success) throw new Error(saved.error || "Failed to save context")
+        setSavedContext(saved.data.context_text)
+      }
+      const result = await createYouTubeScript({
+        title: angle.title,
+        topic: angle.topic,
+        target_length: angle.target_length,
+        format: initial.format,
+        profile_slug: initial.profile_slug,
+        status: "idea",
+        input_text: contextText.trim() || undefined,
+        run_id: initial.id,
+        angle_index: index,
+      })
+      if (!result.success) throw new Error(result.error || "Failed to create script")
+      router.push(`/admin/youtube/${result.data.id}?autoGenerate=1`)
+    } catch (err) {
+      toast(err instanceof Error ? err.message : "Failed to create script", {
+        type: "error",
+      })
+      setGeneratingIndex(null)
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <Stack gap="lg">
+      {/* Header */}
+      <Row align="start" gap="sm">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="mt-1"
+          aria-label="Back to YouTube scripts"
+          render={<Link href={`/admin/youtube?profile=${initial.profile_slug}`} />}
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+        </Button>
+        <Stack gap="xs" className="flex-1 min-w-0">
+          <Title size="h3">Pick an angle to generate</Title>
+          <Text variant="muted" size="sm">
+            Three angles were distilled from your context. Pick one to generate
+            now — you can come back here and try a different angle anytime.
+          </Text>
+        </Stack>
+      </Row>
+
+      {/* Run meta — profile + format */}
+      <Row align="center" gap="sm" wrap>
+        <Text variant="muted" size="sm">Writing for</Text>
+        <ProfileChip slug={initial.profile_slug} />
+        <Text variant="muted" size="sm">
+          · {PROFILES[initial.profile_slug].displayRole}
+        </Text>
+        <Badge variant="outline">
+          <FormatFlagIcon format={initial.format} className="h-3 w-3 mr-1" />
+          {meta.label}
+        </Badge>
+        <Text variant="muted" size="sm">
+          · {meta.minutesLabel} · {meta.wordsLabel}
+        </Text>
+      </Row>
+
+      {/* Context block — editable, with voice-note + save/re-distil controls */}
+      <Card>
+        <CardContent className="p-4">
+          <Stack gap="sm">
+            <Stack gap="xs">
+              <Text className="font-medium">Your context</Text>
+              <Text variant="muted" size="sm">
+                Edit the text or append a voice note. Re-distil if you want a
+                fresh set of angles for the slots that haven't been generated yet.
+              </Text>
+            </Stack>
+            <Textarea
+              value={contextText}
+              onChange={(e) => setContextText(e.target.value)}
+              className="min-h-40 resize-y text-sm leading-relaxed"
+              disabled={voiceState === "transcribing" || isRedistilling}
+            />
+            <Row align="center" className="justify-between" wrap gap="sm">
+              <Row gap="sm" align="center">
+                <VoiceNoteButton
+                  voiceState={voiceState}
+                  recordingDuration={recordingDuration}
+                  onStart={startRecording}
+                  onStop={stopRecording}
+                />
+                <Text
+                  variant="muted"
+                  size="sm"
+                  className={cn(contextOverCap && "text-amber-700 dark:text-amber-300")}
+                >
+                  {contextText.length > 0
+                    ? `${contextText.length.toLocaleString()} characters`
+                    : "Empty"}
+                  {contextOverCap &&
+                    ` · only the first ${CONTEXT_CHAR_CAP.toLocaleString()} reach the LLM`}
+                </Text>
+              </Row>
+              <Row gap="sm">
+                {contextDirty && (
+                  <Button
+                    variant="outline"
+                    onClick={saveContext}
+                    disabled={isSavingContext || isRedistilling || voiceState !== "idle"}
+                  >
+                    {isSavingContext ? (
+                      <>
+                        <Loader2Icon className="h-4 w-4 animate-spin mr-2" />
+                        Saving...
+                      </>
+                    ) : (
+                      "Save context"
+                    )}
+                  </Button>
+                )}
+                <Button
+                  variant="outline"
+                  onClick={redistil}
+                  disabled={
+                    !contextText.trim() ||
+                    isRedistilling ||
+                    voiceState !== "idle" ||
+                    generatingIndex !== null
+                  }
+                >
+                  {isRedistilling ? (
+                    <>
+                      <Loader2Icon className="h-4 w-4 animate-spin mr-2" />
+                      Re-distilling...
+                    </>
+                  ) : (
+                    <>
+                      <RefreshCwIcon className="h-4 w-4 mr-2" />
+                      Re-distil
+                    </>
+                  )}
+                </Button>
+              </Row>
+            </Row>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      {/* Angle cards */}
+      <Stack gap="sm">
+        {angles.map((angle, i) => {
+          const generated = scriptsByAngle.get(i) ?? null
+          const isGenerating = generatingIndex === i
+          const isDisabled = !generated && angle.needs_news_peg
+          const isEditingTitle = editingTitle === i
+          const isEditingTopic = editingTopic === i
+          return (
+            <Card
+              key={i}
+              className={cn(
+                "transition-all",
+                generated
+                  ? "border-primary/20 bg-primary/5"
+                  : isDisabled
+                    ? "opacity-60 border-dashed"
+                    : "hover:border-primary/40"
+              )}
+            >
+              <CardContent className="p-4">
+                <Row align="start" gap="sm">
+                  <div
+                    className={cn(
+                      "h-7 w-7 rounded-full border flex items-center justify-center shrink-0 text-xs font-medium",
+                      generated
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-muted-foreground/30 text-muted-foreground"
+                    )}
+                  >
+                    {generated ? <CheckCircleIcon className="h-4 w-4" /> : i + 1}
+                  </div>
+                  <Stack gap="xs" className="flex-1 min-w-0">
+                    {/* Title */}
+                    {isEditingTitle && !generated ? (
+                      <Input
+                        autoFocus
+                        value={angle.title}
+                        onChange={(e) => updateAngleField(i, "title", e.target.value)}
+                        onBlur={() => {
+                          setEditingTitle(null)
+                          void persistAngles(angles)
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter" || e.key === "Escape") {
+                            setEditingTitle(null)
+                            void persistAngles(angles)
+                          }
+                        }}
+                        disabled={isRedistilling}
+                        className="text-base font-medium"
+                      />
+                    ) : (
+                      <Row align="center" gap="xs">
+                        <Text className="font-medium leading-snug flex-1">
+                          {angle.title}
+                        </Text>
+                        {!generated && (
+                          <button
+                            type="button"
+                            onClick={() => setEditingTitle(i)}
+                            disabled={isRedistilling}
+                            className="text-muted-foreground hover:text-foreground shrink-0 disabled:opacity-40 disabled:cursor-not-allowed"
+                            aria-label="Edit title"
+                          >
+                            <PencilIcon className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </Row>
+                    )}
+
+                    {/* Topic */}
+                    {isEditingTopic && !generated ? (
+                      <Textarea
+                        autoFocus
+                        value={angle.topic}
+                        onChange={(e) => updateAngleField(i, "topic", e.target.value)}
+                        onBlur={() => {
+                          setEditingTopic(null)
+                          void persistAngles(angles)
+                        }}
+                        disabled={isRedistilling}
+                        className="text-sm min-h-20"
+                      />
+                    ) : (
+                      <Row align="start" gap="xs">
+                        <Text variant="muted" size="sm" className="leading-relaxed flex-1">
+                          {angle.topic}
+                        </Text>
+                        {!generated && (
+                          <button
+                            type="button"
+                            onClick={() => setEditingTopic(i)}
+                            disabled={isRedistilling}
+                            className="text-muted-foreground hover:text-foreground shrink-0 mt-0.5 disabled:opacity-40 disabled:cursor-not-allowed"
+                            aria-label="Edit topic"
+                          >
+                            <PencilIcon className="h-3.5 w-3.5" />
+                          </button>
+                        )}
+                      </Row>
+                    )}
+
+                    {angle.why_this_angle && (
+                      <Text size="sm" className="text-primary/80 italic leading-relaxed">
+                        Why this angle: {angle.why_this_angle}
+                      </Text>
+                    )}
+
+                    {angle.news_peg && (
+                      <Row gap="xs" align="center">
+                        <Badge variant="outline" size="sm">
+                          News peg
+                        </Badge>
+                        <Text variant="muted" size="sm">
+                          {angle.news_peg}
+                        </Text>
+                      </Row>
+                    )}
+
+                    {isDisabled && (
+                      <Row gap="xs" align="center">
+                        <AlertTriangleIcon className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0" />
+                        <Text size="sm" className="text-amber-700 dark:text-amber-300">
+                          Needs a current news peg from DLD / RERA / Central Bank UAE / Fitch / Moody&apos;s / S&amp;P
+                        </Text>
+                      </Row>
+                    )}
+
+                    {/* Action row */}
+                    <Row className="pt-2 justify-end" gap="sm" wrap>
+                      {generated ? (
+                        <Button
+                          render={
+                            <Link href={`/admin/youtube/${generated.id}`} />
+                          }
+                          variant="outline"
+                        >
+                          <FileTextIcon className="h-4 w-4 mr-2" />
+                          View script
+                          <ArrowRightIcon className="h-4 w-4 ml-2" />
+                        </Button>
+                      ) : (
+                        <Button
+                          onClick={() => generateAngle(i)}
+                          disabled={isDisabled || generatingIndex !== null || isRedistilling}
+                        >
+                          {isGenerating ? (
+                            <>
+                              <Loader2Icon className="h-4 w-4 animate-spin mr-2" />
+                              Launching...
+                            </>
+                          ) : (
+                            <>
+                              <SparklesIcon className="h-4 w-4 mr-2" />
+                              Generate this angle
+                              <ArrowRightIcon className="h-4 w-4 ml-2" />
+                            </>
+                          )}
+                        </Button>
+                      )}
+                    </Row>
+                  </Stack>
+                </Row>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </Stack>
+    </Stack>
+  )
+}

--- a/catalyst/briefs/complete/complete-20260521_youtube-single-script-runs.md
+++ b/catalyst/briefs/complete/complete-20260521_youtube-single-script-runs.md
@@ -1,0 +1,157 @@
+# Brief: Single-Script Runs — Preserve Context & Try All 3 Angles
+
+**ID:** YT-SINGLE-RUNS
+**Status:** Approved
+**Priority:** P1 — Workflow improvement
+**Surface:** Admin / YouTube generator (Mode B — "Write One Script")
+**Estimate:** 0.5–1 day
+**Tags:** youtube, ai-agent, workflow
+
+---
+
+## Objective
+
+Make the "Write One Script" flow non-destructive: when a user pastes context (text + optional voice note transcript) and gets 3 distilled angles back, that whole bundle becomes a persistent **run**. The user can pick any of the 3 angles, generate the script, view it, and then come back to the run and try a different angle — without losing the original context, the voice note transcript, or the other two angles.
+
+---
+
+## Background
+
+Today the single-script flow is destructive:
+
+1. User pastes context (and optionally records a voice note that's transcribed inline).
+2. `distill-idea` returns 3 angles.
+3. User picks **one**, the row is created in `youtube_scripts`, the user is routed to the detail page and Opus streams.
+4. If the chosen angle is wrong, the user starts over: re-paste context, re-record the voice note, re-run distil — the other 2 angles and the transcript are gone.
+
+The 3-angle distillation is the expensive thinking step. We should bank it.
+
+---
+
+## Scope
+
+### In scope
+
+- Persist a "run" = `{context_text, format, profile_slug, angles[3]}` in a new `youtube_script_runs` table.
+- After distil, redirect to a new run workspace page `/admin/youtube/runs/[runId]` (replaces the inline confirm step).
+- On the run page, the user can:
+  - View the editable context (text + transcript) and append more via the voice note button.
+  - Re-distil if the context changes (overwrites the run's angles — only affects angles not yet generated).
+  - For each of the 3 angles: **Generate this angle** (creates a script row linked to the run via `run_id` + `angle_index`, routes to the existing detail page) or **View script** (if already generated).
+  - Edit the angle's title/topic inline before generating.
+- Script detail page: a `← Back to angles` link appears in the header when the row has a `run_id`, so the user can flip between angles in the same run.
+
+### Out of scope
+
+- Side-by-side comparison view across angles.
+- Storing the raw audio recording (only the transcript persists, as today).
+- Regenerating an angle that has already been generated (the existing detail-page regen pipeline still works per-script).
+- Changes to the brainstorm or review-and-rewrite flows.
+
+---
+
+## Data model
+
+### New table
+
+`public.youtube_script_runs`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `uuid pk default gen_random_uuid()` | |
+| `user_id` | `uuid` | FK `auth.users(id) on delete set null` |
+| `context_text` | `text not null` | The full editable context (includes voice transcript) |
+| `format` | `text not null` | CHECK ∈ the 6 format slugs |
+| `profile_slug` | `text not null default 'tahir'` | CHECK ∈ `('tahir', 'ahmed')` |
+| `angles` | `jsonb not null` | Array of `{title, topic, why_this_angle, news_peg, needs_news_peg, target_length}` |
+| `created_at` | `timestamptz default now()` | |
+| `updated_at` | `timestamptz default now()` | Trigger-maintained |
+
+RLS: single `FOR ALL` policy whose `using`/`with check` inline the same role-membership test used by `youtube_scripts` (`admin | marketing | youtube_editor`). Mirrors the existing pattern; do not introduce a new gate.
+
+### Columns added to `youtube_scripts`
+
+| Column | Type | Notes |
+|---|---|---|
+| `run_id` | `uuid null` | FK `youtube_script_runs(id) on delete set null` |
+| `angle_index` | `int null` | 0..2 — which angle in the run produced this row |
+
+Index: `idx_youtube_scripts_run on (run_id)` for the run → scripts lookup.
+
+---
+
+## API & server actions
+
+No new HTTP routes. The existing `distill-idea` route stays pure-LLM; persistence happens in server actions called by the client after the LLM returns.
+
+New server actions in `lib/actions/youtube.ts`:
+
+- `createYouTubeScriptRun({context_text, format, profile_slug, angles})` → row.
+- `getYouTubeScriptRun(id)` → row.
+- `updateYouTubeScriptRun(id, {context_text?, angles?})` → row. Used when the user edits context, re-distils, or edits an angle inline.
+- `getYouTubeScriptsForRun(runId)` → `YouTubeScript[]` — to know which angle indices have a generated script.
+
+New shared type: `YouTubeScriptRun`.
+
+---
+
+## UI changes
+
+### `app/(admin)/admin/youtube/new/single/single-script-workflow.tsx`
+
+Step 1 (input) stays. On successful distil:
+
+1. Call `createYouTubeScriptRun` with the context + 3 angles.
+2. Redirect to `/admin/youtube/runs/{runId}` (replaces the old `step === "confirm"` branch).
+
+The inline confirm UI is removed from this file — its job is handled by the run page.
+
+### New: `app/(admin)/admin/youtube/runs/[id]/page.tsx`
+
+Server component that loads the run + any scripts already generated for it. Renders a client component that:
+
+- Shows the locked profile chip + format pill at the top.
+- Shows the editable context textarea + `VoiceNoteButton` (appends transcript, same hook as today).
+- Shows a **Re-distil** button (disabled while no edits, calls `distill-idea`, then `updateYouTubeScriptRun({angles})`). Re-distil only replaces angles not yet generated.
+- Shows 3 angle cards. Per card:
+  - If `getYouTubeScriptsForRun` does not include this `angle_index` → **Generate this angle** button. Click: `createYouTubeScript({...angle, format, profile_slug, run_id, angle_index, status: 'idea'})`, route to `/admin/youtube/{newId}?autoGenerate=1`.
+  - Otherwise → **View script** button + status badge. Click: route to `/admin/youtube/{id}`.
+  - Title/topic are inline-editable (same affordance as the old confirm step), but only when the angle has not yet been generated. The edit persists via `updateYouTubeScriptRun({angles})`.
+  - `needs_news_peg` blocks generation as it does today.
+
+### `app/(admin)/admin/youtube/[id]/script-detail-page.tsx`
+
+In the header `← back` button, if `script.run_id` is present, route to `/admin/youtube/runs/{script.run_id}` instead of the script list. Otherwise unchanged.
+
+---
+
+## Invariants & edge cases
+
+- **Re-distil never overwrites a generated angle.** Server action merges: keep entries whose `angle_index` already has a script row; replace the rest.
+- **Coerce on load.** Unknown `format`/`profile_slug` on a run row never errors — coerce to default, same rule as the rest of the YouTube system.
+- **Run deletion cascade.** Deleting a run nulls `run_id` on dependent scripts (keep the scripts; they're real work). FK is `on delete set null`.
+- **Voice note** appends to `context_text` exactly as it does in the old workflow. No new schema for audio.
+- **Auth/RLS** identical to the other YouTube tables — no new gate.
+
+---
+
+## Test plan
+
+- Walk a run end-to-end:
+  - Paste context + record a voice note → distil → land on the run page → context + 3 angles present.
+  - Generate angle 1 → view streamed script → click `← Back to angles` → angle 1 shows "View script", angles 2 + 3 still say "Generate".
+  - Generate angle 2 → confirm both angle 1 and 2 are now visible from the run page, navigable independently.
+  - Edit context, click re-distil → confirm angles 1 + 2 are preserved (they have scripts) and only the remaining angle slot is refreshed.
+- Confirm RLS: a `youtube_editor` user can read/write their own runs.
+- Confirm an old, runless script's detail page back link still goes to the list (no regression).
+
+---
+
+## Recommended sequence
+
+1. Migration (table, columns, indexes, RLS policy, updated_at trigger).
+2. Server actions + `YouTubeScriptRun` type.
+3. Reshape `single-script-workflow.tsx` to redirect to the run page after distil.
+4. Build the run page (`/admin/youtube/runs/[id]`).
+5. Wire the `← Back to angles` link in the script detail page.
+6. Smoke-test in dev.

--- a/lib/actions/youtube.ts
+++ b/lib/actions/youtube.ts
@@ -10,8 +10,14 @@ import { revalidatePath } from "next/cache"
 import { createClient } from "@/lib/supabase/server"
 import { trackActionError } from "@/lib/error-tracking"
 import type { ActionResult } from "./cms"
-import type { Format } from "@/lib/youtube/prompts"
-import type { ProfileSlug } from "@/lib/youtube/profiles"
+import { toFormat, type Format } from "@/lib/youtube/prompts"
+import { toProfileSlug, type ProfileSlug } from "@/lib/youtube/profiles"
+
+// Mirrors the cap in /api/admin/youtube/distill-idea so stored context can't
+// grow indefinitely and so the LLM can never see truncated state we didn't
+// expect.
+const CONTEXT_CHAR_CAP = 12_000
+const MAX_ANGLES_PER_RUN = 3
 
 // =============================================================================
 // TYPES
@@ -40,6 +46,8 @@ export type YouTubeScript = {
   word_count: number | null
   target_length: string | null
   user_id: string | null
+  run_id: string | null
+  angle_index: number | null
   created_at: string | null
   updated_at: string | null
 }
@@ -106,6 +114,40 @@ export type YouTubeScriptInput = {
   panel_reviewed_at?: string | null
   word_count?: number
   target_length?: string
+  run_id?: string
+  angle_index?: number
+}
+
+/**
+ * Single-script "run" — bundles the context + the three distilled angles so
+ * the user can come back and try a different angle without starting over.
+ * One run produces 0..3 youtube_scripts rows.
+ */
+export type DistilledAngle = {
+  title: string
+  topic: string
+  why_this_angle: string
+  news_peg: string | null
+  needs_news_peg: boolean
+  target_length: "quick_take" | "standard" | "deep_dive"
+}
+
+export type YouTubeScriptRun = {
+  id: string
+  user_id: string | null
+  context_text: string
+  format: Format
+  profile_slug: ProfileSlug
+  angles: DistilledAngle[]
+  created_at: string
+  updated_at: string
+}
+
+export type YouTubeScriptRunInput = {
+  context_text: string
+  format: Format
+  profile_slug: ProfileSlug
+  angles: DistilledAngle[]
 }
 
 export type YouTubeScriptMessage = {
@@ -340,5 +382,140 @@ export async function deleteYouTubeScript(id: string): Promise<ActionResult> {
   } catch (error) {
     trackActionError(error, "deleteYouTubeScript")
     return { success: false, error: "Failed to delete script" }
+  }
+}
+
+// =============================================================================
+// RUNS — single-script context + 3-angle bundle
+// =============================================================================
+
+/**
+ * Coerce a row read from `youtube_script_runs` into the strongly-typed shape
+ * the rest of the app expects. Unknown enum values fall back to defaults so a
+ * future enum drift in the DB never crashes the workspace.
+ */
+function coerceRun(row: Record<string, unknown>): YouTubeScriptRun {
+  const angles = Array.isArray(row.angles)
+    ? (row.angles as DistilledAngle[]).slice(0, MAX_ANGLES_PER_RUN)
+    : []
+  return {
+    id: String(row.id),
+    user_id: (row.user_id as string | null) ?? null,
+    context_text: typeof row.context_text === "string" ? row.context_text : "",
+    format: toFormat(row.format),
+    profile_slug: toProfileSlug(row.profile_slug),
+    angles,
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  }
+}
+
+export async function createYouTubeScriptRun(
+  input: YouTubeScriptRunInput
+): Promise<ActionResult<YouTubeScriptRun>> {
+  try {
+    const supabase = await createClient()
+    const { data: { user } } = await supabase.auth.getUser()
+
+    const context = (input.context_text ?? "").slice(0, CONTEXT_CHAR_CAP)
+    if (!context.trim()) {
+      return { success: false, error: "Context is required" }
+    }
+    const angles = Array.isArray(input.angles)
+      ? input.angles.slice(0, MAX_ANGLES_PER_RUN)
+      : []
+    if (angles.length === 0) {
+      return { success: false, error: "At least one angle is required" }
+    }
+
+    const { data, error } = await supabase
+      .from("youtube_script_runs")
+      .insert({
+        context_text: context,
+        format: input.format,
+        profile_slug: input.profile_slug,
+        angles,
+        user_id: user?.id,
+      })
+      .select("*")
+      .single()
+
+    if (error) throw error
+    return { success: true, data: coerceRun(data as Record<string, unknown>) }
+  } catch (error) {
+    trackActionError(error, "createYouTubeScriptRun")
+    return { success: false, error: "Failed to create run" }
+  }
+}
+
+export async function getYouTubeScriptRun(
+  id: string
+): Promise<ActionResult<YouTubeScriptRun>> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from("youtube_script_runs")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle()
+
+    if (error) throw error
+    if (!data) return { success: false, error: "Run not found" }
+    return { success: true, data: coerceRun(data as Record<string, unknown>) }
+  } catch (error) {
+    trackActionError(error, "getYouTubeScriptRun")
+    return { success: false, error: "Failed to load run" }
+  }
+}
+
+export async function updateYouTubeScriptRun(
+  id: string,
+  patch: { context_text?: string; angles?: DistilledAngle[] }
+): Promise<ActionResult<YouTubeScriptRun>> {
+  try {
+    const supabase = await createClient()
+
+    const cleaned: { context_text?: string; angles?: DistilledAngle[] } = {}
+    if (patch.context_text !== undefined) {
+      cleaned.context_text = patch.context_text.slice(0, CONTEXT_CHAR_CAP)
+    }
+    if (patch.angles !== undefined) {
+      cleaned.angles = Array.isArray(patch.angles)
+        ? patch.angles.slice(0, MAX_ANGLES_PER_RUN)
+        : []
+    }
+
+    const { data, error } = await supabase
+      .from("youtube_script_runs")
+      .update(cleaned)
+      .eq("id", id)
+      .select("*")
+      .single()
+
+    if (error) throw error
+    return { success: true, data: coerceRun(data as Record<string, unknown>) }
+  } catch (error) {
+    trackActionError(error, "updateYouTubeScriptRun")
+    return { success: false, error: "Failed to update run" }
+  }
+}
+
+/** Scripts already generated for a run, keyed off run_id. */
+export async function getYouTubeScriptsForRun(
+  runId: string
+): Promise<ActionResult<YouTubeScript[]>> {
+  try {
+    const supabase = await createClient()
+    const { data, error } = await supabase
+      .from("youtube_scripts")
+      .select("*")
+      .eq("run_id", runId)
+      .order("angle_index", { ascending: true })
+
+    if (error) throw error
+    return { success: true, data: (data ?? []) as YouTubeScript[] }
+  } catch (error) {
+    trackActionError(error, "getYouTubeScriptsForRun")
+    return { success: false, error: "Failed to load run scripts" }
   }
 }

--- a/supabase/migrations/20260521000000_youtube_script_runs.sql
+++ b/supabase/migrations/20260521000000_youtube_script_runs.sql
@@ -1,0 +1,72 @@
+-- =============================================================================
+-- youtube_script_runs — bundle a single-script "Write One Script" run
+-- =============================================================================
+-- A "run" is the context the user fed into distil-idea + the 3 angles that
+-- came back. Before this table the angles were ephemeral: pick one, generate
+-- it, lose the other two. With a run row the user can come back and try a
+-- different angle without re-pasting context or re-recording their voice note.
+--
+-- One run produces 0..3 youtube_scripts rows (one per generated angle), linked
+-- via youtube_scripts.run_id + angle_index.
+
+create table if not exists public.youtube_script_runs (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid references auth.users(id) on delete set null,
+
+  -- Editable context the user pasted/dictated. Voice-note transcripts are
+  -- appended here exactly as they would be in any other YouTube input field.
+  context_text text not null,
+
+  -- The format + presenter the run was distilled for. CHECK lists mirror
+  -- youtube_scripts so the two tables stay in lock-step.
+  format text not null
+    check (format in (
+      'authority_analysis',
+      'myth_buster',
+      'reaction',
+      'case_study',
+      'listicle',
+      'qa_mailbag'
+    )),
+  profile_slug text not null default 'tahir'
+    check (profile_slug in ('tahir', 'ahmed')),
+
+  -- The 3 distilled angles. Shape per entry:
+  --   { title, topic, why_this_angle, news_peg, needs_news_peg, target_length }
+  angles jsonb not null,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.youtube_script_runs enable row level security;
+
+-- Single source of truth: can_access_youtube() also gates the API routes
+-- (see 20260516120000_add_youtube_editor_role.sql). If the role list ever
+-- changes, both layers move together.
+create policy "Admins can manage youtube script runs"
+  on public.youtube_script_runs for all
+  using (public.can_access_youtube())
+  with check (public.can_access_youtube());
+
+create trigger update_youtube_script_runs_updated_at
+  before update on public.youtube_script_runs
+  for each row
+  execute function update_updated_at_column();
+
+create index idx_youtube_script_runs_user
+  on public.youtube_script_runs(user_id, created_at desc);
+
+-- =============================================================================
+-- youtube_scripts: link back to the run + angle index
+-- =============================================================================
+-- run_id is on delete set null so deleting a run never destroys a generated
+-- script — the script is real work and survives independently.
+
+alter table public.youtube_scripts
+  add column if not exists run_id uuid references public.youtube_script_runs(id) on delete set null,
+  add column if not exists angle_index integer
+    check (angle_index is null or (angle_index >= 0 and angle_index <= 2));
+
+create index if not exists idx_youtube_scripts_run
+  on public.youtube_scripts(run_id);


### PR DESCRIPTION
## Summary
- Treat the single-script flow as a **run**: context + 3 distilled angles persisted upfront in a new `youtube_script_runs` table.
- `/admin/youtube/runs/[id]` workspace lets the user generate any of the angles, view scripts already generated for the run, edit/save the context, and re-distil for the slots that haven't been generated yet.
- `youtube_scripts` gains `run_id` + `angle_index` so generated scripts know which run they belong to; the script detail page back-arrow returns to the run workspace.

## Test plan
- [ ] `/admin/youtube/new/single` — pick a format, paste context, record a voice note, distil → routes to `/admin/youtube/runs/{id}`
- [ ] Generate angle 1 → routes to `/admin/youtube/{id}?autoGenerate=1` with Opus generation kicking off
- [ ] Back-arrow on script detail page → returns to `/admin/youtube/runs/{id}` (not the list)
- [ ] Generate angle 2 from the same run → second `youtube_scripts` row created with `run_id` + `angle_index=1`
- [ ] Edit context on the run workspace → Save Context button disappears after save (no longer stuck visible)
- [ ] Re-distil with one angle already generated → that slot is preserved, others refreshed
- [ ] Paste > 12,000 chars → amber warning appears in both the initial input and the run workspace
- [ ] Inline edit angle title / topic while a re-distil is in flight → buttons are disabled (no race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)