### PR TITLE
Fix script generator: migrate retired Claude 4.0 model IDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,9 +129,9 @@ AUTH_CUSTOM_ENDPOINT=
 ANTHROPIC_API_KEY=
 
 # Claude model — default for platform features (coach, essentials, etc.)
-CLAUDE_MODEL=claude-sonnet-4-20250514
+CLAUDE_MODEL=claude-sonnet-4-5-20250929
 # Claude model — for YouTube script generation (higher quality)
-YOUTUBE_SCRIPT_MODEL=claude-opus-4-20250514
+YOUTUBE_SCRIPT_MODEL=claude-opus-4-5-20251101
 
 # Perplexity API — for live web-search-backed topic suggestions
 # Get from: https://www.perplexity.ai/settings/api

--- a/app/api/admin/generate-essentials/route.ts
+++ b/app/api/admin/generate-essentials/route.ts
@@ -158,7 +158,7 @@ export async function POST(request: NextRequest) {
     const anthropic = new Anthropic()
 
     const response = await anthropic.messages.create({
-      model: "claude-sonnet-4-20250514",
+      model: "claude-sonnet-4-5-20250929",
       max_tokens: 4000,
       system: systemPrompt,
       messages: [{ role: "user", content: userPrompt }],

--- a/app/api/admin/youtube/chat-edit/route.ts
+++ b/app/api/admin/youtube/chat-edit/route.ts
@@ -337,7 +337,7 @@ ${formatSpec}`
 
     const response = await anthropic.messages.create(
       {
-        model: process.env.YOUTUBE_CHAT_MODEL || "claude-sonnet-4-20250514",
+        model: process.env.YOUTUBE_CHAT_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 4096,
         temperature: 0.5,
         system: systemPrompt,

--- a/app/api/admin/youtube/classify-format/route.ts
+++ b/app/api/admin/youtube/classify-format/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest) {
 
     const response = await anthropic.messages.create(
       {
-        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
+        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 512,
         temperature: 0.1,
         system: SYSTEM_PROMPT,

--- a/app/api/admin/youtube/distill-idea/route.ts
+++ b/app/api/admin/youtube/distill-idea/route.ts
@@ -147,7 +147,7 @@ export async function POST(request: NextRequest) {
 
     const response = await anthropic.messages.create(
       {
-        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
+        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 2048,
         temperature: 0.7,
         system: systemPromptFor(format, profile),

--- a/app/api/admin/youtube/generate-ideas/route.ts
+++ b/app/api/admin/youtube/generate-ideas/route.ts
@@ -171,7 +171,7 @@ export async function POST(request: NextRequest) {
 
     const response = await anthropic.messages.create(
       {
-        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
+        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 4096,
         temperature: 0.9,
         system: getSystemPrompt(profile),

--- a/app/api/admin/youtube/generate-script/route.ts
+++ b/app/api/admin/youtube/generate-script/route.ts
@@ -107,7 +107,7 @@ Generate the full script now, following the format spec exactly. Output Markdown
     // Stream the response — pass request.signal so disconnect cancels upstream call
     const stream = await anthropic.messages.stream(
       {
-        model: process.env.YOUTUBE_SCRIPT_MODEL || "claude-opus-4-20250514",
+        model: process.env.YOUTUBE_SCRIPT_MODEL || "claude-opus-4-5-20251101",
         max_tokens: 16384,
         temperature: 0.7,
         system: systemPrompt,

--- a/app/api/admin/youtube/panel-review/route.ts
+++ b/app/api/admin/youtube/panel-review/route.ts
@@ -50,7 +50,7 @@ const anthropic = new Anthropic({
 })
 
 const REVIEWER_MODEL =
-  process.env.YOUTUBE_PANEL_REVIEWER_MODEL || "claude-sonnet-4-20250514"
+  process.env.YOUTUBE_PANEL_REVIEWER_MODEL || "claude-sonnet-4-5-20250929"
 const SYNTHESISER_MODEL =
   process.env.YOUTUBE_PANEL_SYNTHESISER_MODEL || "claude-haiku-4-5-20251001"
 

--- a/app/api/admin/youtube/regen-from-chat/route.ts
+++ b/app/api/admin/youtube/regen-from-chat/route.ts
@@ -233,7 +233,7 @@ Generate the improved script now, addressing every point of the rewrite brief ab
 
     const stream = await anthropic.messages.stream(
       {
-        model: process.env.YOUTUBE_SCRIPT_MODEL || "claude-opus-4-20250514",
+        model: process.env.YOUTUBE_SCRIPT_MODEL || "claude-opus-4-5-20251101",
         max_tokens: 16_384,
         temperature: 0.7,
         system: systemPrompt,

--- a/app/api/admin/youtube/validate-script/route.ts
+++ b/app/api/admin/youtube/validate-script/route.ts
@@ -240,7 +240,7 @@ ${getBrandGuide(profile)}
 
     const response = await anthropic.messages.create(
       {
-        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
+        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 4096,
         temperature: 0.3,
         system: systemPrompt,

--- a/app/api/coach/chat/route.ts
+++ b/app/api/coach/chat/route.ts
@@ -326,7 +326,7 @@ export async function POST(request: NextRequest) {
 
     // Stream response from Claude
     const stream = await anthropic.messages.stream({
-      model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
+      model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
       max_tokens: 512, // Keep responses concise
       temperature: 0.7,
       system: systemPrompt,

--- a/app/api/coach/roleplay/route.ts
+++ b/app/api/coach/roleplay/route.ts
@@ -271,7 +271,7 @@ export async function POST(request: NextRequest) {
 
       try {
         const response = await anthropic.messages.create({
-          model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
+          model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
           max_tokens: 1024,
           temperature: 0.3,
           system: prompts.roleplay_evaluation,
@@ -355,7 +355,7 @@ export async function POST(request: NextRequest) {
 
       // Stream response for natural feel
       const stream = await anthropic.messages.stream({
-        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-20250514",
+        model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 256,
         temperature: 0.7,
         system: roleplaySystemPrompt,


### PR DESCRIPTION
## Problem

Users hit **"Failed to distil context"** on the YouTube script generator.

Root cause: every AI route defaulted to the May-2025 Claude 4.0 models (`claude-sonnet-4-20250514`, `claude-opus-4-20250514`), which have since been **retired** and now return `not_found_error` from the Anthropic API. The generic catch-all surfaced as "Failed to distil context"; the coach and essentials routes were broken the same way.

## Fix

Migrate all model IDs to the current 4.5 family:
- `claude-sonnet-4-20250514` -> `claude-sonnet-4-5-20250929`
- `claude-opus-4-20250514` -> `claude-opus-4-5-20251101`

Covers all `app/api/admin/youtube/*` and `app/api/coach/*` routes, plus `.env.example`.

## Why no Vercel env change is needed

Production sets neither `CLAUDE_MODEL` nor `YOUTUBE_SCRIPT_MODEL`, so the hardcoded code defaults are authoritative in prod. Bumping them here fixes prod on deploy.

## Verification

- Probed the Anthropic API directly: old IDs `404`, new IDs `200`.
- Ran the full distill prompt against `claude-sonnet-4-5-20250929` — returns 3 parseable angles.
- String-only changes (model field values); no type/build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)