### PR TITLE
Route Knowledge Check to the correct quiz per module

### DIFF
--- a/app/learn/[competency]/[module]/page.tsx
+++ b/app/learn/[competency]/[module]/page.tsx
@@ -137,35 +137,27 @@ async function getAllCompetencies(): Promise<Competency[]> {
 }
 
 /**
- * Get quizzes for a competency to find one related to this module.
+ * Find the quiz tied to a specific module. Match strictly on related_module —
+ * never fall back to "first quiz for this competency", because that silently
+ * serves the wrong quiz when data is misconfigured (see Referral Generation
+ * incident: a quiz with the wrong competency_slug was excluded from the
+ * primary filter and the fallback handed users a different module's quiz,
+ * which they then "completed" repeatedly without affecting their progress).
  */
 async function getRelatedQuiz(
-  competencySlug: string,
+  _competencySlug: string,
   moduleSlug: string
 ): Promise<{ slug: string; title: string } | null> {
   const supabase = await createClient()
-  
-  // Try to find quiz that references this module
-  const { data: exactMatch } = await supabase
+
+  const { data } = await supabase
     .from("quizzes")
     .select("slug, title")
-    .eq("competency_slug", competencySlug)
-    .ilike("related_module", `%${moduleSlug}%`)
+    .eq("related_module", moduleSlug)
     .limit(1)
-    .single()
-  
-  if (exactMatch) return exactMatch
-  
-  // Fallback: get first quiz for this competency
-  const { data: anyQuiz } = await supabase
-    .from("quizzes")
-    .select("slug, title")
-    .eq("competency_slug", competencySlug)
-    .order("slug")
-    .limit(1)
-    .single()
-  
-  return anyQuiz
+    .maybeSingle()
+
+  return data
 }
 
 /**

--- a/content/lms/quizzes/relationship-stewardship-1.md
+++ b/content/lms/quizzes/relationship-stewardship-1.md
@@ -1,8 +1,8 @@
 ---
-quizId: "relationship-stewardship-1"
+slug: "relationship-stewardship-1"
 title: "Relationship Stewardship Quiz: Referral Generation"
-competency: 8
-module: 8.3
+competency: "relationship-stewardship"
+relatedModule: "referral-generation"
 description: "Test your understanding of referral timing, language, and recognition approaches."
 passingScore: 80
 questionCount: 10


### PR DESCRIPTION
## Summary

Users reported "Referral Generation" never marked complete despite passing the quiz repeatedly. Laveena had **6** passing attempts logged — all against `relationship-stewardship-7.3` (Client Communication), not against the Referral Generation quiz she thought she was taking.

Root cause: `content/lms/quizzes/relationship-stewardship-1.md` had numeric `competency: 8` plus `quizId:` instead of `slug:` and no `relatedModule:`. The sync stored `competency_slug = "8"` on the quiz and its questions. `getRelatedQuiz` filters by `competency_slug = "relationship-stewardship"`, which excluded the actual quiz, then fell through to "first quiz in competency" — alphabetically `relationship-stewardship-7.3` — which is what the Knowledge Check CTA rendered.

Production DB was patched manually so users are unblocked already. This PR keeps the fix from regressing on the next content sync and removes the silent fallback that masked the issue.

## Changes

- `content/lms/quizzes/relationship-stewardship-1.md` — frontmatter now matches the convention used by `aml-compliance-1.md` et al. (`slug:` / `competency: "relationship-stewardship"` / `relatedModule: "referral-generation"`).
- `app/learn/[competency]/[module]/page.tsx` — `getRelatedQuiz` matches strictly on `related_module` with `.maybeSingle()`; the "first quiz in competency" fallback that silently mis-routed users is gone, with an explanatory comment.

## Test plan

- [ ] After deploy, visit `/learn/relationship-stewardship/referral-generation` and confirm the Knowledge Check CTA renders the **Referral Generation** quiz (title contains "Referral Generation"), not Client Communication.
- [ ] Submit the quiz with a passing score on a test account; verify the module shows the green tick in the sidebar.
- [ ] Spot-check one other module (e.g. `/learn/aml-compliance/red-flags-typologies`) to confirm its Knowledge Check still resolves to the right quiz.
- [ ] Optional: re-run the LMS content sync and confirm the `quizzes` row for `relationship-stewardship-1` still has `competency_slug = 'relationship-stewardship'` and `related_module = 'referral-generation'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)