### PR TITLE
Wire property browse to CRM facets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,8 +170,12 @@ NEXT_PUBLIC_AHMED_STRATEGY_KIT_URL=
 # (API fetches) and client-side (iframe origin + postMessage validation).
 NEXT_PUBLIC_CRM_BASE_URL=https://crm.primecapitaldubai.com
 
-# Stable agency UUID for prime-capital. Tim provides; do NOT use the slug.
-# Required by the property API and widget iframe URL.
+# Stable agency slug for the public property API.
+# Use "prime-capital" or "steven-leckie".
+NEXT_PUBLIC_CRM_AGENCY_SLUG=prime-capital
+
+# Stable agency UUID for prime-capital. Tim provides.
+# Required by the widget iframe URL.
 NEXT_PUBLIC_CRM_AGENCY_UUID=
 
 # AgentCRM public enquiry endpoint (server-side POST).

--- a/app/(admin)/admin/properties/[id]/property-edit-form.tsx
+++ b/app/(admin)/admin/properties/[id]/property-edit-form.tsx
@@ -66,7 +66,7 @@ type PropertyEditFormProps = {
   property: PropertyRow | null
 }
 
-const PROPERTY_TYPES = [
+const PROPERTY_TYPE_OPTIONS = [
   { value: "villa", label: "Villa" },
   { value: "apartment", label: "Apartment" },
   { value: "penthouse", label: "Penthouse" },
@@ -332,12 +332,12 @@ export function PropertyEditForm({ property }: PropertyEditFormProps) {
                   <div className="grid grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label htmlFor="type">Type <span className="text-destructive">*</span></Label>
-                      <Select name="type" defaultValue={property?.type || "apartment"} items={PROPERTY_TYPES}>
+                      <Select name="type" defaultValue={property?.type || "apartment"} items={PROPERTY_TYPE_OPTIONS}>
                         <SelectTrigger>
                           <SelectValue placeholder="Select type" />
                         </SelectTrigger>
                         <SelectContent>
-                          {PROPERTY_TYPES.map(type => (
+                          {PROPERTY_TYPE_OPTIONS.map(type => (
                             <SelectItem key={type.value} value={type.value}>
                               {type.label}
                             </SelectItem>

--- a/app/(admin)/admin/properties/property-form.tsx
+++ b/app/(admin)/admin/properties/property-form.tsx
@@ -40,7 +40,7 @@ type PropertyFormProps = {
   onOpenChange: (open: boolean) => void
 }
 
-const PROPERTY_TYPES = [
+const PROPERTY_TYPE_OPTIONS = [
   { value: "villa", label: "Villa" },
   { value: "apartment", label: "Apartment" },
   { value: "penthouse", label: "Penthouse" },
@@ -172,7 +172,7 @@ export function PropertyForm({ property, open, onOpenChange }: PropertyFormProps
                       <SelectValue placeholder="Select type" />
                     </SelectTrigger>
                     <SelectContent>
-                      {PROPERTY_TYPES.map(type => (
+                      {PROPERTY_TYPE_OPTIONS.map(type => (
                         <SelectItem key={type.value} value={type.value}>
                           {type.label}
                         </SelectItem>

--- a/app/(web)/_surface/property-search.tsx
+++ b/app/(web)/_surface/property-search.tsx
@@ -1,17 +1,17 @@
 /**
  * CATALYST - Property Search Bar
  *
- * Data-driven floating search bar for the homepage hero.
- * Off-plan only — Prime Capital focuses exclusively on off-plan sales.
- * Dropdowns populated from actual property data via props.
+ * Floating search bar for the homepage hero. Dropdown options come from the
+ * CRM facets payload (lib/crm/facets.ts) — never from inventory inference
+ * or hardcoded arrays. Submits to /properties as a GET form.
  */
 import { ArrowRightIcon, ChevronDownIcon } from "lucide-react"
 
 interface PropertySearchProps {
-  /** Unique property types from the database (e.g. ["villa", "penthouse"]) */
-  types: string[]
-  /** Unique locations from the database (e.g. ["Palm Jumeirah, Dubai", "Downtown Dubai"]) */
+  /** Canonical area list from facets.areas[]. */
   locations: string[]
+  /** Canonical property type list from facets.property_types[]. */
+  types: string[]
 }
 
 export function PropertySearch({ types, locations }: PropertySearchProps) {
@@ -22,8 +22,8 @@ export function PropertySearch({ types, locations }: PropertySearchProps) {
 
   return (
     <form action="/properties" method="GET" className="property-search">
-      {/* Off-Plan indicator — subtle inline label */}
-      <span className="property-search__tag">Off-Plan</span>
+      {/* Brand tag — visual anchor on the bar */}
+      <span className="property-search__tag">Search</span>
 
       {/* Property Type */}
       <div className="property-search__field">

--- a/app/(web)/page.tsx
+++ b/app/(web)/page.tsx
@@ -58,6 +58,7 @@ import {
   type Testimonial,
 } from "@/lib/content"
 import { getCrmProperties } from "@/lib/crm/client"
+import { fetchPropertyFacets } from "@/lib/crm/facets"
 import {
   formatCrmBedrooms,
   formatCrmPriceRange,
@@ -90,17 +91,19 @@ export default async function HomePage() {
     redirect(config.features.rootRedirect)
   }
 
-  const [propertiesResult, testimonials, stats] = await Promise.all([
+  const [propertiesResult, testimonials, stats, facets] = await Promise.all([
     getCrmProperties({ limit: 12, promotionStatus: "top_property" }),
     getWebTestimonials(),
     getWebStats(),
+    fetchPropertyFacets({ promotionStatus: "top_property" }),
   ])
   const properties = propertiesResult.properties
   const featuredProperties = properties.slice(0, 3)
 
-  // Extract unique values from actual property data for search bar
-  const propertyTypes = [...new Set(properties.map((p) => p.propertyType))].sort()
-  const propertyLocations = [...new Set(properties.map((p) => p.area))].sort()
+  // Hero search dropdowns are populated from the canonical CRM facets, not
+  // inferred from the loaded property list.
+  const propertyTypes = facets.propertyTypes.map((option) => option.value)
+  const propertyLocations = facets.areas.map((option) => option.value)
 
   // Fallback stats when database is empty (must match data/stats.json)
   const fallbackStats = [

--- a/app/(web)/properties/_components/properties-filter-bar.tsx
+++ b/app/(web)/properties/_components/properties-filter-bar.tsx
@@ -1,0 +1,333 @@
+/**
+ * CATALYST - Properties Filter Bar
+ *
+ * Count-aware property browse controls. Every option comes from the CRM
+ * facets endpoint, and the URL remains the source of truth for list + facet
+ * fetches.
+ */
+
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react"
+import { SearchIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  LISTING_TYPE_LABELS,
+  type CrmListingType,
+  type PublicPropertyFacetOption,
+  type PublicPropertyFacets,
+} from "@/lib/crm"
+
+interface PropertiesFilterBarProps {
+  facets: PublicPropertyFacets
+  resultCount: number
+}
+
+interface FilterOption {
+  value: string
+  label: string
+  count: number
+}
+
+const ALL_VALUE = "__all__"
+
+export function PropertiesFilterBar({ facets, resultCount }: PropertiesFilterBarProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [isPending, startTransition] = useTransition()
+
+  const activeQuery = searchParams.get("q") ?? ""
+  const [query, setQuery] = useState(activeQuery)
+
+  const applyParams = useCallback(
+    (updates: Record<string, string | null>) => {
+      const next = new URLSearchParams(searchParams.toString())
+      for (const [key, value] of Object.entries(updates)) {
+        if (value === null || value.trim() === "") next.delete(key)
+        else next.set(key, value)
+      }
+      const qs = next.toString()
+      startTransition(() => {
+        router.replace(qs ? `/properties?${qs}` : "/properties", { scroll: false })
+      })
+    },
+    [router, searchParams],
+  )
+
+  useEffect(() => {
+    setQuery(activeQuery)
+  }, [activeQuery])
+
+  useEffect(() => {
+    const nextQuery = query.trim()
+    if (nextQuery === activeQuery) return
+
+    const timeout = window.setTimeout(() => {
+      applyParams({ q: nextQuery || null })
+    }, 300)
+
+    return () => window.clearTimeout(timeout)
+  }, [activeQuery, applyParams, query])
+
+  const currentArea = searchParams.get("area") ?? ""
+  const currentType = searchParams.get("property_type") ?? ""
+  const currentListing = searchParams.get("listing_type") ?? ""
+  const currentBedrooms = bedroomBucketFromParams(
+    searchParams.get("bedrooms_min"),
+    searchParams.get("bedrooms_max"),
+  )
+
+  const areaOptions = useMemo(
+    () => mapFacetOptions(facets.areas, currentArea, (value) => value),
+    [currentArea, facets.areas],
+  )
+  const propertyTypeOptions = useMemo(
+    () => mapFacetOptions(facets.propertyTypes, currentType, titleCase),
+    [currentType, facets.propertyTypes],
+  )
+  const bedroomOptions = useMemo(
+    () => mapFacetOptions(facets.bedrooms, currentBedrooms, formatBedroomBucket),
+    [currentBedrooms, facets.bedrooms],
+  )
+  const listingTypeOptions = useMemo(
+    () => mapFacetOptions(facets.listingTypes, currentListing, formatListingType),
+    [currentListing, facets.listingTypes],
+  )
+
+  return (
+    <div
+      className="properties-filter-bar"
+      data-pending={isPending ? "true" : undefined}
+    >
+      <div className="properties-filter-bar__search">
+        <Label htmlFor="properties-search" className="properties-filter-bar__search-label">
+          Search by name or development
+        </Label>
+        <Input
+          id="properties-search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onClear={() => {
+            setQuery("")
+            applyParams({ q: null })
+          }}
+          clearable
+          startIcon={<SearchIcon />}
+          placeholder="e.g. Sobha Hartland, Burj Vista"
+          className="properties-filter-bar__search-input"
+        />
+      </div>
+
+      <div className="properties-filter-bar__controls">
+        <FilterSelect
+          label="Location"
+          placeholder="All Locations"
+          value={currentArea}
+          onChange={(value) => applyParams({ area: value || null })}
+          options={areaOptions}
+        />
+        <FilterSelect
+          label="Property Type"
+          placeholder="All Types"
+          value={currentType}
+          onChange={(value) => applyParams({ property_type: value || null })}
+          options={propertyTypeOptions}
+        />
+        <FilterSelect
+          label="Bedrooms"
+          placeholder="Any Bedrooms"
+          value={currentBedrooms}
+          onChange={(value) => applyParams(bedroomParamsForBucket(value))}
+          options={bedroomOptions}
+        />
+        <ListingTypeToggle
+          value={currentListing}
+          options={listingTypeOptions}
+          onChange={(value) => applyParams({ listing_type: value || null })}
+        />
+
+        <div className="properties-filter-bar__counter">
+          <span className="properties-filter-bar__counter-value">{resultCount}</span>
+          <span className="properties-filter-bar__counter-label">
+            {resultCount === 1 ? "property" : "properties"}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface FilterSelectProps {
+  label: string
+  placeholder: string
+  value: string
+  onChange: (value: string) => void
+  options: FilterOption[]
+}
+
+function FilterSelect({ label, placeholder, value, onChange, options }: FilterSelectProps) {
+  const items = [
+    { value: ALL_VALUE, label: placeholder },
+    ...options.map((option) => ({
+      value: option.value,
+      label: `${option.label} (${option.count})`,
+    })),
+  ]
+
+  return (
+    <div
+      className="properties-filter-bar__field"
+      data-active={value ? "true" : undefined}
+    >
+      <span className="properties-filter-bar__field-label">{label}</span>
+      <Select
+        value={value || ALL_VALUE}
+        onValueChange={(nextValue) => {
+          if (nextValue == null || nextValue === ALL_VALUE) {
+            onChange("")
+            return
+          }
+          onChange(String(nextValue))
+        }}
+        items={items}
+      >
+        <SelectTrigger
+          aria-label={label}
+          className="properties-filter-bar__select-trigger"
+          disabled={options.length === 0}
+        >
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+        <SelectContent className="properties-filter-bar__select-content">
+          <SelectItem value={ALL_VALUE}>{placeholder}</SelectItem>
+          {options.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              disabled={option.count === 0 && option.value !== value}
+            >
+              {option.label} ({option.count})
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+interface ListingTypeToggleProps {
+  value: string
+  options: FilterOption[]
+  onChange: (value: string) => void
+}
+
+function ListingTypeToggle({ value, options, onChange }: ListingTypeToggleProps) {
+  return (
+    <div className="properties-filter-bar__listing" role="group" aria-label="Listing Type">
+      <span className="properties-filter-bar__field-label">Listing Type</span>
+      <div className="properties-filter-bar__listing-options">
+        {options.map((option) => {
+          const active = value === option.value
+          return (
+            <Button
+              key={option.value}
+              type="button"
+              variant="ghost"
+              size="sm"
+              data-active={active ? "true" : undefined}
+              disabled={option.count === 0 && !active}
+              className="properties-filter-bar__listing-option"
+              onClick={() => onChange(active ? "" : option.value)}
+            >
+              <span>{option.label}</span>
+              <span className="properties-filter-bar__listing-count">{option.count}</span>
+            </Button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function mapFacetOptions(
+  facets: PublicPropertyFacetOption[],
+  selectedValue: string,
+  labelForValue: (value: string) => string,
+): FilterOption[] {
+  const options = facets.map((facet) => ({
+    value: facet.value,
+    label: labelForValue(facet.value),
+    count: facet.count,
+  }))
+
+  if (selectedValue && !options.some((option) => option.value === selectedValue)) {
+    return [
+      ...options,
+      {
+        value: selectedValue,
+        label: labelForValue(selectedValue),
+        count: 0,
+      },
+    ]
+  }
+
+  return options
+}
+
+/**
+ * Bedroom bucket vocabulary mirrors the values emitted by the CRM facets
+ * endpoint. Keeping the URL ↔ bucket ↔ label mapping in a single table avoids
+ * the three functions drifting out of sync if the CRM extends the vocabulary.
+ */
+interface BedroomBucket {
+  min: string
+  max: string | null
+  label: string
+}
+
+const BEDROOM_BUCKETS: Record<string, BedroomBucket> = {
+  studio: { min: "0", max: "0", label: "Studio" },
+  "1": { min: "1", max: "1", label: "1 bedroom" },
+  "2": { min: "2", max: "2", label: "2 bedrooms" },
+  "3": { min: "3", max: "3", label: "3 bedrooms" },
+  "4+": { min: "4", max: null, label: "4 or more" },
+}
+
+function bedroomBucketFromParams(min: string | null, max: string | null): string {
+  if (!min && !max) return ""
+  for (const [value, bucket] of Object.entries(BEDROOM_BUCKETS)) {
+    if (bucket.min === min && bucket.max === max) return value
+  }
+  return ""
+}
+
+function bedroomParamsForBucket(value: string): Record<string, string | null> {
+  const bucket = BEDROOM_BUCKETS[value]
+  if (!bucket) return { bedrooms_min: null, bedrooms_max: null }
+  return { bedrooms_min: bucket.min, bedrooms_max: bucket.max }
+}
+
+function formatBedroomBucket(value: string): string {
+  return BEDROOM_BUCKETS[value]?.label ?? titleCase(value)
+}
+
+function formatListingType(value: string): string {
+  return LISTING_TYPE_LABELS[value as CrmListingType] ?? titleCase(value)
+}
+
+function titleCase(value: string): string {
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}

--- a/app/(web)/properties/_components/properties-filter.tsx
+++ b/app/(web)/properties/_components/properties-filter.tsx
@@ -1,8 +1,9 @@
 /**
- * CATALYST - Properties Filter
+ * CATALYST - Properties Grid
  *
- * Server-rendered filter UI driven by URL query params using CRM canonical
- * field names (property_type, area, bedrooms_min/max, price_min/max).
+ * Pure presentation: renders the property card grid. All filtering lives
+ * in the URL and is applied at the CRM list call; this component only
+ * paints what the server returned.
  */
 
 import Link from "next/link"
@@ -15,103 +16,35 @@ import { ArrowRightIcon, MapPinIcon } from "lucide-react"
 import { propertyTypeImages } from "../../_surface/property-images"
 import { formatCrmBedrooms, formatCrmPriceRange, getStatusBadge, type CrmProperty } from "@/lib/crm"
 
-interface PropertiesFilterProps {
+interface PropertiesGridProps {
   properties: CrmProperty[]
-  /** Currently active CRM property_type filter, or "all". */
-  activeType: string
-  /** Currently active area filter (case-insensitive substring match for tabs). */
-  areaFilter: string
 }
 
-export function PropertiesFilter({ properties, activeType, areaFilter }: PropertiesFilterProps) {
-  const normalisedType = (activeType || "all").toLowerCase()
-  const normalisedArea = areaFilter.trim().toLowerCase()
-
-  const types = Array.from(new Set(properties.map((p) => p.propertyType.toLowerCase())))
-  const typeCounts = types.reduce<Record<string, number>>((acc, type) => {
-    acc[type] = properties.filter((p) => p.propertyType.toLowerCase() === type).length
-    return acc
-  }, {})
-
-  let filtered = properties
-  if (normalisedType !== "all") {
-    filtered = filtered.filter((p) => p.propertyType.toLowerCase() === normalisedType)
-  }
-  if (normalisedArea) {
-    filtered = filtered.filter((p) => p.area.toLowerCase().includes(normalisedArea))
-  }
-
-  const filterHref = (type: string) => {
-    const params = new URLSearchParams()
-    if (type !== "all") params.set("property_type", type)
-    if (areaFilter) params.set("area", areaFilter)
-    const qs = params.toString()
-    return `/properties${qs ? `?${qs}` : ""}`
-  }
-
+export function PropertiesGrid({ properties }: PropertiesGridProps) {
   return (
-    <>
-      <section className="bg-[var(--web-off-white)] py-8 border-b border-[var(--web-serenity)]/20">
-        <Container size="xl">
-          <div className="flex flex-wrap justify-center gap-3">
-            <FilterTab href={filterHref("all")} active={normalisedType === "all"}>
-              All Properties ({properties.length})
-            </FilterTab>
-            {types.map((type) => (
-              <FilterTab key={type} href={filterHref(type)} active={normalisedType === type} capitalize>
-                {type} ({typeCounts[type]})
-              </FilterTab>
+    <section className="bg-[var(--web-off-white)] py-[var(--web-section-gap)]">
+      <Container size="xl">
+        {properties.length === 0 ? (
+          <Stack gap="md" align="center" className="text-center py-12">
+            <Title
+              as="h2"
+              className="font-headline text-[var(--web-ash)] text-2xl font-normal"
+            >
+              No properties match those filters
+            </Title>
+            <Text className="text-[var(--web-spruce)] text-[15px] font-light max-w-md">
+              Loosen your criteria or contact us for off-market opportunities.
+            </Text>
+          </Stack>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {properties.map((property) => (
+              <PropertyCard key={property.id} property={property} />
             ))}
           </div>
-        </Container>
-      </section>
-
-      <section className="bg-[var(--web-off-white)] py-[var(--web-section-gap)]">
-        <Container size="xl">
-          {filtered.length === 0 ? (
-            <Stack gap="md" align="center" className="text-center py-12">
-              <Text className="text-[var(--web-spruce)] text-[15px] font-light">
-                No properties match those filters. Contact us for off-market opportunities.
-              </Text>
-            </Stack>
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {filtered.map((property) => (
-                <PropertyCard key={property.id} property={property} />
-              ))}
-            </div>
-          )}
-        </Container>
-      </section>
-    </>
-  )
-}
-
-function FilterTab({
-  href,
-  active,
-  capitalize,
-  children,
-}: {
-  href: string
-  active: boolean
-  capitalize?: boolean
-  children: React.ReactNode
-}) {
-  return (
-    <Link
-      href={href}
-      scroll={false}
-      className={`px-5 py-2 rounded-[2px] text-[13px] uppercase tracking-wider transition-colors ${
-        capitalize ? "capitalize" : ""
-      } ${
-        active
-          ? "bg-[var(--web-ash)] text-[var(--web-off-white)]"
-          : "bg-transparent text-[var(--web-spruce)] border border-[var(--web-spruce)]/30 hover:bg-[var(--web-spruce)] hover:text-[var(--web-off-white)]"
-      }`}
-    >
-      {children}
-    </Link>
+        )}
+      </Container>
+    </section>
   )
 }
 

--- a/app/(web)/properties/page.tsx
+++ b/app/(web)/properties/page.tsx
@@ -5,6 +5,11 @@
  * promotion_status=top_property so this page only ever shows the curated
  * picks — the CRM's full catalogue is ~1.4k rows and would silently
  * truncate at 50 otherwise.
+ *
+ * Filter values and counts are sourced from the CRM facets endpoint
+ * (`/api/public/properties/facets`) — see lib/crm/facets.ts. No hardcoded
+ * enums for areas, property types, listing types, or bedrooms live in this
+ * surface.
  */
 
 import Link from "next/link"
@@ -12,12 +17,21 @@ import Image from "next/image"
 
 import { config } from "@/lib/config"
 import { getCrmProperties } from "@/lib/crm/client"
-import type { CrmListFilters, CrmPropertyType, CrmSort } from "@/lib/crm"
+import { fetchPropertyFacets } from "@/lib/crm/facets"
+import type {
+  CrmListFilters,
+  CrmListingType,
+  CrmPromotionStatus,
+  CrmPropertyStatus,
+  CrmPropertyType,
+  CrmSort,
+} from "@/lib/crm"
 import { Container, Stack, Grid, Text, Title } from "@/components/core"
 import { Button } from "@/components/ui/button"
 import { ArrowRightIcon } from "lucide-react"
 
-import { PropertiesFilter } from "./_components/properties-filter"
+import { PropertiesGrid } from "./_components/properties-filter"
+import { PropertiesFilterBar } from "./_components/properties-filter-bar"
 import propertiesImage from "@/public/images/hero/properties.jpg"
 
 export const revalidate = 300 // Match CRM Cache-Control max-age
@@ -49,12 +63,17 @@ export const metadata = {
 
 interface PropertiesPageProps {
   searchParams: Promise<{
+    q?: string | string[]
     property_type?: string | string[]
     area?: string | string[]
+    listing_type?: string | string[]
     bedrooms_min?: string | string[]
     bedrooms_max?: string | string[]
     price_min?: string | string[]
     price_max?: string | string[]
+    status?: string | string[]
+    promotion_status?: string | string[]
+    tag?: string | string[]
     sort?: string | string[]
   }>
 }
@@ -73,21 +92,57 @@ function numericParam(value: string | string[] | undefined): number | undefined 
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
+function textParam(value: string | string[] | undefined): string | undefined {
+  const raw = singleParam(value)?.trim()
+  return raw ? raw : undefined
+}
+
+const USER_FILTER_KEYS = [
+  "q",
+  "property_type",
+  "area",
+  "listing_type",
+  "bedrooms_min",
+  "bedrooms_max",
+  "price_min",
+  "price_max",
+  "status",
+  "promotion_status",
+  "tag",
+  "sort",
+] as const
+
+function hasAnyUserFilter(params: Awaited<PropertiesPageProps["searchParams"]>): boolean {
+  return USER_FILTER_KEYS.some((k) => {
+    const v = params[k]
+    return v != null && v !== ""
+  })
+}
+
 function parseFilters(
-  params: Awaited<PropertiesPageProps["searchParams"]>
+  params: Awaited<PropertiesPageProps["searchParams"]>,
 ): CrmListFilters {
   const sortRaw = singleParam(params.sort)
   const sort = ALLOWED_SORTS.includes(sortRaw as CrmSort) ? (sortRaw as CrmSort) : undefined
   const propertyType = singleParam(params.property_type) as CrmPropertyType | undefined
 
+  // The CRM silently drops invalid filter values, so we forward strings as-is
+  // (cast to the canonical union type for downstream signatures). No
+  // site-side allowlist — keeps the CRM as the single source of truth for
+  // which values exist.
   return {
+    q: textParam(params.q),
     propertyType: propertyType && propertyType !== "all" ? propertyType : undefined,
-    area: singleParam(params.area),
+    area: textParam(params.area),
+    listingType: singleParam(params.listing_type) as CrmListingType | undefined,
     bedroomsMin: numericParam(params.bedrooms_min),
     bedroomsMax: numericParam(params.bedrooms_max),
     priceMin: numericParam(params.price_min),
     priceMax: numericParam(params.price_max),
-    promotionStatus: "top_property",
+    status: singleParam(params.status) as CrmPropertyStatus | undefined,
+    promotionStatus:
+      (singleParam(params.promotion_status) as CrmPromotionStatus | undefined) ?? "top_property",
+    tag: textParam(params.tag),
     sort,
     limit: 50,
   }
@@ -101,18 +156,21 @@ export default async function PropertiesPage({ searchParams }: PropertiesPagePro
   }
 
   const filters = parseFilters(params)
-  const { properties, total } = await getCrmProperties(filters)
+  const [{ properties, total }, facets] = await Promise.all([
+    getCrmProperties(filters),
+    fetchPropertyFacets(filters),
+  ])
 
-  if (properties.length === 0) {
+  // Show the friendly "coming soon" state only when there's genuinely nothing
+  // to filter — i.e., no user filters AND no inventory.
+  const hasUserFilters = hasAnyUserFilter(params)
+  if (!hasUserFilters && properties.length === 0) {
     return <EmptyState />
   }
 
-  const propertyCount = total || properties.length
+  const propertyCount = total // pagination.total under the active filter set
   const categoryCount = new Set(properties.map((p) => p.propertyType.toLowerCase())).size
   const areaCount = new Set(properties.map((p) => p.area.toLowerCase())).size
-
-  const activeType = singleParam(params.property_type) ?? "all"
-  const areaFilter = singleParam(params.area) ?? ""
 
   return (
     <div className="web-properties">
@@ -122,11 +180,13 @@ export default async function PropertiesPage({ searchParams }: PropertiesPagePro
         areaCount={areaCount}
       />
 
-      <PropertiesFilter
-        properties={properties}
-        activeType={activeType}
-        areaFilter={areaFilter}
-      />
+      <section className="bg-[var(--web-off-white)] py-8 border-b border-[var(--web-serenity)]/20">
+        <Container size="xl">
+          <PropertiesFilterBar facets={facets} resultCount={propertyCount} />
+        </Container>
+      </section>
+
+      <PropertiesGrid properties={properties} />
 
       <CTASection />
     </div>
@@ -214,34 +274,6 @@ function HeroStat({ value, label }: { value: number; label: string }) {
 // EMPTY / DISABLED STATES
 // =============================================================================
 
-function FeatureDisabledState() {
-  return (
-    <section className="bg-[var(--web-off-white)] py-[var(--web-section-gap)]">
-      <Container size="lg">
-        <Stack gap="md" align="center" className="text-center py-20">
-          <Title
-            as="h1"
-            className="font-headline text-[var(--web-ash)] text-[clamp(28px,4vw,40px)]"
-          >
-            Properties Coming Soon
-          </Title>
-          <Text className="text-[var(--web-spruce)] text-[15px] font-light max-w-md">
-            Our curated portfolio is being prepared. Contact us directly to discuss available
-            opportunities.
-          </Text>
-          <Button
-            className="mt-4 h-12 px-8 bg-[var(--web-spruce)] text-[var(--web-off-white)] hover:bg-[var(--web-ash)] rounded-[2px] text-[11px] font-normal uppercase tracking-[0.2em]"
-            render={<Link href="/contact" />}
-          >
-            Contact Us
-            <ArrowRightIcon className="ml-2 h-4 w-4" />
-          </Button>
-        </Stack>
-      </Container>
-    </section>
-  )
-}
-
 function EmptyState() {
   return (
     <div className="web-properties">
@@ -294,6 +326,34 @@ function EmptyState() {
       </section>
       <CTASection />
     </div>
+  )
+}
+
+function FeatureDisabledState() {
+  return (
+    <section className="bg-[var(--web-off-white)] py-[var(--web-section-gap)]">
+      <Container size="lg">
+        <Stack gap="md" align="center" className="text-center py-20">
+          <Title
+            as="h1"
+            className="font-headline text-[var(--web-ash)] text-[clamp(28px,4vw,40px)]"
+          >
+            Properties Coming Soon
+          </Title>
+          <Text className="text-[var(--web-spruce)] text-[15px] font-light max-w-md">
+            Our curated portfolio is being prepared. Contact us directly to discuss available
+            opportunities.
+          </Text>
+          <Button
+            className="mt-4 h-12 px-8 bg-[var(--web-spruce)] text-[var(--web-off-white)] hover:bg-[var(--web-ash)] rounded-[2px] text-[11px] font-normal uppercase tracking-[0.2em]"
+            render={<Link href="/contact" />}
+          >
+            Contact Us
+            <ArrowRightIcon className="ml-2 h-4 w-4" />
+          </Button>
+        </Stack>
+      </Container>
+    </section>
   )
 }
 

--- a/app/(web)/web.css
+++ b/app/(web)/web.css
@@ -3715,3 +3715,176 @@
 .cert-public__revoked p {
   color: var(--web-spruce);
 }
+
+/* =============================================================================
+   PROPERTIES FILTER BAR
+   Count-aware CRM facets + name search on /properties.
+   ============================================================================= */
+
+.properties-filter-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  background: #fff;
+  border: 1px solid oklch(from var(--web-serenity) l c h / 0.28);
+  border-radius: 3px;
+  box-shadow: 0 2px 12px oklch(0 0 0 / 0.04);
+  transition: opacity 200ms ease;
+}
+
+.properties-filter-bar[data-pending="true"] {
+  opacity: 0.7;
+}
+
+.properties-filter-bar__search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  width: 100%;
+}
+
+.properties-filter-bar__search-label,
+.properties-filter-bar__field-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--web-spruce);
+}
+
+.properties-filter-bar__search .properties-filter-bar__search-input {
+  min-height: 46px;
+  border-color: oklch(from var(--web-serenity) l c h / 0.34);
+  border-radius: 2px;
+  background: var(--web-off-white);
+  color: var(--web-ash);
+  box-shadow: none;
+}
+
+.properties-filter-bar__search .ui-input.properties-filter-bar__search-input {
+  min-height: auto;
+  border: 0;
+  background: transparent;
+}
+
+.properties-filter-bar__controls {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+  width: 100%;
+  align-items: end;
+}
+
+@media (min-width: 720px) {
+  .properties-filter-bar__controls {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1180px) {
+  .properties-filter-bar {
+    padding: 1.15rem 1.25rem;
+  }
+
+  .properties-filter-bar__controls {
+    grid-template-columns: 1.15fr 1fr 0.9fr 1.15fr auto;
+  }
+}
+
+.properties-filter-bar__field {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.properties-filter-bar__select-trigger {
+  width: 100%;
+  height: 42px;
+  justify-content: space-between;
+  background: var(--web-off-white);
+  border-color: oklch(from var(--web-serenity) l c h / 0.34);
+  border-radius: 2px;
+  color: var(--web-ash);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  box-shadow: none;
+}
+
+.properties-filter-bar__field:hover .properties-filter-bar__select-trigger {
+  border-color: var(--web-spruce);
+}
+
+.properties-filter-bar__field[data-active="true"] .properties-filter-bar__select-trigger {
+  background: var(--web-spruce);
+  border-color: var(--web-spruce);
+  color: var(--web-off-white);
+}
+
+.properties-filter-bar__field[data-active="true"] .properties-filter-bar__select-trigger svg {
+  color: var(--web-off-white);
+}
+
+.properties-filter-bar__select-content {
+  max-height: 18rem;
+  border-radius: 3px;
+  font-size: 13px;
+}
+
+.properties-filter-bar__listing {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.properties-filter-bar__listing-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.properties-filter-bar__listing-option {
+  min-width: 0;
+  height: 42px;
+  justify-content: space-between;
+  border-color: oklch(from var(--web-serenity) l c h / 0.34);
+  border-radius: 2px;
+  background: var(--web-off-white);
+  color: var(--web-ash);
+  font-size: 12px;
+}
+
+.properties-filter-bar__listing-option[data-active="true"] {
+  border-color: var(--web-spruce);
+  background: var(--web-spruce);
+  color: var(--web-off-white);
+}
+
+.properties-filter-bar__listing-count {
+  color: inherit;
+  opacity: 0.72;
+}
+
+.properties-filter-bar__counter {
+  display: inline-flex;
+  align-items: baseline;
+  justify-content: flex-start;
+  gap: 0.4rem;
+  min-height: 42px;
+  padding: 0.65rem 0.25rem 0;
+}
+
+.properties-filter-bar__counter-value {
+  font-family: var(--font-headline, serif);
+  font-size: 22px;
+  color: var(--web-ash);
+  line-height: 1;
+}
+
+.properties-filter-bar__counter-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--web-spruce);
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,9 @@ const eslintConfig = defineConfig([
     "scripts/**",
     // Legacy folder - deprecated code, not actively maintained
     "legacy/**",
+    // Conductor workspace scratch files - local agent artifacts, not source
+    ".context/**",
+    ".playwright-mcp/**",
     // Docs folder - internal documentation, not user-facing code
     "app/(docs)/**",
     // Examples folder - reference implementations

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -164,6 +164,7 @@ export const config = {
    */
   crm: {
     baseUrl: process.env.NEXT_PUBLIC_CRM_BASE_URL || "https://crm.primecapitaldubai.com",
+    agencySlug: process.env.NEXT_PUBLIC_CRM_AGENCY_SLUG || "prime-capital",
     agencyUuid: process.env.NEXT_PUBLIC_CRM_AGENCY_UUID || "",
   },
 

--- a/lib/crm/client.ts
+++ b/lib/crm/client.ts
@@ -38,15 +38,16 @@ interface FetchOptions {
 function isCrmConfigured(): boolean {
   return Boolean(
     config.crm.baseUrl &&
-      config.crm.agencyUuid &&
-      config.crm.agencyUuid.length <= CRM_PARAM_MAX_LENGTH,
+      config.crm.agencySlug &&
+      config.crm.agencySlug.length <= CRM_PARAM_MAX_LENGTH,
   )
 }
 
 function buildListUrl(filters: CrmListFilters | undefined): string {
   const url = new URL("/api/public/properties", config.crm.baseUrl)
-  url.searchParams.set("agency", config.crm.agencyUuid)
+  url.searchParams.set("agency", config.crm.agencySlug)
 
+  if (filters?.q) url.searchParams.set("q", filters.q)
   if (filters?.listingType) url.searchParams.set("listing_type", filters.listingType)
   if (filters?.area) url.searchParams.set("area", filters.area)
   if (filters?.propertyType) url.searchParams.set("property_type", filters.propertyType)
@@ -57,6 +58,15 @@ function buildListUrl(filters: CrmListFilters | undefined): string {
   if (filters?.status) url.searchParams.set("status", filters.status)
   if (filters?.promotionStatus)
     url.searchParams.set("promotion_status", filters.promotionStatus)
+  if (filters?.paymentPlanPreset)
+    url.searchParams.set("payment_plan_preset", filters.paymentPlanPreset)
+  if (filters?.completionYearMin != null)
+    url.searchParams.set("completion_year_min", String(filters.completionYearMin))
+  if (filters?.completionYearMax != null)
+    url.searchParams.set("completion_year_max", String(filters.completionYearMax))
+  if (filters?.completionMonth != null)
+    url.searchParams.set("completion_month", String(filters.completionMonth))
+  if (filters?.tag) url.searchParams.set("tag", filters.tag)
   if (filters?.sort) url.searchParams.set("sort", filters.sort)
   if (filters?.cursor) url.searchParams.set("cursor", filters.cursor)
   if (filters?.limit != null) url.searchParams.set("limit", String(Math.min(filters.limit, 50)))
@@ -66,7 +76,7 @@ function buildListUrl(filters: CrmListFilters | undefined): string {
 
 function buildDetailUrl(slugOrId: string): string {
   const url = new URL(`/api/public/properties/${encodeURIComponent(slugOrId)}`, config.crm.baseUrl)
-  url.searchParams.set("agency", config.crm.agencyUuid)
+  url.searchParams.set("agency", config.crm.agencySlug)
   return url.toString()
 }
 
@@ -141,6 +151,8 @@ function mapListItem(row: CrmPropertyListItem): CrmProperty {
     completionDate: row.completion_date,
     constructionProgress: row.construction_progress,
     amenities: row.amenities ?? [],
+
+    paymentPlanPreset: row.payment_plan_preset ?? null,
 
     images: row.images ?? [],
 

--- a/lib/crm/facets.ts
+++ b/lib/crm/facets.ts
@@ -1,0 +1,132 @@
+/**
+ * CATALYST - AgentCRM Property Facets (Server Only)
+ *
+ * Reads count-bearing filter facets from the CRM. The API cross-filters
+ * counts using the active browse filters, including free-text `q`.
+ *
+ * Endpoint: GET /api/public/properties/facets?agency=<slug>
+ *
+ * Server-only: do NOT import from a Client Component. Pass the resolved
+ * facets object as a prop to client filter UIs instead.
+ */
+
+import "server-only"
+
+import { config } from "@/lib/config"
+import { trackError } from "@/lib/error-tracking"
+import type {
+  CrmListFilters,
+  PublicPropertyFacetOption,
+  PublicPropertyFacets,
+} from "./types"
+
+const REVALIDATE_SECONDS = 300
+
+interface RawFacetOption {
+  value: string
+  count: number
+}
+
+interface RawFacetsResponse {
+  areas?: RawFacetOption[]
+  property_types?: RawFacetOption[]
+  listing_types?: RawFacetOption[]
+  bedrooms?: RawFacetOption[]
+}
+
+const EMPTY_FACETS: PublicPropertyFacets = {
+  areas: [],
+  propertyTypes: [],
+  listingTypes: [],
+  bedrooms: [],
+}
+
+function isCrmConfigured(): boolean {
+  return Boolean(config.crm.baseUrl && config.crm.agencySlug)
+}
+
+function sortFacetOptions(options: PublicPropertyFacetOption[]): PublicPropertyFacetOption[] {
+  return [...options].sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count
+    return a.value.localeCompare(b.value)
+  })
+}
+
+function mapFacetOptions(options: RawFacetOption[] | undefined): PublicPropertyFacetOption[] {
+  if (!Array.isArray(options)) return []
+  return sortFacetOptions(
+    options
+      .filter((option) => typeof option?.value === "string")
+      .map((option) => ({
+        value: option.value,
+        count: Number.isFinite(option.count) ? option.count : 0,
+      })),
+  )
+}
+
+function appendFilterParams(url: URL, filters: CrmListFilters | undefined): void {
+  if (!filters) return
+
+  if (filters.q) url.searchParams.set("q", filters.q)
+  if (filters.listingType) url.searchParams.set("listing_type", filters.listingType)
+  if (filters.area) url.searchParams.set("area", filters.area)
+  if (filters.propertyType) url.searchParams.set("property_type", filters.propertyType)
+  if (filters.bedroomsMin != null) url.searchParams.set("bedrooms_min", String(filters.bedroomsMin))
+  if (filters.bedroomsMax != null) url.searchParams.set("bedrooms_max", String(filters.bedroomsMax))
+  if (filters.priceMin != null) url.searchParams.set("price_min", String(filters.priceMin))
+  if (filters.priceMax != null) url.searchParams.set("price_max", String(filters.priceMax))
+  if (filters.status) url.searchParams.set("status", filters.status)
+  if (filters.promotionStatus) url.searchParams.set("promotion_status", filters.promotionStatus)
+  if (filters.tag) url.searchParams.set("tag", filters.tag)
+}
+
+function mapFacets(raw: RawFacetsResponse): PublicPropertyFacets {
+  return {
+    areas: mapFacetOptions(raw.areas),
+    propertyTypes: mapFacetOptions(raw.property_types),
+    listingTypes: mapFacetOptions(raw.listing_types),
+    bedrooms: mapFacetOptions(raw.bedrooms),
+  }
+}
+
+/**
+ * Returns live, count-bearing facets for the configured agency and active
+ * browse filters. Always resolves with an empty shape on upstream failure.
+ */
+export async function fetchPropertyFacets(
+  filters?: CrmListFilters,
+): Promise<PublicPropertyFacets> {
+  if (!isCrmConfigured()) return EMPTY_FACETS
+
+  const url = new URL("/api/public/properties/facets", config.crm.baseUrl)
+  url.searchParams.set("agency", config.crm.agencySlug)
+  appendFilterParams(url, filters)
+
+  let res: Response
+  try {
+    res = await fetch(url.toString(), {
+      headers: { Accept: "application/json" },
+      next: { revalidate: REVALIDATE_SECONDS },
+    })
+  } catch (error) {
+    trackError(error, { context: "crm-facets", url: url.toString(), action: "fetch" })
+    return EMPTY_FACETS
+  }
+
+  if (!res.ok) {
+    trackError(new Error(`CRM facets responded ${res.status}`), {
+      context: "crm-facets",
+      url: url.toString(),
+      status: res.status,
+    })
+    return EMPTY_FACETS
+  }
+
+  try {
+    const raw = (await res.json()) as RawFacetsResponse
+    return mapFacets(raw)
+  } catch (error) {
+    trackError(error, { context: "crm-facets", url: url.toString(), action: "parse" })
+    return EMPTY_FACETS
+  }
+}

--- a/lib/crm/index.ts
+++ b/lib/crm/index.ts
@@ -7,3 +7,4 @@
 
 export * from "./types"
 export * from "./widget"
+export * from "./labels"

--- a/lib/crm/labels.ts
+++ b/lib/crm/labels.ts
@@ -1,0 +1,50 @@
+/**
+ * CATALYST - CRM Label Helpers (Client-Safe)
+ *
+ * Site-authored labels for CRM-canonical machine values. The CRM owns the
+ * vocabulary (`60_40`, `off_plan`, etc.); this module owns how those values
+ * are presented to humans.
+ */
+
+import type { CrmListingType, CrmPaymentPlanPreset } from "./types"
+
+/** Short label for a payment-plan preset, used in dropdown options. */
+export const PAYMENT_PLAN_PRESET_LABELS: Record<CrmPaymentPlanPreset, string> = {
+  "60_40": "60/40",
+  "50_50": "50/50",
+  "40_60": "40/60",
+  "20_80": "20/80",
+  "10_90": "10/90",
+  other: "Other / Non-standard",
+}
+
+/** Expanded explainer for the construction/handover split. */
+export const PAYMENT_PLAN_PRESET_SUBLABELS: Record<CrmPaymentPlanPreset, string> = {
+  "60_40": "60% during construction, 40% on handover",
+  "50_50": "50% during construction, 50% on handover",
+  "40_60": "40% during construction, 60% on handover",
+  "20_80": "20% during construction, 80% on handover",
+  "10_90": "10% during construction, 90% on handover",
+  other: "Bespoke or post-handover plans",
+}
+
+/** "60_40" → "60/40 — 60% during construction, 40% on handover" */
+export function formatPaymentPlanPreset(preset: CrmPaymentPlanPreset): string {
+  return `${PAYMENT_PLAN_PRESET_LABELS[preset]} — ${PAYMENT_PLAN_PRESET_SUBLABELS[preset]}`
+}
+
+/**
+ * Sort preset values for display. `other` (~57% of off-plan rows) always
+ * sorts last so it doesn't dominate the dropdown.
+ */
+export function sortPaymentPlanPresets(presets: CrmPaymentPlanPreset[]): CrmPaymentPlanPreset[] {
+  const STANDARD: CrmPaymentPlanPreset[] = ["60_40", "50_50", "40_60", "20_80", "10_90"]
+  const standard = STANDARD.filter((p) => presets.includes(p))
+  const includesOther = presets.includes("other")
+  return includesOther ? [...standard, "other"] : standard
+}
+
+export const LISTING_TYPE_LABELS: Record<CrmListingType, string> = {
+  off_plan: "Off-plan",
+  secondary: "Secondary",
+}

--- a/lib/crm/types.ts
+++ b/lib/crm/types.ts
@@ -37,6 +37,19 @@ export type CrmPropertyType =
 
 export type CrmFurnished = "unfurnished" | "furnished" | "semi-furnished" | (string & {})
 
+/**
+ * Canonical payment-plan shorthand from the CRM. `other` is the bulk bucket
+ * for non-standard plans (~57% of off-plan rows) — render it last and label
+ * it explicitly ("Other / Non-standard").
+ */
+export type CrmPaymentPlanPreset =
+  | "60_40"
+  | "50_50"
+  | "40_60"
+  | "20_80"
+  | "10_90"
+  | "other"
+
 export interface CrmPaymentInstallment {
   milestone: string
   percentage: number
@@ -106,6 +119,8 @@ export interface CrmPropertyListItem {
   completion_date: string | null
   construction_progress: number | null
   amenities: string[]
+
+  payment_plan_preset: CrmPaymentPlanPreset | null
 
   images: string[]
 
@@ -201,6 +216,8 @@ export interface CrmProperty {
   constructionProgress: number | null
   amenities: string[]
 
+  paymentPlanPreset: CrmPaymentPlanPreset | null
+
   images: string[]
 
   createdAt: string
@@ -246,9 +263,17 @@ export interface CrmPropertyFull extends CrmProperty {
 
 export type CrmSort = "price_asc" | "price_desc" | "newest" | "oldest"
 
-export type CrmPromotionStatus = "top_property" | "shadow_picks" | "discount" | (string & {})
+export type CrmPromotionStatus =
+  | "top_property"
+  | "inventory"
+  | "deal_only"
+  | "archive"
+  | "shadow_picks"
+  | "discount"
+  | (string & {})
 
 export interface CrmListFilters {
+  q?: string
   listingType?: CrmListingType
   area?: string
   propertyType?: CrmPropertyType
@@ -258,10 +283,33 @@ export interface CrmListFilters {
   priceMax?: number
   status?: CrmPropertyStatus
   promotionStatus?: CrmPromotionStatus
+  /** Canonical payment-plan shorthand. Only meaningful for off-plan rows. */
+  paymentPlanPreset?: CrmPaymentPlanPreset
+  completionYearMin?: number
+  completionYearMax?: number
+  /** Only honoured by the API when completionYearMin === completionYearMax. */
+  completionMonth?: number
+  tag?: string
   sort?: CrmSort
   cursor?: string
   /** Default 20, max 50. */
   limit?: number
+}
+
+/**
+ * Live filter facets for an agency. Counts are scoped by the current query
+ * params so picking one facet updates all other option counts.
+ */
+export interface PublicPropertyFacetOption {
+  value: string
+  count: number
+}
+
+export interface PublicPropertyFacets {
+  areas: PublicPropertyFacetOption[]
+  propertyTypes: PublicPropertyFacetOption[]
+  listingTypes: PublicPropertyFacetOption[]
+  bedrooms: PublicPropertyFacetOption[]
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- add agency slug support and wire property list/facet requests to the CRM public API
- replace hardcoded/inferred property browse filters with live count-bearing facets
- add debounced name/development search via the q query param

## Verification
- pnpm exec tsc --noEmit
- pnpm exec eslint app/'(web)'/page.tsx app/'(web)'/properties/page.tsx app/'(web)'/properties/_components/properties-filter-bar.tsx app/'(web)'/properties/_components/properties-filter.tsx app/'(admin)'/admin/properties/property-form.tsx app/'(admin)'/admin/properties/'[id]'/property-edit-form.tsx lib/config.ts lib/crm/client.ts lib/crm/facets.ts lib/crm/types.ts lib/crm/labels.ts
- rg -n "LOCATIONS\s*=|PROPERTY_TYPES\s*=" . -g '!node_modules' -g '!.next' -g '!.context' -S
- live CRM facets curl for prime-capital top_property and off_plan cross-filter
- Playwright verification at http://localhost:3010/properties

Note: the production CRM list endpoint currently appears to ignore q, which matches the parallel rollout caveat in the task. The site sends q to both list and facets endpoints.