### PR TITLE
Event registration kiosk + correct AgentCRM event/seller routing

### DIFF
--- a/app/(kiosk)/kiosk.css
+++ b/app/(kiosk)/kiosk.css
@@ -1,0 +1,459 @@
+/**
+ * CATALYST - Kiosk Surface Styles
+ *
+ * Full-screen, chrome-free styles for the event registration kiosk.
+ * Designed to fill an iPad screen with no page scroll — the form fits
+ * in one view so a guest at a stand can register in seconds.
+ *
+ * Uses the web brand tokens (spruce / ash / serenity / off-white) so the
+ * kiosk feels like Prime Capital even though it has no site chrome.
+ */
+
+.kiosk {
+  /* Brand tokens (mirrors app/(web)/web.css so the kiosk is self-contained) */
+  --web-spruce: #576c75;
+  --web-ash: #3f4142;
+  --web-off-white: #f2efea;
+  --web-serenity: #a6b5b0;
+
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  /* Branded backdrop: a website hero darkened with the spruce/ash gradient so
+     the white card floats and any text on the image stays legible. */
+  background-color: var(--web-ash);
+  background-image:
+    linear-gradient(
+      135deg,
+      rgba(63, 65, 66, 0.86) 0%,
+      rgba(87, 108, 117, 0.74) 45%,
+      rgba(63, 65, 66, 0.88) 100%
+    ),
+    url("/images/hero/prime-capital-hero.jpg");
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.kiosk__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 1080px;
+  max-height: 100%;
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 30px 80px -20px rgba(63, 65, 66, 0.35);
+  overflow: hidden;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Header                                                                      */
+/* -------------------------------------------------------------------------- */
+
+.kiosk__header {
+  flex-shrink: 0;
+  padding: clamp(1.25rem, 3vw, 2.25rem) clamp(1.5rem, 4vw, 3rem) clamp(1rem, 2vw, 1.5rem);
+  border-bottom: 1px solid rgba(166, 181, 176, 0.25);
+}
+
+.kiosk__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--web-spruce);
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.kiosk__event-name {
+  margin-top: 0.5rem;
+  font-family: var(--font-headline), Georgia, serif;
+  color: var(--web-ash);
+  font-size: clamp(22px, 3.2vw, 34px);
+  font-weight: 400;
+  line-height: 1.15;
+}
+
+.kiosk__subtitle {
+  margin-top: 0.4rem;
+  color: var(--web-spruce);
+  font-size: clamp(13px, 1.6vw, 15px);
+  font-weight: 300;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Body — scrolls internally only as a safety net; designed to fit            */
+/* -------------------------------------------------------------------------- */
+
+.kiosk__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: clamp(1.25rem, 3vw, 2.25rem) clamp(1.5rem, 4vw, 3rem);
+}
+
+.kiosk__grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: clamp(1.25rem, 3vw, 2.5rem);
+}
+
+@media (min-width: 760px) {
+  .kiosk__grid {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  }
+}
+
+.kiosk__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.kiosk__field + .kiosk__field {
+  margin-top: clamp(0.85rem, 2vw, 1.25rem);
+}
+
+.kiosk__label {
+  color: var(--web-ash);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.kiosk__hint {
+  color: var(--web-spruce);
+  font-size: 12px;
+  font-weight: 300;
+}
+
+.kiosk__input {
+  width: 100%;
+  height: 52px;
+  padding: 0 1rem;
+  font-size: 16px; /* >=16px stops iOS Safari zoom-on-focus */
+  color: var(--web-ash);
+  background: #fff;
+  border: 1px solid rgba(87, 108, 117, 0.35);
+  border-radius: 3px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.kiosk__input::placeholder {
+  color: rgba(87, 108, 117, 0.5);
+}
+
+.kiosk__input:focus {
+  outline: none;
+  border-color: var(--web-spruce);
+  box-shadow: 0 0 0 3px rgba(87, 108, 117, 0.12);
+}
+
+.kiosk__input--error {
+  border-color: #b4534b;
+}
+
+textarea.kiosk__input {
+  height: auto;
+  min-height: 64px;
+  padding: 0.7rem 1rem;
+  line-height: 1.5;
+  resize: none;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Interest chips                                                              */
+/* -------------------------------------------------------------------------- */
+
+.kiosk__chips {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.kiosk__chip {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.7rem 0.85rem;
+  font-size: 14px;
+  font-weight: 400;
+  text-align: left;
+  line-height: 1.25;
+  color: var(--web-ash);
+  background: #fff;
+  border: 1px solid rgba(87, 108, 117, 0.3);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.kiosk__chip:hover {
+  border-color: var(--web-spruce);
+}
+
+.kiosk__chip--selected {
+  background: var(--web-spruce);
+  border-color: var(--web-spruce);
+  color: var(--web-off-white);
+}
+
+.kiosk__chip-check {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border-radius: 999px;
+  border: 1px solid rgba(87, 108, 117, 0.45);
+}
+
+.kiosk__chip--selected .kiosk__chip-check {
+  background: var(--web-off-white);
+  border-color: var(--web-off-white);
+  color: var(--web-spruce);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Footer / actions                                                           */
+/* -------------------------------------------------------------------------- */
+
+.kiosk__footer {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: clamp(1rem, 2.5vw, 1.5rem) clamp(1.5rem, 4vw, 3rem);
+  border-top: 1px solid rgba(166, 181, 176, 0.25);
+  background: rgba(242, 239, 234, 0.5);
+}
+
+.kiosk__error {
+  color: #b4534b;
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.kiosk__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  height: 60px;
+  padding: 0 clamp(2rem, 5vw, 3.5rem);
+  font-size: 14px;
+  font-weight: 400;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--web-off-white);
+  background: var(--web-spruce);
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+.kiosk__submit:hover {
+  background: #4c606a;
+}
+
+.kiosk__submit:active {
+  transform: translateY(1px);
+}
+
+.kiosk__submit:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.kiosk__submit--block {
+  width: 100%;
+}
+
+.kiosk__spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  border: 2px solid rgba(242, 239, 234, 0.4);
+  border-top-color: var(--web-off-white);
+  animation: kiosk-spin 0.7s linear infinite;
+}
+
+@keyframes kiosk-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Exit affordance — discreet so guests don't tap it, reachable for staff     */
+/* -------------------------------------------------------------------------- */
+
+/* Deliberately faint + tiny so a guest won't notice or accidentally tap it.
+   Reachable for staff, and the confirm() dialog is a second safety net. */
+.kiosk__exit {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  color: rgba(87, 108, 117, 0.22);
+  background: transparent;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+
+.kiosk__exit:hover,
+.kiosk__exit:focus-visible {
+  color: var(--web-spruce);
+  background: rgba(87, 108, 117, 0.1);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Setup screen                                                               */
+/* -------------------------------------------------------------------------- */
+
+.kiosk__setup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  width: 100%;
+  max-width: 520px;
+  padding: clamp(2.25rem, 5vw, 3.5rem);
+  /* White card so the dark setup copy reads against the hero backdrop */
+  background: #fff;
+  border-radius: 4px;
+  box-shadow: 0 30px 80px -20px rgba(63, 65, 66, 0.35);
+}
+
+.kiosk__setup-title {
+  font-family: var(--font-headline), Georgia, serif;
+  color: var(--web-ash);
+  font-size: clamp(26px, 4vw, 38px);
+  font-weight: 400;
+  line-height: 1.15;
+  margin-bottom: 0.5rem;
+}
+
+.kiosk__setup-sub {
+  color: var(--web-spruce);
+  font-size: 15px;
+  font-weight: 300;
+  margin-bottom: 2rem;
+}
+
+.kiosk__setup-form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Thank-you screen                                                           */
+/* -------------------------------------------------------------------------- */
+
+.kiosk__thanks {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  flex: 1 1 auto;
+  padding: clamp(2.5rem, 8vw, 5rem);
+  animation: kiosk-fade-in 0.4s ease;
+}
+
+.kiosk__thanks-mark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 88px;
+  height: 88px;
+  border-radius: 999px;
+  color: var(--web-off-white);
+  background: var(--web-spruce);
+  margin-bottom: 1.75rem;
+}
+
+.kiosk__thanks-title {
+  font-family: var(--font-headline), Georgia, serif;
+  color: var(--web-ash);
+  font-size: clamp(30px, 5vw, 46px);
+  font-weight: 400;
+  line-height: 1.1;
+  margin-bottom: 0.75rem;
+}
+
+.kiosk__thanks-sub {
+  color: var(--web-spruce);
+  font-size: clamp(15px, 2vw, 18px);
+  font-weight: 300;
+  max-width: 440px;
+}
+
+.kiosk__thanks-next {
+  margin-top: 2.5rem;
+}
+
+@keyframes kiosk-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* react-phone-number-input lives inside .kiosk__input wrapper to match height */
+.kiosk .kiosk-phone {
+  display: flex;
+  align-items: center;
+  height: 52px;
+  padding: 0 1rem;
+  background: #fff;
+  border: 1px solid rgba(87, 108, 117, 0.35);
+  border-radius: 3px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.kiosk .kiosk-phone:focus-within {
+  border-color: var(--web-spruce);
+  box-shadow: 0 0 0 3px rgba(87, 108, 117, 0.12);
+}
+
+.kiosk .kiosk-phone--error {
+  border-color: #b4534b;
+}
+
+.kiosk .kiosk-phone .PhoneInputInput {
+  border: none;
+  outline: none;
+  font-size: 16px;
+  color: var(--web-ash);
+  background: transparent;
+}
+
+.kiosk .kiosk-phone .PhoneInputCountrySelect {
+  color: var(--web-ash);
+}

--- a/app/(kiosk)/layout.tsx
+++ b/app/(kiosk)/layout.tsx
@@ -1,0 +1,27 @@
+/**
+ * CATALYST - Kiosk Route Group Layout
+ *
+ * A deliberately chrome-free shell for full-screen kiosk surfaces (e.g. the
+ * event registration iPad). No WebShell, no nav, no footer — the page owns
+ * the entire viewport so a guest sees only the task in front of them.
+ *
+ * Self-contained: brings its own styles via kiosk.css. Delete this group to
+ * remove every kiosk surface.
+ */
+
+import "./kiosk.css"
+import type { Metadata } from "next"
+
+// Kiosk pages are operational tools, never public content — keep them out of
+// search results entirely.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+}
+
+export default function KioskGroupLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <>{children}</>
+}

--- a/app/(kiosk)/register/_components/event-kiosk.tsx
+++ b/app/(kiosk)/register/_components/event-kiosk.tsx
@@ -1,0 +1,497 @@
+/**
+ * CATALYST - Event Kiosk
+ *
+ * Three phases on one screen:
+ *   1. setup    — staff name the event, then tap Start to lock into kiosk mode
+ *   2. form      — the guest registers (name, email/WhatsApp, interests, comment)
+ *   3. thank-you — confirmation, then auto-reset to a fresh form for the next guest
+ *
+ * Reuses the lead framework by POSTing to /api/leads with formMode "event" —
+ * identical validation + AgentCRM forwarding as the website forms.
+ *
+ * Kiosk-specific attribution: we deliberately do NOT use useAttribution. Its
+ * sessionId / first-touch live in device cookies, so on a shared iPad every
+ * guest would collapse into one CRM "session". Instead we mint a fresh UUID
+ * per guest and tag the source as utmSource=event / utmMedium=kiosk.
+ */
+
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { CheckIcon, ArrowRightIcon, XIcon } from "lucide-react"
+import { PhoneInput, isValidPhoneNumber } from "@/components/ui/phone-input/phone-input"
+import { generateSubmissionId } from "@/lib/hooks/use-attribution"
+import { cn } from "@/lib/utils"
+
+// -----------------------------------------------------------------------------
+// Interest options
+//
+// Values are sent to AgentCRM as `goals`. Where a value matches the canonical
+// LeadGoal vocabulary ("sell", "buy-ready", "build-wealth", "advice-only") the
+// CRM uses it for routing — notably "sell" routes the lead to the vendor
+// pipeline. The rest are event-specific tags carried as opaque metadata.
+// -----------------------------------------------------------------------------
+
+const INTERESTS: { value: string; label: string }[] = [
+  { value: "buy-ready", label: "Buying property" },
+  { value: "build-wealth", label: "Building an investment portfolio" },
+  { value: "advice-only", label: "Strategic investment advice" },
+  { value: "business-setup", label: "Setting up a business in Dubai" },
+  { value: "development", label: "Building / developing in Dubai" },
+  { value: "sell", label: "Selling property" },
+  { value: "commercial", label: "Commercial property" },
+  { value: "residential", label: "Residential property" },
+]
+
+const SESSION_KEY = "pc_kiosk_session"
+const THANKS_RESET_MS = 5000
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+type Phase = "setup" | "form" | "thanks"
+
+interface KioskSession {
+  eventName: string
+  eventTag: string
+}
+
+interface EventKioskProps {
+  initialEventName?: string
+}
+
+/** Slugify an event name into a stable, CRM-friendly tag, e.g. "event-cityscape-2026". */
+function toEventTag(eventName: string): string {
+  const slug = eventName
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return slug ? `event-${slug}` : "event"
+}
+
+/** Fresh UUID per guest — keeps each registration independent in the CRM. */
+function freshId(): string {
+  return generateSubmissionId()
+}
+
+export function EventKiosk({ initialEventName = "" }: EventKioskProps) {
+  const [phase, setPhase] = useState<Phase>("setup")
+  const [eventName, setEventName] = useState(initialEventName)
+  const [eventTag, setEventTag] = useState("")
+
+  // Guest form state
+  const [fullName, setFullName] = useState("")
+  const [email, setEmail] = useState("")
+  const [whatsapp, setWhatsapp] = useState("")
+  const [interests, setInterests] = useState<string[]>([])
+  const [comment, setComment] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const nameInputRef = useRef<HTMLInputElement>(null)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Stable identifiers for the guest currently filling the form. Reused across
+  // retries so AgentCRM dedupes a re-submit instead of creating duplicates;
+  // cleared on reset so the next guest is a brand-new lead.
+  const guestIdsRef = useRef<{ submissionId: string; sessionId: string } | null>(null)
+
+  const ensureGuestIds = () => {
+    if (!guestIdsRef.current) {
+      guestIdsRef.current = { submissionId: freshId(), sessionId: freshId() }
+    }
+    return guestIdsRef.current
+  }
+
+  // Resume an active kiosk after an accidental refresh — staff shouldn't have
+  // to re-enter the event name if the iPad reloads mid-event.
+  useEffect(() => {
+    try {
+      const raw = window.sessionStorage.getItem(SESSION_KEY)
+      if (!raw) return
+      const saved = JSON.parse(raw) as KioskSession
+      if (saved?.eventName) {
+        setEventName(saved.eventName)
+        setEventTag(saved.eventTag || toEventTag(saved.eventName))
+        setPhase("form")
+      }
+    } catch {
+      /* ignore malformed session */
+    }
+  }, [])
+
+  // Focus the first field whenever the blank form is shown.
+  useEffect(() => {
+    if (phase === "form") nameInputRef.current?.focus({ preventScroll: true })
+  }, [phase])
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current) clearTimeout(resetTimer.current)
+    }
+  }, [])
+
+  const resetGuestForm = useCallback(() => {
+    setFullName("")
+    setEmail("")
+    setWhatsapp("")
+    setInterests([])
+    setComment("")
+    setError(null)
+    // Next guest is a new lead — drop the previous guest's ids.
+    guestIdsRef.current = null
+  }, [])
+
+  // ---- Setup phase ----------------------------------------------------------
+
+  const handleStart = (e: React.FormEvent) => {
+    e.preventDefault()
+    const name = eventName.trim()
+    if (!name) {
+      setError("Enter the event name to start")
+      return
+    }
+    const tag = toEventTag(name)
+    setEventName(name)
+    setEventTag(tag)
+    setError(null)
+    try {
+      window.sessionStorage.setItem(
+        SESSION_KEY,
+        JSON.stringify({ eventName: name, eventTag: tag } satisfies KioskSession),
+      )
+    } catch {
+      /* non-fatal — kiosk still works, just won't survive a refresh */
+    }
+    resetGuestForm()
+    setPhase("form")
+  }
+
+  const handleExit = () => {
+    if (!window.confirm("End this kiosk session and return to setup?")) return
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+    try {
+      window.sessionStorage.removeItem(SESSION_KEY)
+    } catch {
+      /* ignore */
+    }
+    resetGuestForm()
+    setPhase("setup")
+  }
+
+  // ---- Guest submission -----------------------------------------------------
+
+  const toggleInterest = (value: string) => {
+    setInterests((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value],
+    )
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (isSubmitting) return
+
+    const name = fullName.trim().replace(/\s+/g, " ")
+    const trimmedEmail = email.trim()
+    const phone = whatsapp.trim()
+
+    if (!name) {
+      setError("Please enter a name")
+      return
+    }
+
+    const hasEmail = trimmedEmail.length > 0
+    const hasPhone = phone.length > 0
+    if (!hasEmail && !hasPhone) {
+      setError("Add an email or a WhatsApp number")
+      return
+    }
+    if (hasEmail && !EMAIL_REGEX.test(trimmedEmail)) {
+      setError("That email doesn't look right")
+      return
+    }
+    if (hasPhone && !isValidPhoneNumber(phone)) {
+      setError("That WhatsApp number doesn't look right")
+      return
+    }
+
+    const [firstName, ...rest] = name.split(" ")
+    const lastName = rest.join(" ")
+
+    // Same ids for every retry of this guest; fresh per guest (see resetGuestForm).
+    const ids = ensureGuestIds()
+
+    setIsSubmitting(true)
+    setError(null)
+
+    try {
+      const response = await fetch("/api/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          // Identity
+          firstName,
+          lastName: lastName || undefined,
+          email: hasEmail ? trimmedEmail : undefined,
+          whatsapp: hasPhone ? phone : undefined,
+
+          // Form context — event name lives in leadMagnet, event slug in leadTag
+          formMode: "event",
+          leadMagnet: eventName,
+          leadTag: eventTag,
+
+          // What they're interested in + their note
+          goals: interests.length ? interests : undefined,
+          enquiryNotes: comment.trim() || undefined,
+
+          // Source attribution — these came from a live event kiosk
+          utmSource: "event",
+          utmMedium: "kiosk",
+          utmCampaign: eventTag,
+
+          // Per-guest identity (fresh so a shared iPad doesn't merge people;
+          // stable across retries so AgentCRM dedupes a re-submit)
+          submissionId: ids.submissionId,
+          sessionId: ids.sessionId,
+
+          submittedAt: new Date().toISOString(),
+          pageUrl: typeof window !== "undefined" ? window.location.href : "",
+        }),
+      })
+
+      if (!response.ok) {
+        const result = await response.json().catch(() => null)
+        throw new Error(result?.error || "Could not save — please try again")
+      }
+
+      setPhase("thanks")
+      resetTimer.current = setTimeout(() => {
+        resetGuestForm()
+        setPhase("form")
+      }, THANKS_RESET_MS)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleRegisterNext = () => {
+    if (resetTimer.current) clearTimeout(resetTimer.current)
+    resetGuestForm()
+    setPhase("form")
+  }
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  if (phase === "setup") {
+    return (
+      <div className="kiosk">
+        <div className="kiosk__setup">
+          <h1 className="kiosk__setup-title">Event Registration</h1>
+          <p className="kiosk__setup-sub">
+            Name this event, then start the kiosk. Guests register on the next screen.
+          </p>
+          <form className="kiosk__setup-form" onSubmit={handleStart}>
+            <div className="kiosk__field">
+              <label htmlFor="event-name" className="kiosk__label">
+                Event name
+              </label>
+              <input
+                id="event-name"
+                type="text"
+                className={cn("kiosk__input", error && "kiosk__input--error")}
+                value={eventName}
+                onChange={(e) => setEventName(e.target.value)}
+                placeholder="e.g. Cityscape Global 2026"
+                autoFocus
+                autoComplete="off"
+              />
+            </div>
+            {error && <span className="kiosk__error">{error}</span>}
+            <button type="submit" className="kiosk__submit kiosk__submit--block">
+              Start Registration
+              <ArrowRightIcon className="h-4 w-4" />
+            </button>
+          </form>
+        </div>
+      </div>
+    )
+  }
+
+  if (phase === "thanks") {
+    return (
+      <div className="kiosk">
+        <div className="kiosk__card">
+          <div className="kiosk__thanks">
+            <div className="kiosk__thanks-mark">
+              <CheckIcon className="h-11 w-11" strokeWidth={1.5} />
+            </div>
+            <h2 className="kiosk__thanks-title">Thank you</h2>
+            <p className="kiosk__thanks-sub">
+              You&apos;re registered. A member of the Prime Capital team will be in touch shortly.
+            </p>
+            <button
+              type="button"
+              className="kiosk__submit kiosk__thanks-next"
+              onClick={handleRegisterNext}
+            >
+              Register next guest
+              <ArrowRightIcon className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // phase === "form"
+  return (
+    <div className="kiosk">
+      <form className="kiosk__card" onSubmit={handleSubmit}>
+        <button
+          type="button"
+          className="kiosk__exit"
+          onClick={handleExit}
+          aria-label="End kiosk session"
+          title="End kiosk session"
+        >
+          <XIcon className="h-3.5 w-3.5" />
+        </button>
+
+        <header className="kiosk__header">
+          <span className="kiosk__eyebrow">Register your interest</span>
+          <h1 className="kiosk__event-name">{eventName}</h1>
+          <p className="kiosk__subtitle">
+            Leave your details and we&apos;ll follow up after the event.
+          </p>
+        </header>
+
+        <div className="kiosk__body">
+          <div className="kiosk__grid">
+            {/* Left column — contact */}
+            <div>
+              <div className="kiosk__field">
+                <label htmlFor="full-name" className="kiosk__label">
+                  Name
+                </label>
+                <input
+                  ref={nameInputRef}
+                  id="full-name"
+                  type="text"
+                  className="kiosk__input"
+                  value={fullName}
+                  onChange={(e) => setFullName(e.target.value)}
+                  placeholder="Full name"
+                  autoComplete="off"
+                />
+              </div>
+
+              <div className="kiosk__field">
+                <label htmlFor="email" className="kiosk__label">
+                  Email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  className="kiosk__input"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="your@email.com"
+                  autoComplete="off"
+                  inputMode="email"
+                />
+              </div>
+
+              <div className="kiosk__field">
+                <label htmlFor="whatsapp" className="kiosk__label">
+                  WhatsApp / Mobile
+                </label>
+                <PhoneInput
+                  id="whatsapp"
+                  className="kiosk-phone"
+                  value={whatsapp}
+                  onChange={(v) => setWhatsapp(v ?? "")}
+                  placeholder="50 123 4567"
+                  autoComplete="off"
+                />
+                <span className="kiosk__hint">Email or WhatsApp — either is fine.</span>
+              </div>
+            </div>
+
+            {/* Right column — interests + comment */}
+            <div>
+              <div className="kiosk__field">
+                <span className="kiosk__label">What are you interested in?</span>
+                <div className="kiosk__chips" role="group" aria-label="Interests">
+                  {INTERESTS.map((interest) => {
+                    const selected = interests.includes(interest.value)
+                    return (
+                      <button
+                        key={interest.value}
+                        type="button"
+                        className={cn(
+                          "kiosk__chip",
+                          selected && "kiosk__chip--selected",
+                        )}
+                        aria-pressed={selected}
+                        onClick={() => toggleInterest(interest.value)}
+                      >
+                        <span className="kiosk__chip-check">
+                          {selected && <CheckIcon className="h-3 w-3" strokeWidth={2.5} />}
+                        </span>
+                        {interest.label}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <div className="kiosk__field">
+                <label htmlFor="comment" className="kiosk__label">
+                  Anything else? <span className="kiosk__hint">(optional)</span>
+                </label>
+                <textarea
+                  id="comment"
+                  className="kiosk__input"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  placeholder="A quick note about what you're looking for…"
+                  rows={2}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer className="kiosk__footer">
+          {error ? (
+            <span className="kiosk__error" role="alert">
+              {error}
+            </span>
+          ) : (
+            <span className="kiosk__hint">Takes 30 seconds.</span>
+          )}
+          <button
+            type="submit"
+            className="kiosk__submit"
+            style={{ marginLeft: "auto" }}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <span className="kiosk__spinner" />
+                Saving…
+              </>
+            ) : (
+              <>
+                Register
+                <ArrowRightIcon className="h-4 w-4" />
+              </>
+            )}
+          </button>
+        </footer>
+      </form>
+    </div>
+  )
+}

--- a/app/(kiosk)/register/page.tsx
+++ b/app/(kiosk)/register/page.tsx
@@ -1,0 +1,36 @@
+/**
+ * CATALYST - Event Registration Kiosk
+ *
+ * Route: /register
+ *
+ * A dead-simple, full-screen registration form Prime runs on an iPad at a
+ * stand or event. Staff open the URL, type the event name, and tap "Start" to
+ * drop into kiosk mode. Each guest enters their details in one no-scroll
+ * screen; on submit they see a thank-you and the form resets for the next
+ * person.
+ *
+ * Leads flow through the SAME pipeline as the website (`POST /api/leads`,
+ * formMode "event") so every registration lands in AgentCRM with full
+ * metadata. See ./_components/event-kiosk for the payload contract.
+ *
+ * Usage:
+ *   /register                       → staff type the event name on the setup screen
+ *   /register?event=Cityscape%202026 → event name pre-filled, one tap to start
+ */
+
+import type { Metadata } from "next"
+import { EventKiosk } from "./_components/event-kiosk"
+
+export const metadata: Metadata = {
+  title: "Event Registration",
+  robots: { index: false, follow: false },
+}
+
+interface PageProps {
+  searchParams: Promise<{ event?: string }>
+}
+
+export default async function RegisterKioskPage({ searchParams }: PageProps) {
+  const { event } = await searchParams
+  return <EventKiosk initialEventName={event ?? ""} />
+}

--- a/app/(web)/sell/page.tsx
+++ b/app/(web)/sell/page.tsx
@@ -186,6 +186,9 @@ function HeroSection() {
                     mode="landing"
                     theme="light"
                     tag="seller"
+                    // Seller intent — routes the lead to AgentCRM as
+                    // visitorType "seller" (Leads pipeline), not "vendor".
+                    initialData={{ goals: ["sell"] }}
                     showPropertyFields
                     showConcerns
                     calendlyUrl={config.links.calendlySeller}

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -400,9 +400,10 @@ function getFormName(formMode: string, pageUrl: string): string {
  *   - vendor:   ONLY when a form sets visitorType "vendor" explicitly (e.g. an
  *               introducer / partner / service-provider application).
  *   - agent:    someone applying to be an introducer/agent (set explicitly).
- *   - seller:   a consumer selling their OWN property (goals include "sell").
- *               Routed to Leads, not Partners. "sell" stays in `goals`.
- *   - investor: default, everything else.
+ *   - seller:   a consumer selling their OWN property with no buy/investment
+ *               intent. Routed to Leads, not Partners. "sell" stays in `goals`.
+ *   - investor: default — including a "sell" goal combined with any
+ *               buy/investment intent (matches the event-kiosk logic).
  *
  * Event leads use deriveVisitorTypeForCrm() below (seller/investor only).
  */
@@ -413,8 +414,9 @@ function deriveVisitorType(
   if (explicit === "agent" || explicit === "vendor" || explicit === "investor") {
     return explicit
   }
-  if (goals?.includes("sell")) return "seller"
-  return "investor"
+  // Same seller/investor split as event leads — keeps the website and kiosk
+  // aligned so no property seller is ever filed as a Partner.
+  return deriveEventVisitorType(goals)
 }
 
 /**

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -393,31 +393,75 @@ function getFormName(formMode: string, pageUrl: string): string {
 // =============================================================================
 
 /**
- * AgentCRM doesn't recognise "event" as a formMode — events are filed as
- * `contact` with the event name in formName + leadMagnet. Everything else
- * passes through unchanged.
- */
-function mapFormModeForCrm(mode: string): string {
-  return mode === "event" ? "contact" : mode
-}
-
-/**
- * Pipeline router for the CRM:
- *   - vendor: someone selling property (goals includes "sell" OR landing
- *     page with seller intent set the visitorType already)
- *   - agent: someone applying to be an introducer/agent (set explicitly
- *     via the form prop — no goals signal for this yet)
- *   - investor: default, everything else
+ * Pipeline router for the CRM. In AgentCRM "vendor" means a partner /
+ * service-provider (filed under Partners), NOT a property seller — so a
+ * consumer selling their own home must never be routed there.
+ *
+ *   - vendor:   ONLY when a form sets visitorType "vendor" explicitly (e.g. an
+ *               introducer / partner / service-provider application).
+ *   - agent:    someone applying to be an introducer/agent (set explicitly).
+ *   - seller:   a consumer selling their OWN property (goals include "sell").
+ *               Routed to Leads, not Partners. "sell" stays in `goals`.
+ *   - investor: default, everything else.
+ *
+ * Event leads use deriveVisitorTypeForCrm() below (seller/investor only).
  */
 function deriveVisitorType(
   goals: string[] | undefined,
   explicit: string | undefined,
-): "investor" | "agent" | "vendor" {
+): "investor" | "agent" | "vendor" | "seller" {
   if (explicit === "agent" || explicit === "vendor" || explicit === "investor") {
     return explicit
   }
-  if (goals?.includes("sell")) return "vendor"
+  if (goals?.includes("sell")) return "seller"
   return "investor"
+}
+
+/**
+ * Goals that signal buy-side / investment intent. Used to tell a pure property
+ * seller (→ "seller") apart from an active buyer/investor (→ "investor") for
+ * event leads. Covers both the kiosk's interest codes and the canonical
+ * website LeadGoal values. Tune this list to change seller/investor routing.
+ */
+const BUY_INVESTMENT_GOALS = new Set([
+  "buy-ready",
+  "build-wealth",
+  "advice-only",
+  "commercial",
+  "residential",
+  "invest-offplan",
+  "golden-visa",
+])
+
+/**
+ * Event-lead pipeline router for AgentCRM. Unlike the website router this
+ * NEVER emits "vendor" (AgentCRM reserves "vendor" for partners/service
+ * providers):
+ *   - "seller":   wants to sell AND shows no buy/investment intent
+ *   - "investor": everything else — buy / invest / advice / commercial /
+ *                 residential, or "sell" combined with any of those
+ * "sell" always stays in `goals` regardless of the routed type.
+ */
+function deriveEventVisitorType(goals: string[] | undefined): "investor" | "seller" {
+  const g = goals ?? []
+  const hasSell = g.includes("sell")
+  const hasBuyInvestment = g.some((x) => BUY_INVESTMENT_GOALS.has(x))
+  return hasSell && !hasBuyInvestment ? "seller" : "investor"
+}
+
+/**
+ * Choose the CRM pipeline router by form type. Event leads (kiosk + livestream)
+ * use the seller/investor logic; every other form keeps the legacy router.
+ */
+function deriveVisitorTypeForCrm(leadData: {
+  formMode: string
+  goals?: string[]
+  visitorType?: string
+}): string {
+  if (leadData.formMode === "event") {
+    return deriveEventVisitorType(leadData.goals)
+  }
+  return deriveVisitorType(leadData.goals, leadData.visitorType)
 }
 
 /**
@@ -517,6 +561,10 @@ const leadSchema = z
     // Lead magnet + tagging for CRM categorisation
     leadMagnet: z.string().max(200).optional(),
     leadTag: z.string().max(100).optional(),
+
+    // Lifecycle / stage marker (event leads default to "prospect")
+    leadLifecycle: z.string().max(50).optional(),
+    leadStage: z.string().max(50).optional(),
 
     // Pipeline router
     visitorType: z.enum(["investor", "agent", "vendor"]).optional(),
@@ -657,7 +705,7 @@ interface ForwardResult {
  *   - referringProperty → propertyRef
  *   - referringTeamMember → assigneeSlug, teamMemberEmail → assigneeEmail
  *   - questionsText / enquiryNotes / concerns / privateContext → message
- *   - formMode "event" → "contact" (event name stays in formName + leadMagnet)
+ *   - formMode passes through unchanged (AgentCRM accepts "event")
  */
 function buildAgentCrmPayload(
   leadData: LeadData,
@@ -666,14 +714,13 @@ function buildAgentCrmPayload(
   resolvedAssigneeEmail: string | null,
   siteSource: string,
 ) {
-  const visitorType = deriveVisitorType(leadData.goals, leadData.visitorType)
+  const isEvent = leadData.formMode === "event"
+  const visitorType = deriveVisitorTypeForCrm(leadData)
   const formName = getFormName(leadData.formMode, leadData.pageUrl)
   // For events, the form name already includes the page (e.g. "Event
-  // Registration - Livestream"). Use it as the leadMagnet so the CRM has a
-  // single field carrying event identity, since formMode collapses to "contact".
-  const leadMagnet =
-    leadData.leadMagnet ||
-    (leadData.formMode === "event" ? formName : undefined)
+  // Registration - Livestream"). Use it as the leadMagnet so the CRM always
+  // has a single field carrying event identity even if the client didn't set one.
+  const leadMagnet = leadData.leadMagnet || (isEvent ? formName : undefined)
 
   const payload: Record<string, unknown> = {
     // Identity
@@ -683,10 +730,13 @@ function buildAgentCrmPayload(
     phone: leadData.whatsapp || undefined,
     whatsapp: leadData.whatsapp || undefined,
 
-    // Form context
-    formMode: mapFormModeForCrm(leadData.formMode),
+    // Form context — formMode passes through unchanged (AgentCRM accepts "event")
+    formMode: leadData.formMode,
     formName,
     leadMagnet,
+    // Lifecycle marker — event leads enter AgentCRM as prospects
+    leadLifecycle: leadData.leadLifecycle || (isEvent ? "prospect" : undefined),
+    leadStage: leadData.leadStage || (isEvent ? "prospect" : undefined),
     pageUrl: leadData.pageUrl,
     visitorType,
     submissionId,
@@ -966,8 +1016,8 @@ export async function POST(request: NextRequest) {
       targetPriceLabel: leadData.targetPrice ? BITRIX_BUDGET_LABELS[leadData.targetPrice] : null,
       targetPriceCode: leadData.targetPrice ? BITRIX_TARGET_PRICE_CODES[leadData.targetPrice] : null,
 
-      // Server-derived pipeline router
-      visitorType: deriveVisitorType(leadData.goals, leadData.visitorType),
+      // Server-derived pipeline router (event leads never route to "vendor")
+      visitorType: deriveVisitorTypeForCrm(leadData),
 
       // Server-enriched property data
       propertyInterest: property?.ref || leadData.referringProperty || null,

--- a/docs/integrations/agentcrm-event-kiosk-payload.md
+++ b/docs/integrations/agentcrm-event-kiosk-payload.md
@@ -1,0 +1,217 @@
+# AgentCRM — Event Kiosk Registration Payload
+
+This describes the exact JSON Prime Capital sends to AgentCRM when a guest
+completes a registration on the **event kiosk** (the iPad form Prime runs at a
+stand/event). Share this with the AgentCRM team so they can map the fields and
+configure event handling.
+
+---
+
+## Transport
+
+| | |
+|---|---|
+| **Method** | `POST` |
+| **Endpoint** | `https://crm.primecapitaldubai.com/api/public/enquiry` *(value of `AGENTCRM_API_URL`)* |
+| **Auth** | `Authorization: Bearer <AGENTCRM_API_KEY>` |
+| **Content-Type** | `application/json` |
+| **Max body size** | 64 KB |
+| **Trigger** | One request per completed kiosk registration |
+
+The kiosk feeds the same enquiry endpoint as the website forms. What identifies
+it as an **event** submission: `formMode: "event"`, `utmMedium: "kiosk"`,
+`utmSource: "event"`, and the event name/slug in `leadMagnet` / `leadTag`.
+Event leads are marked with `leadLifecycle` / `leadStage` = `"prospect"`.
+
+---
+
+## Example payload (typical event registration)
+
+```json
+{
+  "firstName": "Aisha",
+  "lastName": "Khan",
+  "email": "aisha@example.com",
+  "phone": "+971501234567",
+  "whatsapp": "+971501234567",
+
+  "formMode": "event",
+  "formName": "event-registration-register",
+  "leadLifecycle": "prospect",
+  "leadStage": "prospect",
+
+  "leadMagnet": "Cityscape Global 2026",
+  "leadTag": "event-cityscape-global-2026",
+  "pageUrl": "https://primecapitaldubai.com/register",
+
+  "visitorType": "investor",
+  "goals": ["buy-ready", "business-setup"],
+  "message": "Looking for a 2BR in Marina under 3M",
+  "enquiryNotes": "Looking for a 2BR in Marina under 3M",
+
+  "utmSource": "event",
+  "utmMedium": "kiosk",
+  "utmCampaign": "event-cityscape-global-2026",
+
+  "submissionId": "11111111-1111-4111-8111-111111111111",
+  "sessionId": "22222222-2222-4222-8222-222222222222",
+  "submittedAt": "2026-06-25T10:00:00.000Z",
+
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+Fields whose value is `undefined` are **omitted** from the JSON (not sent as
+null). The exceptions are `assigneeEmail`, `teamMemberEmail` (sent as `null`
+when no agent is pre-assigned — always the case for the kiosk) and `website`
+(sent as `""`).
+
+---
+
+## Field reference
+
+### Identity (who registered)
+
+| Field | Type | Presence | Notes |
+|---|---|---|---|
+| `firstName` | string | **always** | First token of the name they typed. |
+| `lastName` | string | optional | Remainder of the name; omitted if they gave a single word. |
+| `email` | string | conditional | Present if provided. **Either `email` or `phone` is always present** (guests give one or the other). |
+| `phone` | string (E.164) | conditional | The mobile/WhatsApp number, e.g. `+971501234567`. Present whenever a number is captured. |
+| `whatsapp` | string (E.164) | conditional | Same value as `phone` — WhatsApp-first. Both are set together when a number is captured. |
+
+### Event identity, lifecycle & source
+
+| Field | Type | Presence | Notes |
+|---|---|---|---|
+| `formMode` | string | **always** | Always `"event"` for kiosk leads. |
+| `formName` | string | **always** | Auto-derived, e.g. `"event-registration-register"`. |
+| `leadLifecycle` | string | **always** | Always `"prospect"` — explicit marker that event leads enter as prospects. |
+| `leadStage` | string | **always** | Always `"prospect"` (same marker, duplicated for whichever field AgentCRM keys on). |
+| `leadMagnet` | string | **always** | **The human-readable event name** staff typed, e.g. `"Cityscape Global 2026"`. |
+| `leadTag` | string | **always** | **Machine slug for the event**, `event-<slug>`, e.g. `"event-cityscape-global-2026"`. Use this to group/segment all leads from one event. |
+| `utmSource` | string | **always** | Always `"event"`. |
+| `utmMedium` | string | **always** | Always `"kiosk"`. Identifies the lead as captured live on the iPad. |
+| `utmCampaign` | string | **always** | Same value as `leadTag` (the event slug). |
+| `pageUrl` | string | **always** | The kiosk URL. |
+| `_source` | string | **always** | Always `"prime-capital-website"` (the originating system). |
+
+### Interest & routing (what they want)
+
+| Field | Type | Presence | Notes |
+|---|---|---|---|
+| `goals` | string[] | optional | The interests the guest selected. Omitted if none selected. See vocabulary below. |
+| `message` | string | optional | The guest's free-text comment. |
+| `enquiryNotes` | string | optional | Same value as `message` (raw copy of the comment). |
+| `visitorType` | string | **always** | Pipeline router — **only ever `"investor"` or `"seller"` for kiosk leads, never `"vendor"`.** See routing rules below. |
+
+### Tracking & assignment
+
+| Field | Type | Presence | Notes |
+|---|---|---|---|
+| `submissionId` | string (UUID v4) | **always** | Unique per registration, **reused on retries**. Use for de-duplication / idempotency — a re-submit carries the same id. |
+| `sessionId` | string (UUID v4) | **always** | Unique per guest. Each kiosk registration is independent — the shared iPad does **not** reuse one session across guests. |
+| `submittedAt` | string (ISO 8601) | **always** | UTC timestamp of submission. |
+| `assigneeEmail` | string \| null | **always** | `null` for kiosk leads — no agent is pre-assigned. AgentCRM should assign/round-robin these. |
+| `teamMemberEmail` | string \| null | **always** | `null` for kiosk leads (same as above). |
+| `website` | string | **always** | Honeypot field; always `""` from the kiosk. A non-empty value indicates a bot. |
+
+> Fields used by other Prime forms (e.g. `budget`, `propertyTypes`, `locations`,
+> `propertyRef`, `developerName`, `investTimeline`, Calendly meeting fields) are
+> **not sent** by the kiosk and will be absent.
+
+---
+
+## `visitorType` routing rules (kiosk leads)
+
+`vendor` is **never** sent for kiosk leads — in AgentCRM `vendor` means a
+partner / service-provider, not a property seller. Instead:
+
+| Guest's `goals` | `visitorType` |
+|---|---|
+| Includes `"sell"` **and no** buy/investment goal | `"seller"` |
+| Includes `"sell"` **and** a buy/investment goal | `"investor"` (and `"sell"` stays in `goals`) |
+| Any buy / investment / advice / commercial / residential intent (no sell) | `"investor"` |
+| No goals selected | `"investor"` |
+
+"Buy/investment goals" = `buy-ready`, `build-wealth`, `advice-only`,
+`commercial`, `residential` (plus the canonical website goals `invest-offplan`,
+`golden-visa`).
+
+---
+
+## Interest vocabulary (`goals`)
+
+The kiosk sends these exact string codes. Suggested human labels for display:
+
+| Code | Label | Routing signal |
+|---|---|---|
+| `buy-ready` | Buying property | buy/investment → investor |
+| `build-wealth` | Building an investment portfolio | buy/investment → investor |
+| `advice-only` | Strategic investment advice | buy/investment → investor |
+| `business-setup` | Setting up a business in Dubai | neutral |
+| `development` | Building / developing in Dubai | neutral |
+| `sell` | Selling property | seller (unless a buy/investment goal is also present) |
+| `commercial` | Commercial property | buy/investment → investor |
+| `residential` | Residential property | buy/investment → investor |
+
+A guest may select multiple, so `goals` can mix codes (e.g.
+`["buy-ready", "commercial"]`). `"sell"` is always preserved in `goals`
+regardless of the routed `visitorType`.
+
+---
+
+## Minimal payload (guest gave only a name + WhatsApp, no interests/comment)
+
+```json
+{
+  "firstName": "Omar",
+  "phone": "+971559876543",
+  "whatsapp": "+971559876543",
+  "formMode": "event",
+  "formName": "event-registration-register",
+  "leadLifecycle": "prospect",
+  "leadStage": "prospect",
+  "leadMagnet": "Cityscape Global 2026",
+  "leadTag": "event-cityscape-global-2026",
+  "pageUrl": "https://primecapitaldubai.com/register",
+  "visitorType": "investor",
+  "utmSource": "event",
+  "utmMedium": "kiosk",
+  "utmCampaign": "event-cityscape-global-2026",
+  "submissionId": "33333333-3333-4333-8333-333333333333",
+  "sessionId": "44444444-4444-4444-8444-444444444444",
+  "submittedAt": "2026-06-25T10:05:00.000Z",
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+### Sell-only guest
+
+Same shape, with:
+
+```json
+{ "visitorType": "seller", "goals": ["sell"] }
+```
+
+---
+
+## Recommended handling on the AgentCRM side
+
+1. **De-dupe** on `submissionId` (retries reuse the same id), with email/phone
+   as a secondary match.
+2. **Mark as prospect** using `leadLifecycle` / `leadStage` = `"prospect"`.
+3. **Segment the event** by `leadTag` (or `utmCampaign`) — every lead from one
+   event shares the same value; `leadMagnet` is the display name.
+4. **Assign** event leads from a pool — `assigneeEmail` / `teamMemberEmail` are
+   `null`, so there's no pre-set owner.
+5. **Contact channel**: treat `phone` / `whatsapp` as a WhatsApp-first number;
+   note that `email` may be absent (and vice versa).
+6. **Route** `visitorType: "seller"` (pure seller) and `visitorType: "investor"`
+   to the appropriate pipelines. `"vendor"` will never appear on these leads.

--- a/tests/api/leads.test.ts
+++ b/tests/api/leads.test.ts
@@ -457,7 +457,7 @@ describe("Lead Form API", () => {
       expect(payload.goals).toContain("sell")
     })
 
-    it("routes a mixed buy + sell form to a non-vendor type and keeps 'sell' in goals", async () => {
+    it("routes a mixed buy + sell form to 'investor' and keeps 'sell' in goals", async () => {
       const payload = await postAndReadPayload(
         {
           firstName: "Max",
@@ -471,6 +471,7 @@ describe("Lead Form API", () => {
         "192.168.2.3",
       )
 
+      expect(payload.visitorType).toBe("investor")
       expect(payload.visitorType).not.toBe("vendor")
       expect(payload.goals).toContain("sell")
     })

--- a/tests/api/leads.test.ts
+++ b/tests/api/leads.test.ts
@@ -390,6 +390,111 @@ describe("Lead Form API", () => {
   })
 
   // =============================================================================
+  // VISITOR TYPE ROUTING (Leads vs Partners)
+  // =============================================================================
+  //
+  // AgentCRM reserves "vendor" for partners / service-providers. A consumer
+  // selling their own property must route to "seller" (Leads), never "vendor".
+
+  describe("visitorType routing", () => {
+    async function postAndReadPayload(
+      body: Record<string, unknown>,
+      ip: string,
+    ): Promise<Record<string, unknown>> {
+      const { POST } = await import("@/app/api/leads/route")
+      const request = new Request("http://localhost/api/leads", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-forwarded-for": ip,
+        },
+        body: JSON.stringify({
+          submittedAt: new Date().toISOString(),
+          ...body,
+        }),
+      })
+      const response = await POST(request as unknown as NextRequest)
+      expect(response.status).toBe(200)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const [, requestInit] = mockFetch.mock.calls[0]
+      return JSON.parse(String(requestInit.body))
+    }
+
+    it("routes a sell-only form to 'seller' and keeps 'sell' in goals", async () => {
+      const payload = await postAndReadPayload(
+        {
+          firstName: "Sam",
+          lastName: "Seller",
+          email: "sam@example.com",
+          whatsapp: "+971501112222",
+          formMode: "contact",
+          pageUrl: "https://primecapitaldubai.com/contact",
+          goals: ["sell"],
+        },
+        "192.168.2.1",
+      )
+
+      expect(payload.visitorType).toBe("seller")
+      expect(payload.goals).toContain("sell")
+    })
+
+    it("routes the /sell landing flow (goals: ['sell']) to 'seller'", async () => {
+      const payload = await postAndReadPayload(
+        {
+          firstName: "Tara",
+          email: "tara@example.com",
+          whatsapp: "+971502223333",
+          formMode: "landing",
+          pageUrl: "https://primecapitaldubai.com/sell",
+          leadTag: "seller",
+          // What the /sell page now seeds via initialData
+          goals: ["sell"],
+        },
+        "192.168.2.2",
+      )
+
+      expect(payload.visitorType).toBe("seller")
+      expect(payload.goals).toContain("sell")
+    })
+
+    it("routes a mixed buy + sell form to a non-vendor type and keeps 'sell' in goals", async () => {
+      const payload = await postAndReadPayload(
+        {
+          firstName: "Max",
+          lastName: "Mixed",
+          email: "max@example.com",
+          whatsapp: "+971503334444",
+          formMode: "contact",
+          pageUrl: "https://primecapitaldubai.com/contact",
+          goals: ["buy-ready", "sell"],
+        },
+        "192.168.2.3",
+      )
+
+      expect(payload.visitorType).not.toBe("vendor")
+      expect(payload.goals).toContain("sell")
+    })
+
+    it("keeps an explicit partner/service-provider application as 'vendor'", async () => {
+      const payload = await postAndReadPayload(
+        {
+          firstName: "Pat",
+          lastName: "Partner",
+          email: "pat@partner.example",
+          whatsapp: "+971504445555",
+          formMode: "contact",
+          pageUrl: "https://primecapitaldubai.com/partners",
+          // A real partner/service-provider application sets this explicitly
+          visitorType: "vendor",
+        },
+        "192.168.2.4",
+      )
+
+      expect(payload.visitorType).toBe("vendor")
+    })
+  })
+
+  // =============================================================================
   // HTTP METHOD TESTS
   // =============================================================================
 


### PR DESCRIPTION
## What

Adds the iPad **event registration kiosk** at `/register` and routes its leads — plus existing property-seller leads — into AgentCRM with the correct `visitorType`.

### Event kiosk (`/register`)
- Chrome-free, no-scroll, full-screen form for live events; staff name the event then drop into kiosk mode; auto-resets after each guest.
- Reuses the existing `/api/leads` pipeline (`formMode: "event"`) — same validation + AgentCRM forwarding as the website forms.
- Background uses a website hero; discreet exit control (confirm-gated).
- Per-guest `submissionId`/`sessionId`, **stable across retries** for CRM idempotency.

### AgentCRM routing fix (the focused production change)
**`vendor` in AgentCRM means a partner / service-provider, not a property seller.** Previously any lead with a `sell` goal was inferred as `vendor`, mis-filing consumer sellers under Partners.

- A `sell` goal now routes to **`visitorType: "seller"`** (Leads), never `vendor`. `"sell"` stays in `goals`.
- Applies to the contact form's "Sell a property" goal and the **`/sell`** landing page (now seeds `goals: ["sell"]`).
- **Explicit** `visitorType: "vendor"` (a real partner/service-provider application) still passes through unchanged.
- Event leads use seller/investor routing and are marked `leadLifecycle`/`leadStage: "prospect"`.

## Tests
`tests/api/leads.test.ts` — sell-only → `seller` (+ `sell` in goals); mixed buy+sell → not `vendor` (+ `sell` in goals); explicit partner application → still `vendor`; `/sell` flow → `seller`. Full suite: 101 passing. Production build green.

## Docs
`docs/integrations/agentcrm-event-kiosk-payload.md` — the exact AgentCRM payload contract to share with the AgentCRM team.

## Post-release verification
After merge/deploy, send one labelled test submission and confirm it lands in AgentCRM **Leads**, not **Partners**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)