### PR TITLE
Capture event lead distribution (team vs managers) on kiosk

### DIFF
--- a/app/(kiosk)/kiosk.css
+++ b/app/(kiosk)/kiosk.css
@@ -367,6 +367,63 @@ textarea.kiosk__input {
   gap: 1rem;
 }
 
+/* Segmented control — lead distribution choice on the setup screen */
+.kiosk__seg {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem;
+}
+
+.kiosk__seg-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.85rem 0.9rem;
+  text-align: center;
+  background: #fff;
+  border: 1px solid rgba(87, 108, 117, 0.3);
+  border-radius: 3px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+
+.kiosk__seg-option:hover {
+  border-color: var(--web-spruce);
+}
+
+.kiosk__seg-option--selected {
+  background: var(--web-spruce);
+  border-color: var(--web-spruce);
+  color: var(--web-off-white);
+}
+
+.kiosk__seg-title {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.kiosk__seg-hint {
+  font-size: 11px;
+  line-height: 1.3;
+  opacity: 0.75;
+}
+
+/* Faint staff cue shown on the guest form when distribution is "managers" */
+.kiosk__mode-badge {
+  position: absolute;
+  top: 0.6rem;
+  left: 0.75rem;
+  z-index: 2;
+  padding: 0.25rem 0.55rem;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(87, 108, 117, 0.55);
+  background: rgba(87, 108, 117, 0.08);
+  border-radius: 999px;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Thank-you screen                                                           */
 /* -------------------------------------------------------------------------- */

--- a/app/(kiosk)/register/_components/event-kiosk.tsx
+++ b/app/(kiosk)/register/_components/event-kiosk.tsx
@@ -36,6 +36,7 @@ const INTERESTS: { value: string; label: string }[] = [
   { value: "buy-ready", label: "Buying property" },
   { value: "build-wealth", label: "Building an investment portfolio" },
   { value: "advice-only", label: "Strategic investment advice" },
+  { value: "golden-visa-wills", label: "Golden Visa & Wills" },
   { value: "business-setup", label: "Setting up a business in Dubai" },
   { value: "development", label: "Building / developing in Dubai" },
   { value: "sell", label: "Selling property" },

--- a/app/(kiosk)/register/_components/event-kiosk.tsx
+++ b/app/(kiosk)/register/_components/event-kiosk.tsx
@@ -26,10 +26,10 @@ import { cn } from "@/lib/utils"
 // -----------------------------------------------------------------------------
 // Interest options
 //
-// Values are sent to AgentCRM as `goals`. Where a value matches the canonical
-// LeadGoal vocabulary ("sell", "buy-ready", "build-wealth", "advice-only") the
-// CRM uses it for routing — notably "sell" routes the lead to the vendor
-// pipeline. The rest are event-specific tags carried as opaque metadata.
+// Values are sent to AgentCRM as `goals` and drive seller/investor routing
+// server-side: a "sell"-only selection routes to "seller" (never "vendor" —
+// AgentCRM reserves that for partners). "sell" combined with any buy/investment
+// interest routes to "investor". The rest are tags carried as metadata.
 // -----------------------------------------------------------------------------
 
 const INTERESTS: { value: string; label: string }[] = [

--- a/app/(kiosk)/register/_components/event-kiosk.tsx
+++ b/app/(kiosk)/register/_components/event-kiosk.tsx
@@ -49,9 +49,24 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 type Phase = "setup" | "form" | "thanks"
 
+// Who the event's leads are released to in AgentCRM:
+//   - "team":     available to all agents for pickup
+//   - "managers": held for manager / admin distribution only
+type LeadDistribution = "team" | "managers"
+
+const DISTRIBUTION_OPTIONS: {
+  value: LeadDistribution
+  label: string
+  hint: string
+}[] = [
+  { value: "team", label: "Available to team", hint: "Any agent can pick these up" },
+  { value: "managers", label: "Managers only", hint: "Held for manager / admin distribution" },
+]
+
 interface KioskSession {
   eventName: string
   eventTag: string
+  distribution: LeadDistribution
 }
 
 interface EventKioskProps {
@@ -77,6 +92,7 @@ export function EventKiosk({ initialEventName = "" }: EventKioskProps) {
   const [phase, setPhase] = useState<Phase>("setup")
   const [eventName, setEventName] = useState(initialEventName)
   const [eventTag, setEventTag] = useState("")
+  const [distribution, setDistribution] = useState<LeadDistribution>("team")
 
   // Guest form state
   const [fullName, setFullName] = useState("")
@@ -111,6 +127,9 @@ export function EventKiosk({ initialEventName = "" }: EventKioskProps) {
       if (saved?.eventName) {
         setEventName(saved.eventName)
         setEventTag(saved.eventTag || toEventTag(saved.eventName))
+        if (saved.distribution === "managers" || saved.distribution === "team") {
+          setDistribution(saved.distribution)
+        }
         setPhase("form")
       }
     } catch {
@@ -156,7 +175,7 @@ export function EventKiosk({ initialEventName = "" }: EventKioskProps) {
     try {
       window.sessionStorage.setItem(
         SESSION_KEY,
-        JSON.stringify({ eventName: name, eventTag: tag } satisfies KioskSession),
+        JSON.stringify({ eventName: name, eventTag: tag, distribution } satisfies KioskSession),
       )
     } catch {
       /* non-fatal — kiosk still works, just won't survive a refresh */
@@ -237,6 +256,8 @@ export function EventKiosk({ initialEventName = "" }: EventKioskProps) {
           formMode: "event",
           leadMagnet: eventName,
           leadTag: eventTag,
+          // Who these leads are released to: "team" (all agents) or "managers" only
+          leadDistribution: distribution,
 
           // What they're interested in + their note
           goals: interests.length ? interests : undefined,
@@ -308,6 +329,29 @@ export function EventKiosk({ initialEventName = "" }: EventKioskProps) {
                 autoComplete="off"
               />
             </div>
+            <div className="kiosk__field">
+              <span className="kiosk__label">Lead distribution</span>
+              <div className="kiosk__seg" role="group" aria-label="Lead distribution">
+                {DISTRIBUTION_OPTIONS.map((opt) => {
+                  const selected = distribution === opt.value
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      className={cn(
+                        "kiosk__seg-option",
+                        selected && "kiosk__seg-option--selected",
+                      )}
+                      aria-pressed={selected}
+                      onClick={() => setDistribution(opt.value)}
+                    >
+                      <span className="kiosk__seg-title">{opt.label}</span>
+                      <span className="kiosk__seg-hint">{opt.hint}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
             {error && <span className="kiosk__error">{error}</span>}
             <button type="submit" className="kiosk__submit kiosk__submit--block">
               Start Registration
@@ -349,6 +393,10 @@ export function EventKiosk({ initialEventName = "" }: EventKioskProps) {
   return (
     <div className="kiosk">
       <form className="kiosk__card" onSubmit={handleSubmit}>
+        {/* Staff-facing cue that this session is restricted distribution */}
+        {distribution === "managers" && (
+          <span className="kiosk__mode-badge">Managers only</span>
+        )}
         <button
           type="button"
           className="kiosk__exit"

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -581,6 +581,10 @@ const leadSchema = z
     referringTeamMember: z.string().max(100).optional(),
     referringTeamMemberEmail: z.string().max(100).optional(),
 
+    // AgentCRM prospect binder from the welcome-email link — forwarded verbatim
+    // so AgentCRM can promote the existing prospect instead of duplicating it.
+    ref: z.string().max(200).optional(),
+
     // Legacy URL source parameter. Accepted for compatibility, but never
     // forwarded to CRM because CRM expects utmSource explicitly.
     source: z.string().max(100).optional(),
@@ -748,6 +752,9 @@ function buildAgentCrmPayload(
     leadDistribution: leadData.leadDistribution,
     pageUrl: leadData.pageUrl,
     visitorType,
+    // Prospect binder from the AgentCRM welcome-email link (verbatim). Lets
+    // AgentCRM match + promote the existing prospect (Prospect → Lead).
+    ref: leadData.ref,
     submissionId,
     sessionId: leadData.sessionId,
     submittedAt: leadData.submittedAt,

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -568,6 +568,10 @@ const leadSchema = z
     leadLifecycle: z.string().max(50).optional(),
     leadStage: z.string().max(50).optional(),
 
+    // Kiosk distribution scope — who the event's leads are released to:
+    // "team" (all agents) or "managers" (manager/admin distribution only)
+    leadDistribution: z.enum(["team", "managers"]).optional(),
+
     // Pipeline router
     visitorType: z.enum(["investor", "agent", "vendor"]).optional(),
 
@@ -739,6 +743,8 @@ function buildAgentCrmPayload(
     // Lifecycle marker — event leads enter AgentCRM as prospects
     leadLifecycle: leadData.leadLifecycle || (isEvent ? "prospect" : undefined),
     leadStage: leadData.leadStage || (isEvent ? "prospect" : undefined),
+    // Distribution scope for event/kiosk leads ("team" | "managers")
+    leadDistribution: leadData.leadDistribution,
     pageUrl: leadData.pageUrl,
     visitorType,
     submissionId,

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -433,6 +433,7 @@ const BUY_INVESTMENT_GOALS = new Set([
   "residential",
   "invest-offplan",
   "golden-visa",
+  "golden-visa-wills",
 ])
 
 /**

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -393,37 +393,12 @@ function getFormName(formMode: string, pageUrl: string): string {
 // =============================================================================
 
 /**
- * Pipeline router for the CRM. In AgentCRM "vendor" means a partner /
- * service-provider (filed under Partners), NOT a property seller — so a
- * consumer selling their own home must never be routed there.
- *
- *   - vendor:   ONLY when a form sets visitorType "vendor" explicitly (e.g. an
- *               introducer / partner / service-provider application).
- *   - agent:    someone applying to be an introducer/agent (set explicitly).
- *   - seller:   a consumer selling their OWN property with no buy/investment
- *               intent. Routed to Leads, not Partners. "sell" stays in `goals`.
- *   - investor: default — including a "sell" goal combined with any
- *               buy/investment intent (matches the event-kiosk logic).
- *
- * Event leads use deriveVisitorTypeForCrm() below (seller/investor only).
- */
-function deriveVisitorType(
-  goals: string[] | undefined,
-  explicit: string | undefined,
-): "investor" | "agent" | "vendor" | "seller" {
-  if (explicit === "agent" || explicit === "vendor" || explicit === "investor") {
-    return explicit
-  }
-  // Same seller/investor split as event leads — keeps the website and kiosk
-  // aligned so no property seller is ever filed as a Partner.
-  return deriveEventVisitorType(goals)
-}
-
-/**
  * Goals that signal buy-side / investment intent. Used to tell a pure property
- * seller (→ "seller") apart from an active buyer/investor (→ "investor") for
- * event leads. Covers both the kiosk's interest codes and the canonical
- * website LeadGoal values. Tune this list to change seller/investor routing.
+ * seller (→ "seller") apart from an active buyer/investor (→ "investor").
+ * Covers the kiosk's interest codes and the canonical website LeadGoal values.
+ *
+ * NOTE: this Set drives seller/investor inference for BOTH website and kiosk
+ * leads (they share the same router) — tuning it changes routing everywhere.
  */
 const BUY_INVESTMENT_GOALS = new Set([
   "buy-ready",
@@ -436,16 +411,18 @@ const BUY_INVESTMENT_GOALS = new Set([
   "golden-visa-wills",
 ])
 
+const EXPLICIT_VISITOR_TYPES = new Set(["investor", "agent", "vendor", "seller"])
+
 /**
- * Event-lead pipeline router for AgentCRM. Unlike the website router this
- * NEVER emits "vendor" (AgentCRM reserves "vendor" for partners/service
- * providers):
+ * Infer the pipeline router from a lead's goals (used when a form doesn't set
+ * visitorType explicitly). NEVER emits "vendor" — AgentCRM reserves "vendor"
+ * for partners/service-providers, so a property seller must not land there:
  *   - "seller":   wants to sell AND shows no buy/investment intent
  *   - "investor": everything else — buy / invest / advice / commercial /
  *                 residential, or "sell" combined with any of those
  * "sell" always stays in `goals` regardless of the routed type.
  */
-function deriveEventVisitorType(goals: string[] | undefined): "investor" | "seller" {
+function inferVisitorTypeFromGoals(goals: string[] | undefined): "investor" | "seller" {
   const g = goals ?? []
   const hasSell = g.includes("sell")
   const hasBuyInvestment = g.some((x) => BUY_INVESTMENT_GOALS.has(x))
@@ -453,18 +430,20 @@ function deriveEventVisitorType(goals: string[] | undefined): "investor" | "sell
 }
 
 /**
- * Choose the CRM pipeline router by form type. Event leads (kiosk + livestream)
- * use the seller/investor logic; every other form keeps the legacy router.
+ * Resolve the CRM pipeline router for any form (website + kiosk):
+ *   - An explicit `visitorType` set by the form always wins. This is the only
+ *     way "vendor" (partner/service-provider) or "agent" (recruitment) is ever
+ *     sent, and it lets a dedicated form force "seller"/"investor".
+ *   - Otherwise we infer "seller"/"investor" from goals (never "vendor").
  */
 function deriveVisitorTypeForCrm(leadData: {
-  formMode: string
   goals?: string[]
   visitorType?: string
 }): string {
-  if (leadData.formMode === "event") {
-    return deriveEventVisitorType(leadData.goals)
+  if (leadData.visitorType && EXPLICIT_VISITOR_TYPES.has(leadData.visitorType)) {
+    return leadData.visitorType
   }
-  return deriveVisitorType(leadData.goals, leadData.visitorType)
+  return inferVisitorTypeFromGoals(leadData.goals)
 }
 
 /**
@@ -573,8 +552,8 @@ const leadSchema = z
     // "team" (all agents) or "managers" (manager/admin distribution only)
     leadDistribution: z.enum(["team", "managers"]).optional(),
 
-    // Pipeline router
-    visitorType: z.enum(["investor", "agent", "vendor"]).optional(),
+    // Pipeline router (explicit override; otherwise inferred from goals)
+    visitorType: z.enum(["investor", "agent", "vendor", "seller"]).optional(),
 
     // Context from referring pages
     referringProperty: z.string().max(500).optional(),

--- a/components/shared/lead-form/schema.ts
+++ b/components/shared/lead-form/schema.ts
@@ -59,7 +59,7 @@ export const formModeSchema = z.enum([
   "event",
 ])
 
-export const visitorTypeSchema = z.enum(["investor", "agent", "vendor"])
+export const visitorTypeSchema = z.enum(["investor", "agent", "vendor", "seller"])
 
 // =============================================================================
 // STEP SCHEMAS

--- a/components/shared/lead-form/types.ts
+++ b/components/shared/lead-form/types.ts
@@ -69,8 +69,9 @@ export type FormMode =
   | "newsletter"
   | "event"
 
-// Pipeline router (CRM uses to assign leads). Default is investor.
-export type VisitorType = "investor" | "agent" | "vendor"
+// Pipeline router (CRM uses to assign leads). Default is investor. "seller" is
+// usually inferred server-side from a "sell" goal, not set here.
+export type VisitorType = "investor" | "agent" | "vendor" | "seller"
 export type FormTheme = "light" | "dark"
 
 // =============================================================================

--- a/components/shared/lead-form/types.ts
+++ b/components/shared/lead-form/types.ts
@@ -174,6 +174,11 @@ export interface LeadFormData {
   referringTeamMember?: string       // Team member slug from query param
   referringTeamMemberEmail?: string  // Team member email from query param
 
+  // CRM prospect binder — opaque ref from the AgentCRM welcome-email link
+  // (?ref=…). Forwarded verbatim so AgentCRM promotes the existing prospect
+  // (Prospect → Lead) instead of creating a duplicate.
+  ref?: string
+
   // Honeypot for bot protection (hidden field)
   website?: string
 }

--- a/components/shared/lead-form/use-lead-form.ts
+++ b/components/shared/lead-form/use-lead-form.ts
@@ -166,8 +166,11 @@ export function useLeadForm({
     // AgentCRM welcome-email link params: `ref` binds the existing prospect,
     // `email` prefills + secondary-matches. Read once at mount and seeded into
     // form state so they survive multi-step navigation and re-renders.
+    // Only prefill `email` when `ref` is present (i.e. a genuine welcome-email
+    // link) so an unrelated ?email= tracking param can't silently pre-fill and
+    // submit the wrong address.
     const ref = params.get("ref") || undefined
-    const email = params.get("email")?.trim() || undefined
+    const email = ref ? params.get("email")?.trim() || undefined : undefined
     return {
       ...(property ? { referringProperty: property } : {}),
       ...(teamMember ? { referringTeamMember: teamMember } : {}),

--- a/components/shared/lead-form/use-lead-form.ts
+++ b/components/shared/lead-form/use-lead-form.ts
@@ -163,10 +163,17 @@ export function useLeadForm({
     const property = params.get("property") || undefined
     const teamMember = params.get("teamMember") || undefined
     const teamMemberEmail = params.get("teamMemberEmail") || undefined
+    // AgentCRM welcome-email link params: `ref` binds the existing prospect,
+    // `email` prefills + secondary-matches. Read once at mount and seeded into
+    // form state so they survive multi-step navigation and re-renders.
+    const ref = params.get("ref") || undefined
+    const email = params.get("email")?.trim() || undefined
     return {
       ...(property ? { referringProperty: property } : {}),
       ...(teamMember ? { referringTeamMember: teamMember } : {}),
       ...(teamMemberEmail ? { referringTeamMemberEmail: teamMemberEmail } : {}),
+      ...(ref ? { ref } : {}),
+      ...(email ? { email } : {}),
     }
   }, [])
 
@@ -313,6 +320,8 @@ export function useLeadForm({
         referringProperty: mergedData.referringProperty,
         referringTeamMember: mergedData.referringTeamMember,
         referringTeamMemberEmail: mergedData.referringTeamMemberEmail,
+        // CRM prospect binder from the welcome-email link (?ref=…)
+        ref: mergedData.ref,
         // Lead tagging for CRM categorisation
         leadMagnet: mergedData.leadMagnet || leadMagnet,
         leadTag: mergedData.leadTag || tag,

--- a/docs/integrations/agentcrm-event-kiosk-payload.md
+++ b/docs/integrations/agentcrm-event-kiosk-payload.md
@@ -5,6 +5,11 @@ completes a registration on the **event kiosk** (the iPad form Prime runs at a
 stand/event). Share this with the AgentCRM team so they can map the fields and
 configure event handling.
 
+> For the full picture — architecture, delivery semantics, the complete
+> `visitorType` model, and worked examples for every form type — see the
+> **[AgentCRM Integration Brief](./agentcrm-integration-brief.md)**. This page is
+> the quick field reference for the event kiosk specifically.
+
 ---
 
 ## Transport

--- a/docs/integrations/agentcrm-event-kiosk-payload.md
+++ b/docs/integrations/agentcrm-event-kiosk-payload.md
@@ -145,8 +145,8 @@ partner / service-provider, not a property seller. Instead:
 | No goals selected | `"investor"` |
 
 "Buy/investment goals" = `buy-ready`, `build-wealth`, `advice-only`,
-`commercial`, `residential` (plus the canonical website goals `invest-offplan`,
-`golden-visa`).
+`commercial`, `residential`, `golden-visa-wills` (plus the canonical website
+goals `invest-offplan`, `golden-visa`).
 
 ### Full `visitorType` vocabulary (applies to all Prime forms, not just the kiosk)
 
@@ -171,6 +171,7 @@ The kiosk sends these exact string codes. Suggested human labels for display:
 | `buy-ready` | Buying property | buy/investment → investor |
 | `build-wealth` | Building an investment portfolio | buy/investment → investor |
 | `advice-only` | Strategic investment advice | buy/investment → investor |
+| `golden-visa-wills` | Golden Visa & Wills | buy/investment → investor |
 | `business-setup` | Setting up a business in Dubai | neutral |
 | `development` | Building / developing in Dubai | neutral |
 | `sell` | Selling property | seller (unless a buy/investment goal is also present) |

--- a/docs/integrations/agentcrm-event-kiosk-payload.md
+++ b/docs/integrations/agentcrm-event-kiosk-payload.md
@@ -39,6 +39,7 @@ Event leads are marked with `leadLifecycle` / `leadStage` = `"prospect"`.
   "formName": "event-registration-register",
   "leadLifecycle": "prospect",
   "leadStage": "prospect",
+  "leadDistribution": "team",
 
   "leadMagnet": "Cityscape Global 2026",
   "leadTag": "event-cityscape-global-2026",
@@ -89,8 +90,9 @@ when no agent is pre-assigned — always the case for the kiosk) and `website`
 |---|---|---|---|
 | `formMode` | string | **always** | Always `"event"` for kiosk leads. |
 | `formName` | string | **always** | Auto-derived, e.g. `"event-registration-register"`. |
-| `leadLifecycle` | string | **always** | Always `"prospect"` — explicit marker that event leads enter as prospects. |
+| `leadLifecycle` | string | **always** | Always `"prospect"` — marker that event leads should enter as prospects. **Currently informational** (see note below). |
 | `leadStage` | string | **always** | Always `"prospect"` (same marker, duplicated for whichever field AgentCRM keys on). |
+| `leadDistribution` | string | **always (event)** | Who the event's leads are released to: **`"team"`** (available to all agents) or **`"managers"`** (held for manager / admin distribution only). Set by staff per event on the kiosk setup screen. |
 | `leadMagnet` | string | **always** | **The human-readable event name** staff typed, e.g. `"Cityscape Global 2026"`. |
 | `leadTag` | string | **always** | **Machine slug for the event**, `event-<slug>`, e.g. `"event-cityscape-global-2026"`. Use this to group/segment all leads from one event. |
 | `utmSource` | string | **always** | Always `"event"`. |
@@ -141,6 +143,18 @@ partner / service-provider, not a property seller. Instead:
 `commercial`, `residential` (plus the canonical website goals `invest-offplan`,
 `golden-visa`).
 
+### Full `visitorType` vocabulary (applies to all Prime forms, not just the kiosk)
+
+| Value | Meaning | How it's set |
+|---|---|---|
+| `investor` | Buyer / investor / advice — the default Leads pipeline | inferred (default) |
+| `seller` | A consumer selling **their own** property, no buy/investment intent | inferred from a `sell` goal |
+| `vendor` | A **partner / service-provider** (AgentCRM Partners, not Leads) | **explicit only** — a partner application form sets it |
+| `agent` | Agent recruitment applicant | **explicit only** — a recruitment form sets it |
+
+A property seller is **never** routed to `vendor`. `vendor` and `agent` only
+appear when a form sets `visitorType` explicitly.
+
 ---
 
 ## Interest vocabulary (`goals`)
@@ -175,6 +189,7 @@ regardless of the routed `visitorType`.
   "formName": "event-registration-register",
   "leadLifecycle": "prospect",
   "leadStage": "prospect",
+  "leadDistribution": "managers",
   "leadMagnet": "Cityscape Global 2026",
   "leadTag": "event-cityscape-global-2026",
   "pageUrl": "https://primecapitaldubai.com/register",
@@ -206,12 +221,20 @@ Same shape, with:
 
 1. **De-dupe** on `submissionId` (retries reuse the same id), with email/phone
    as a secondary match.
-2. **Mark as prospect** using `leadLifecycle` / `leadStage` = `"prospect"`.
-3. **Segment the event** by `leadTag` (or `utmCampaign`) — every lead from one
+2. **Mark as prospect** for event leads. Today `leadLifecycle` / `leadStage`
+   = `"prospect"` are **informational only** — AgentCRM stores them in the raw
+   payload but does not yet treat them as lifecycle controls. The planned
+   AgentCRM-side change should read these (combined with `formMode: "event"` /
+   `utmMedium: "kiosk"`) to park event/kiosk submissions as Prospects.
+3. **Honour distribution scope** via `leadDistribution`: `"team"` leads can be
+   released to all agents; `"managers"` leads should be held for manager / admin
+   distribution only (do not surface to the general agent pool).
+4. **Segment the event** by `leadTag` (or `utmCampaign`) — every lead from one
    event shares the same value; `leadMagnet` is the display name.
-4. **Assign** event leads from a pool — `assigneeEmail` / `teamMemberEmail` are
+5. **Assign** event leads from a pool — `assigneeEmail` / `teamMemberEmail` are
    `null`, so there's no pre-set owner.
-5. **Contact channel**: treat `phone` / `whatsapp` as a WhatsApp-first number;
+6. **Contact channel**: treat `phone` / `whatsapp` as a WhatsApp-first number;
    note that `email` may be absent (and vice versa).
-6. **Route** `visitorType: "seller"` (pure seller) and `visitorType: "investor"`
-   to the appropriate pipelines. `"vendor"` will never appear on these leads.
+7. **Route** `visitorType` to the right pipeline — `seller` and `investor` for
+   organic leads; `vendor` (Partners) and `agent` only ever arrive when set
+   explicitly by a partner / recruitment form. A property seller is never `vendor`.

--- a/docs/integrations/agentcrm-integration-brief.md
+++ b/docs/integrations/agentcrm-integration-brief.md
@@ -1,0 +1,537 @@
+# Prime Capital → AgentCRM Lead Integration Brief
+
+A complete, self-contained explanation of how Prime Capital sends lead data to
+AgentCRM — the flow, the delivery semantics, the routing model, and worked
+example payloads for every scenario. Read this top to bottom to fully understand
+the integration.
+
+> Quick field reference (event kiosk): `agentcrm-event-kiosk-payload.md`.
+> This brief is the broader picture and supersedes it where they overlap.
+
+---
+
+## 1. What this is
+
+Every lead Prime Capital captures — website enquiry forms **and** the on-site
+iPad **event kiosk** — is normalised by our backend and forwarded to AgentCRM as
+a single JSON enquiry. This brief tells the AgentCRM team exactly what arrives,
+when, and what each field means, so leads can be de-duplicated, routed to the
+right pipeline (Leads vs Partners), segmented by event, and distributed to the
+right people.
+
+---
+
+## 2. How it works (architecture & flow)
+
+```
+  Browser / iPad
+  ┌─────────────────────────────┐
+  │  Website forms (contact,    │
+  │  /sell, property enquiry,   │        ┌──────────────────────────────┐
+  │  download, private, …)      │        │  Prime backend               │
+  │  + Event kiosk (/register)  │  POST  │  /api/leads                  │
+  │                             ├───────►│  1. validate (reject bad)    │
+  └─────────────────────────────┘  JSON  │  2. enrich (property, agent) │
+                                          │  3. build AgentCRM payload   │
+                                          └──────────────┬───────────────┘
+                                                         │ POST (Bearer)
+                                                         ▼
+                                          ┌──────────────────────────────┐
+                                          │  AgentCRM                    │
+                                          │  /api/public/enquiry         │
+                                          └──────────────────────────────┘
+```
+
+- **Origin:** all forms post to **our** endpoint (`/api/leads`), never directly
+  to AgentCRM. The browser never holds the AgentCRM key.
+- **Our backend** validates the submission, enriches it server-side (resolves a
+  property slug to name/URL/flags; resolves a referring team member to an email),
+  then builds the AgentCRM-shaped payload and forwards it.
+- **Best-effort, non-blocking:** forwarding never blocks the user. If AgentCRM is
+  unreachable we log it; the guest still sees a success screen.
+
+---
+
+## 3. Transport & delivery semantics
+
+| | |
+|---|---|
+| **Method** | `POST` |
+| **Endpoint** | `https://crm.primecapitaldubai.com/api/public/enquiry` *(`AGENTCRM_API_URL`)* |
+| **Auth** | `Authorization: Bearer <AGENTCRM_API_KEY>` |
+| **Content-Type** | `application/json` |
+| **Body size** | We reject and never send anything over **64 KB**. |
+| **Trigger** | One request per completed submission. |
+| **Success** | We treat **any 2xx** as success and do not parse the response body. |
+
+**Idempotency & de-duplication.** Every payload carries a `submissionId` (UUID
+v4). A user-initiated **retry resends the same `submissionId`**, so AgentCRM
+should **de-dupe on `submissionId`** (with email/phone as a secondary match).
+There is no server-side auto-retry today — see Open Questions.
+
+**Field omission.** Any field whose value is empty/unknown is **omitted** from
+the JSON (not sent as `null`). The deliberate exceptions are `assigneeEmail`,
+`teamMemberEmail` (sent as `null` when no owner is pre-assigned) and `website`
+(sent as `""`).
+
+---
+
+## 4. `visitorType` — the pipeline router
+
+`visitorType` tells AgentCRM which pipeline a lead belongs to. **This is the most
+important routing field.**
+
+| Value | Meaning | Pipeline | How it's set |
+|---|---|---|---|
+| `investor` | Buyer / investor / advice-seeker | **Leads** (default) | inferred (default) |
+| `seller` | A consumer selling **their own** property, with no buy/investment intent | **Leads** | inferred from a `sell` goal |
+| `vendor` | A **partner / service-provider** | **Partners** | **explicit only** |
+| `agent` | Agent-recruitment applicant | recruitment | **explicit only** |
+
+**The critical rule:** a property **seller is never `vendor`.** In AgentCRM
+`vendor` means a partner/service-provider (Partners), so a homeowner selling
+their flat must route to `seller` (Leads).
+
+**Inference logic** (when a form does not set `visitorType` explicitly):
+
+| Goals on the lead | Result |
+|---|---|
+| Includes `sell` **and no** buy/investment goal | `seller` |
+| Includes `sell` **and** a buy/investment goal | `investor` (and `sell` stays in `goals`) |
+| Any buy/investment/advice/commercial/residential intent (no sell) | `investor` |
+| No goals at all | `investor` |
+
+"Buy/investment goals" = `buy-ready`, `build-wealth`, `advice-only`,
+`commercial`, `residential`, `invest-offplan`, `golden-visa`.
+
+`vendor` and `agent` **only** appear when a dedicated partner/recruitment form
+sets `visitorType` explicitly. (Those forms are noted as illustrative below —
+see §7.6/§7.7.)
+
+---
+
+## 5. Lead sources (`formMode`)
+
+| `formMode` | Source |
+|---|---|
+| `event` | The on-site iPad event kiosk (`/register`) — see §6. |
+| `contact` | Full contact / qualification form (collects goals, budget, timeline, etc.) |
+| `landing` | Quick-capture landing pages (e.g. `/sell`, campaign pages) |
+| `property-enquiry` | Enquiry from a specific property listing |
+| `download` | Lead-magnet / guide download |
+| `private` | Private/UHNW channel |
+| `newsletter` | Newsletter signup |
+
+`formName` is an auto-derived slug combining the mode and page, e.g.
+`event-registration-register`, `contact-form-contact-page`, `quick-enquiry-sell`.
+
+---
+
+## 6. Event kiosk specifics
+
+The kiosk is one shared iPad at a stand/event. Staff name the event and choose a
+distribution scope, then guests self-register. Every kiosk submission has
+`formMode: "event"` plus:
+
+- **`leadMagnet`** — the human event name staff typed (e.g. `"Cityscape Global 2026"`).
+- **`leadTag`** — machine slug `event-<slug>` (e.g. `"event-cityscape-global-2026"`). Group/segment all leads from one event by this.
+- **`utmSource: "event"`, `utmMedium: "kiosk"`, `utmCampaign: <leadTag>`** — identifies the channel.
+- **`leadLifecycle: "prospect"`, `leadStage: "prospect"`** — markers that these should enter as prospects. **Currently informational** — AgentCRM stores them in the raw payload but does not yet act on them. The planned AgentCRM-side change should read these (with `formMode: "event"` / `utmMedium: "kiosk"`) to park event leads as Prospects.
+- **`leadDistribution`** — `"team"` (release to all agents) or `"managers"` (hold for manager/admin distribution only — keep out of the general agent pool). Set per event by staff on the kiosk setup screen.
+- **`submissionId` / `sessionId`** — a fresh UUID per guest, stable across that guest's retries (the shared iPad never merges two guests).
+- **`phone` + `whatsapp`** — both set to the same E.164 number (WhatsApp-first) when a number is captured.
+- **`assigneeEmail` / `teamMemberEmail`** — `null` (no pre-assigned owner; assign from a pool).
+
+Guests give a name and **either** an email **or** a WhatsApp number (one is
+enough), optionally pick interests, and optionally leave a comment.
+
+---
+
+## 7. Worked example payloads
+
+These are the exact JSON bodies AgentCRM receives. `//` comments are annotations,
+**not** part of the real JSON.
+
+### 7.1 Event kiosk — investor, available to team
+
+Guest picked "Buying property" + "Setting up a business", left a note.
+
+```json
+{
+  "firstName": "Aisha",
+  "lastName": "Khan",
+  "email": "aisha@example.com",
+  "phone": "+971501234567",
+  "whatsapp": "+971501234567",
+
+  "formMode": "event",
+  "formName": "event-registration-register",
+  "leadLifecycle": "prospect",
+  "leadStage": "prospect",
+  "leadDistribution": "team",
+
+  "leadMagnet": "Cityscape Global 2026",
+  "leadTag": "event-cityscape-global-2026",
+  "pageUrl": "https://primecapitaldubai.com/register",
+
+  "visitorType": "investor",
+  "goals": ["buy-ready", "business-setup"],
+  "message": "Looking for a 2BR in Marina under 3M",
+  "enquiryNotes": "Looking for a 2BR in Marina under 3M",
+
+  "utmSource": "event",
+  "utmMedium": "kiosk",
+  "utmCampaign": "event-cityscape-global-2026",
+
+  "submissionId": "11111111-1111-4111-8111-111111111111",
+  "sessionId": "22222222-2222-4222-8222-222222222222",
+  "submittedAt": "2026-06-25T10:00:00.000Z",
+
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+### 7.2 Event kiosk — seller, managers-only distribution
+
+Guest picked only "Selling property"; staff set the kiosk to Managers only.
+
+```json
+{
+  "firstName": "Sam",
+  "lastName": "Seller",
+  "whatsapp": "+971501112222",
+  "phone": "+971501112222",
+
+  "formMode": "event",
+  "formName": "event-registration-register",
+  "leadLifecycle": "prospect",
+  "leadStage": "prospect",
+  "leadDistribution": "managers",
+
+  "leadMagnet": "Cityscape Global 2026",
+  "leadTag": "event-cityscape-global-2026",
+  "pageUrl": "https://primecapitaldubai.com/register",
+
+  "visitorType": "seller",
+  "goals": ["sell"],
+
+  "utmSource": "event",
+  "utmMedium": "kiosk",
+  "utmCampaign": "event-cityscape-global-2026",
+
+  "submissionId": "33333333-3333-4333-8333-333333333333",
+  "sessionId": "44444444-4444-4444-8444-444444444444",
+  "submittedAt": "2026-06-25T10:05:00.000Z",
+
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+> Note: no `email`, no `goals`-based investor signal, no `message` — those keys
+> are simply absent. `visitorType` is `seller` (Leads), **not** `vendor`.
+
+### 7.3 Event kiosk — minimal (name + WhatsApp only)
+
+```json
+{
+  "firstName": "Omar",
+  "phone": "+971559876543",
+  "whatsapp": "+971559876543",
+  "formMode": "event",
+  "formName": "event-registration-register",
+  "leadLifecycle": "prospect",
+  "leadStage": "prospect",
+  "leadDistribution": "team",
+  "leadMagnet": "Cityscape Global 2026",
+  "leadTag": "event-cityscape-global-2026",
+  "pageUrl": "https://primecapitaldubai.com/register",
+  "visitorType": "investor",
+  "utmSource": "event",
+  "utmMedium": "kiosk",
+  "utmCampaign": "event-cityscape-global-2026",
+  "submissionId": "55555555-5555-4555-8555-555555555555",
+  "sessionId": "66666666-6666-4666-8666-666666666666",
+  "submittedAt": "2026-06-25T10:07:00.000Z",
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+### 7.4 Website `/sell` landing — seller
+
+The dedicated seller page; quick capture + a callback booking.
+
+```json
+{
+  "firstName": "Tara",
+  "lastName": "Vendoria",
+  "email": "tara@example.com",
+  "phone": "+971502223333",
+  "whatsapp": "+971502223333",
+
+  "formMode": "landing",
+  "formName": "quick-enquiry-sell",
+  "pageUrl": "https://primecapitaldubai.com/sell",
+
+  "visitorType": "seller",
+  "goals": ["sell"],
+  "propertyLocation": "Dubai Marina",
+  "message": "2-bed in Marina Gate, looking to sell within 3 months",
+
+  "leadTag": "seller",
+  "utmSource": "google",
+  "utmMedium": "cpc",
+  "utmCampaign": "sell-dubai-2026",
+
+  "submissionId": "77777777-7777-4777-8777-777777777777",
+  "sessionId": "88888888-8888-4888-8888-888888888888",
+  "submittedAt": "2026-06-25T11:00:00.000Z",
+
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+### 7.5 Website contact form — investor (qualified buyer)
+
+A full contact form: buyer qualification fields are included.
+
+```json
+{
+  "firstName": "Bea",
+  "lastName": "Buyer",
+  "email": "bea@example.com",
+  "phone": "+971501230000",
+  "whatsapp": "+971501230000",
+
+  "formMode": "contact",
+  "formName": "contact-form-contact-page",
+  "pageUrl": "https://primecapitaldubai.com/contact",
+
+  "visitorType": "investor",
+  "goals": ["buy-ready", "build-wealth"],
+  "investTimeline": "3_6_months",
+  "budget": "3m-5m",
+  "budgetMin": 3000000,
+  "budgetMax": 5000000,
+  "propertyTypes": ["apartment", "townhouse"],
+  "locations": ["Dubai Marina", "Downtown Dubai"],
+  "bedrooms": 2,
+  "message": "Keen on high-yield off-plan",
+
+  "utmSource": "newsletter",
+  "utmMedium": "email",
+  "utmCampaign": "june-2026",
+  "firstTouchUtmSource": "instagram",
+  "firstTouchUtmMedium": "social",
+  "firstTouchAt": "2026-05-30T08:12:00.000Z",
+
+  "submissionId": "99999999-9999-4999-8999-999999999999",
+  "sessionId": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  "submittedAt": "2026-06-25T12:00:00.000Z",
+
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+> `budgetMin`/`budgetMax` are server-derived AED bounds for the selected band.
+> `firstTouch*` fields carry first-touch attribution when a returning visitor's
+> 30-day cookie is present.
+
+### 7.6 Partner / service-provider application — `vendor` (illustrative)
+
+There is **no** partner application form yet. When one is built it will set
+`visitorType: "vendor"` explicitly, and the payload will look like:
+
+```json
+{
+  "firstName": "Pat",
+  "lastName": "Partner",
+  "email": "pat@partner.example",
+  "phone": "+971504445555",
+  "whatsapp": "+971504445555",
+  "formMode": "contact",
+  "formName": "contact-form-partners",
+  "pageUrl": "https://primecapitaldubai.com/partners",
+  "visitorType": "vendor",
+  "message": "Mortgage brokerage interested in a referral partnership",
+  "submissionId": "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+  "sessionId": "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  "submittedAt": "2026-06-25T13:00:00.000Z",
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+### 7.7 Agent recruitment — `agent` (illustrative)
+
+Likewise illustrative — a recruitment form would set `visitorType: "agent"`:
+
+```json
+{
+  "firstName": "Ade",
+  "lastName": "Applicant",
+  "email": "ade@example.com",
+  "phone": "+971506660000",
+  "whatsapp": "+971506660000",
+  "formMode": "contact",
+  "formName": "contact-form-careers",
+  "pageUrl": "https://primecapitaldubai.com/careers",
+  "visitorType": "agent",
+  "message": "5 years Dubai brokerage experience, RERA certified",
+  "submissionId": "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+  "sessionId": "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+  "submittedAt": "2026-06-25T14:00:00.000Z",
+  "assigneeEmail": null,
+  "teamMemberEmail": null,
+  "_source": "prime-capital-website",
+  "website": ""
+}
+```
+
+---
+
+## 8. Complete field reference
+
+### Identity
+
+| Field | Type | Presence | Notes |
+|---|---|---|---|
+| `firstName` | string | always | First token of the name. |
+| `lastName` | string | optional | Remainder; omitted for a single-word name. |
+| `email` | string | conditional | **`email` or `phone` is always present** (one is enough). |
+| `phone` | string (E.164) | conditional | Mobile/WhatsApp number, e.g. `+971501234567`. |
+| `whatsapp` | string (E.164) | conditional | Same value as `phone` (WhatsApp-first); both set together. |
+
+### Source, routing & lifecycle
+
+| Field | Type | Presence | Notes |
+|---|---|---|---|
+| `formMode` | string | always | `event` / `contact` / `landing` / `property-enquiry` / `download` / `private` / `newsletter`. |
+| `formName` | string | always | Auto-derived mode+page slug. |
+| `visitorType` | string | always | `investor` / `seller` / `vendor` / `agent` — see §4. |
+| `goals` | string[] | optional | Interest codes — see vocabulary below. `sell` is always preserved. |
+| `message` | string | optional | Free-text comment (coalesced from the form's notes field). |
+| `enquiryNotes` | string | optional | Raw copy of the comment (event kiosk). |
+| `leadLifecycle` | string | event: always | `"prospect"` — informational today (see §6). |
+| `leadStage` | string | event: always | `"prospect"` — informational today. |
+| `leadDistribution` | string | event: always | `"team"` or `"managers"` — see §6. |
+| `leadMagnet` | string | event: always | Human event name (also set by download/lead-magnet forms). |
+| `leadTag` | string | conditional | `event-<slug>` for events; campaign tag (e.g. `seller`, `distressed`) elsewhere. |
+| `_source` | string | always | Always `"prime-capital-website"`. |
+
+### Buyer qualification (contact / property-enquiry forms)
+
+| Field | Type | Notes |
+|---|---|---|
+| `investTimeline` | string | e.g. `immediate`, `3_6_months`, `6_12_months`, `12_24_months`, `24_plus_months`, `flexible`. |
+| `budget` | string | Band, e.g. `under-1m`, `1m-3m`, `3m-5m`, `5m-10m`, `10m-20m`, `50m-plus`. |
+| `budgetMin` / `budgetMax` | number | Server-derived AED bounds for the band. |
+| `propertyTypes` | string[] | e.g. `apartment`, `villa`, `townhouse`, `penthouse`, `studio`, `commercial`, `office`, `land`. |
+| `locations` | string[] | Canonical Dubai locations (e.g. `Dubai Marina`). |
+| `bedrooms` | number | Bedroom count. |
+| `propertyLocation` / `propertyName` / `propertyType` / `saleTimeline` / `targetPrice` | string | Seller-side qualification. |
+
+### Property enquiry enrichment (server-side, when a listing is referenced)
+
+| Field | Type | Notes |
+|---|---|---|
+| `propertyRef` | string | Property slug. |
+| `propertyName` / `propertyUrl` | string | Server-resolved (not trusted from the client). |
+| `developerName` | string | |
+| `isOffPlan` / `isDistressed` | boolean | |
+
+### Attribution
+
+| Field | Type | Notes |
+|---|---|---|
+| `utmSource` / `utmMedium` / `utmCampaign` / `utmContent` / `utmTerm` | string | Last-touch UTM (event kiosk overrides to `event`/`kiosk`/`<leadTag>`). |
+| `referrer` | string | Last-touch referrer. |
+| `firstTouchUtm*` / `firstTouchReferrer` / `firstTouchLandingPage` / `firstTouchAt` | string | First-touch (30-day cookie) when present. |
+| `manychat` | string | Passed through when present. |
+
+### Tracking & assignment
+
+| Field | Type | Presence | Notes |
+|---|---|---|---|
+| `submissionId` | string (UUID v4) | always | **De-dupe key.** Reused on retries. |
+| `sessionId` | string (UUID v4) | always | Unique per guest/visitor. |
+| `submittedAt` | string (ISO 8601) | always | UTC timestamp. |
+| `assigneeEmail` / `teamMemberEmail` | string \| null | always | Resolved team-member email when the lead came from an agent's page; `null` otherwise (incl. all kiosk leads). |
+| `pageUrl` | string | always | Page the lead was submitted from. |
+| `website` | string | always | Honeypot; `""` on legitimate leads, non-empty indicates a bot. |
+
+### Goals vocabulary
+
+| Code | Label | Routing signal |
+|---|---|---|
+| `buy-ready` | Buying property | buy/investment → investor |
+| `build-wealth` | Building an investment portfolio | buy/investment → investor |
+| `advice-only` | Strategic investment advice | buy/investment → investor |
+| `commercial` | Commercial property | buy/investment → investor |
+| `residential` | Residential property | buy/investment → investor |
+| `business-setup` | Setting up a business in Dubai | neutral |
+| `development` | Building / developing in Dubai | neutral |
+| `sell` | Selling property | seller (unless a buy/investment goal is also present) |
+| `invest-offplan` | Invest in off-plan (website) | buy/investment → investor |
+| `golden-visa` | Golden Visa via property (website) | buy/investment → investor |
+
+---
+
+## 9. Guarantees & edge cases
+
+- **One of `email`/`phone` is always present**; the other may be absent.
+- **`phone` and `whatsapp` are the same value**, set together (WhatsApp-first).
+- **A property seller is never `vendor`** — `vendor`/`agent` are explicit-only.
+- **`sell` is never stripped** from `goals`, even when routed to `investor`.
+- **Retries reuse `submissionId`** — expect occasional duplicate ids; de-dupe.
+- **Honeypot:** a non-empty `website` means a bot; we still forward it so
+  AgentCRM can silently drop it.
+- **Omitted vs null:** unknown values are omitted; only `assigneeEmail`,
+  `teamMemberEmail` (`null`) and `website` (`""`) are sent when empty.
+
+---
+
+## 10. Recommended AgentCRM-side handling
+
+1. **De-dupe** on `submissionId` (secondary: email/phone).
+2. **Prospect parking** for event leads — read `formMode: "event"` /
+   `utmMedium: "kiosk"` (and the `leadLifecycle`/`leadStage` markers once you
+   honour them) to file event/kiosk submissions as Prospects.
+3. **Distribution** — honour `leadDistribution`: `"team"` → general agent pool;
+   `"managers"` → restricted to manager/admin distribution.
+4. **Pipeline** — route `visitorType`: `investor`/`seller` → Leads,
+   `vendor` → Partners, `agent` → recruitment.
+5. **Event segmentation** — group by `leadTag` / `utmCampaign`; `leadMagnet` is
+   the display name.
+6. **Assignment** — event leads have `assigneeEmail`/`teamMemberEmail` = `null`;
+   assign from a pool.
+7. **Contact** — WhatsApp-first; `email` may be absent.
+
+---
+
+## 11. Open questions for the AgentCRM team
+
+1. **Field naming/enums** — are `visitorType` values (`investor`/`seller`/`vendor`/`agent`), `leadDistribution` (`team`/`managers`), and `leadLifecycle`/`leadStage` (`prospect`) the exact names/values you want, or should we align to your schema?
+2. **Lifecycle controls** — confirm the AgentCRM-side change to honour
+   `leadLifecycle`/`leadStage` (and/or `formMode`/`utmMedium`) for Prospect parking.
+3. **Delivery durability** — we currently send once (best-effort, no server-side
+   retry/queue). If you want guaranteed delivery on transient 5xx, we can add a
+   durable retry. Do you return a stable lead id we should capture?
+4. **De-dupe window** — confirm `submissionId` is the right idempotency key on
+   your side.

--- a/docs/integrations/agentcrm-integration-brief.md
+++ b/docs/integrations/agentcrm-integration-brief.md
@@ -102,7 +102,7 @@ their flat must route to `seller` (Leads).
 | No goals at all | `investor` |
 
 "Buy/investment goals" = `buy-ready`, `build-wealth`, `advice-only`,
-`commercial`, `residential`, `invest-offplan`, `golden-visa`.
+`commercial`, `residential`, `golden-visa-wills`, `invest-offplan`, `golden-visa`.
 
 `vendor` and `agent` **only** appear when a dedicated partner/recruitment form
 sets `visitorType` explicitly. (Those forms are noted as illustrative below —
@@ -483,6 +483,7 @@ Likewise illustrative — a recruitment form would set `visitorType: "agent"`:
 | `buy-ready` | Buying property | buy/investment → investor |
 | `build-wealth` | Building an investment portfolio | buy/investment → investor |
 | `advice-only` | Strategic investment advice | buy/investment → investor |
+| `golden-visa-wills` | Golden Visa & Wills | buy/investment → investor |
 | `commercial` | Commercial property | buy/investment → investor |
 | `residential` | Residential property | buy/investment → investor |
 | `business-setup` | Setting up a business in Dubai | neutral |

--- a/docs/integrations/agentcrm-integration-brief.md
+++ b/docs/integrations/agentcrm-integration-brief.md
@@ -50,6 +50,43 @@ right people.
 - **Best-effort, non-blocking:** forwarding never blocks the user. If AgentCRM is
   unreachable we log it; the guest still sees a success screen.
 
+### Prospect promotion (welcome-email round-trip)
+
+Event kiosk leads enter AgentCRM as **Prospects** (name + contact, no
+qualification). The AgentCRM welcome email links the prospect back to our full
+enquiry form so the same record can be promoted (Prospect → Lead):
+
+```
+AgentCRM welcome email
+  link: https://www.primecapitaldubai.com/contact?ref=…&email=…&utm_*=…
+        │ (prospect clicks)
+        ▼
+  /contact   ← reads params, prefills email, keeps them through submit
+        │ POST
+        ▼
+  /api/leads ← forwards the params into the AgentCRM payload (exact names)
+        │ POST (Bearer)
+        ▼
+  /api/public/enquiry ← resolves ref/email → updates the EXISTING prospect
+```
+
+What survives the round-trip, by **exact payload field name**:
+
+| URL param on the CTA link | → payload field | Purpose |
+|---|---|---|
+| `ref` (e.g. `pr_8f2c…`) | **`ref`** (verbatim) | **Primary binder** — identifies the existing prospect |
+| `email` | `email` | Secondary match + prefilled on the form |
+| `utm_source` (e.g. `crm`) | `utmSource` | Attribution |
+| `utm_medium` (e.g. `email`) | `utmMedium` | Attribution |
+| `utm_campaign` (e.g. `event-aapi-convention-2026`) | `utmCampaign` | The event (matches the kiosk `leadTag`) |
+| `utm_content` (e.g. `event-welcome`) | `utmContent` | Which email drove the click |
+
+`ref` is opaque and forwarded **verbatim** — it's the precise binder and works
+even if the prospect edits their email on the form. If `ref` is ever absent we
+still forward `email` (+ `phone`) and the UTM params, so AgentCRM can de-dupe on
+normalised email/phone. Params are read on `/contact` at load and held in form
+state, so they survive multi-step navigation and re-renders.
+
 ---
 
 ## 3. Transport & delivery semantics
@@ -469,6 +506,7 @@ Likewise illustrative — a recruitment form would set `visitorType: "agent"`:
 
 | Field | Type | Presence | Notes |
 |---|---|---|---|
+| `ref` | string | conditional | **Prospect binder** from the welcome-email link (`?ref=…`), forwarded verbatim. Present only on prospect-promotion submissions; use it to match + promote the existing prospect. |
 | `submissionId` | string (UUID v4) | always | **De-dupe key.** Reused on retries. |
 | `sessionId` | string (UUID v4) | always | Unique per guest/visitor. |
 | `submittedAt` | string (ISO 8601) | always | UTC timestamp. |

--- a/tests/api/leads.test.ts
+++ b/tests/api/leads.test.ts
@@ -493,6 +493,41 @@ describe("Lead Form API", () => {
 
       expect(payload.visitorType).toBe("vendor")
     })
+
+    it("honours an explicit visitorType on an event submission (not bypassed)", async () => {
+      const payload = await postAndReadPayload(
+        {
+          firstName: "Vera",
+          lastName: "Vendor",
+          email: "vera@partner.example",
+          formMode: "event",
+          pageUrl: "https://primecapitaldubai.com/register",
+          goals: ["sell"],
+          // Explicit override must win even though goals would infer "seller"
+          visitorType: "vendor",
+        },
+        "192.168.2.5",
+      )
+
+      expect(payload.visitorType).toBe("vendor")
+    })
+
+    it("accepts and honours an explicit 'seller' (not stripped by schema)", async () => {
+      const payload = await postAndReadPayload(
+        {
+          firstName: "Stan",
+          lastName: "Seller",
+          email: "stan@example.com",
+          formMode: "contact",
+          pageUrl: "https://primecapitaldubai.com/contact",
+          // No goals — would infer "investor"; explicit "seller" must win.
+          visitorType: "seller",
+        },
+        "192.168.2.6",
+      )
+
+      expect(payload.visitorType).toBe("seller")
+    })
   })
 
   // =============================================================================

--- a/tests/api/leads.test.ts
+++ b/tests/api/leads.test.ts
@@ -496,6 +496,54 @@ describe("Lead Form API", () => {
   })
 
   // =============================================================================
+  // EVENT KIOSK METADATA
+  // =============================================================================
+
+  describe("event kiosk metadata", () => {
+    async function postEvent(
+      distribution: "team" | "managers",
+      ip: string,
+    ): Promise<Record<string, unknown>> {
+      const { POST } = await import("@/app/api/leads/route")
+      const request = new Request("http://localhost/api/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-forwarded-for": ip },
+        body: JSON.stringify({
+          firstName: "Guest",
+          whatsapp: "+971501112222",
+          formMode: "event",
+          leadMagnet: "Cityscape Global 2026",
+          leadTag: "event-cityscape-global-2026",
+          leadDistribution: distribution,
+          utmSource: "event",
+          utmMedium: "kiosk",
+          utmCampaign: "event-cityscape-global-2026",
+          submittedAt: new Date().toISOString(),
+          pageUrl: "https://www.primecapitaldubai.com/register",
+        }),
+      })
+      const response = await POST(request as unknown as NextRequest)
+      expect(response.status).toBe(200)
+      const [, requestInit] = mockFetch.mock.calls[0]
+      return JSON.parse(String(requestInit.body))
+    }
+
+    it("forwards leadDistribution 'managers' with prospect markers", async () => {
+      const payload = await postEvent("managers", "192.168.3.1")
+      expect(payload.leadDistribution).toBe("managers")
+      expect(payload.leadLifecycle).toBe("prospect")
+      expect(payload.leadStage).toBe("prospect")
+      expect(payload.formMode).toBe("event")
+      expect(payload.utmMedium).toBe("kiosk")
+    })
+
+    it("forwards leadDistribution 'team'", async () => {
+      const payload = await postEvent("team", "192.168.3.2")
+      expect(payload.leadDistribution).toBe("team")
+    })
+  })
+
+  // =============================================================================
   // HTTP METHOD TESTS
   // =============================================================================
 

--- a/tests/api/leads.test.ts
+++ b/tests/api/leads.test.ts
@@ -544,6 +544,72 @@ describe("Lead Form API", () => {
   })
 
   // =============================================================================
+  // PROSPECT PROMOTION (welcome-email round-trip)
+  // =============================================================================
+  //
+  // AgentCRM appends ref/email/utm* to the welcome-email CTA. They must survive
+  // /contact -> /api/leads -> the AgentCRM payload so the existing prospect is
+  // promoted (Prospect -> Lead), not duplicated.
+
+  describe("prospect binder pass-through", () => {
+    it("forwards ref, email, and utm* verbatim for prospect promotion", async () => {
+      const { POST } = await import("@/app/api/leads/route")
+      const request = new Request("http://localhost/api/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-forwarded-for": "192.168.4.1" },
+        body: JSON.stringify({
+          firstName: "Aisha",
+          email: "aisha@example.com",
+          whatsapp: "+971501234567",
+          formMode: "contact",
+          pageUrl: "https://www.primecapitaldubai.com/contact",
+          ref: "pr_8f2c1234",
+          utmSource: "crm",
+          utmMedium: "email",
+          utmCampaign: "event-aapi-convention-2026",
+          utmContent: "event-welcome",
+          submittedAt: new Date().toISOString(),
+        }),
+      })
+
+      const response = await POST(request as unknown as NextRequest)
+      expect(response.status).toBe(200)
+
+      const [, requestInit] = mockFetch.mock.calls[0]
+      const payload = JSON.parse(String(requestInit.body))
+      expect(payload.ref).toBe("pr_8f2c1234")
+      expect(payload.email).toBe("aisha@example.com")
+      expect(payload.utmSource).toBe("crm")
+      expect(payload.utmMedium).toBe("email")
+      expect(payload.utmCampaign).toBe("event-aapi-convention-2026")
+      expect(payload.utmContent).toBe("event-welcome")
+    })
+
+    it("omits ref entirely when absent (no null)", async () => {
+      const { POST } = await import("@/app/api/leads/route")
+      const request = new Request("http://localhost/api/leads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-forwarded-for": "192.168.4.2" },
+        body: JSON.stringify({
+          firstName: "No",
+          lastName: "Ref",
+          email: "noref@example.com",
+          formMode: "contact",
+          pageUrl: "https://www.primecapitaldubai.com/contact",
+          submittedAt: new Date().toISOString(),
+        }),
+      })
+
+      const response = await POST(request as unknown as NextRequest)
+      expect(response.status).toBe(200)
+
+      const [, requestInit] = mockFetch.mock.calls[0]
+      const payload = JSON.parse(String(requestInit.body))
+      expect("ref" in payload).toBe(false)
+    })
+  })
+
+  // =============================================================================
   // HTTP METHOD TESTS
   // =============================================================================
 


### PR DESCRIPTION
## What

Adds a **lead distribution** choice to the event kiosk setup screen and sends it to AgentCRM, so each event's leads can be marked as available to the whole team or held for manager/admin distribution only.

### Kiosk setup
- New "Lead distribution" segmented control next to the event name:
  - **Available to team** (default) — any agent can pick these up
  - **Managers only** — held for manager / admin distribution
- Persisted in the kiosk session (survives an accidental refresh).
- A faint "Managers only" badge appears on the guest form when restricted, so staff can confirm the mode at a glance.

### Payload
- Event submissions now send `leadDistribution: "team" | "managers"`.
- Validated server-side (enum) and forwarded in the AgentCRM enquiry payload.

## Tests
`tests/api/leads.test.ts` — asserts `leadDistribution` ("team" and "managers") forwards alongside the prospect markers. Full suite green; production build green.

## Docs
`docs/integrations/agentcrm-event-kiosk-payload.md` updated: `leadDistribution` field, full `visitorType` vocabulary (`investor` / `seller` / `vendor` = partner / `agent` = recruitment), and a note that `leadLifecycle`/`leadStage` are currently informational markers (AgentCRM-side change pending to honour them).

## Note
`leadDistribution` is a marker for AgentCRM to act on — the website does not itself enforce visibility. The AgentCRM follow-up should hold `"managers"` leads out of the general agent pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)