### PR TITLE
Add Anthropic prompt caching

### DIFF
--- a/app/api/admin/youtube/chat-edit/route.ts
+++ b/app/api/admin/youtube/chat-edit/route.ts
@@ -36,6 +36,7 @@ import {
   createRateLimitResponse,
   RATE_LIMITS,
 } from "@/lib/rate-limit"
+import { withCachedFinalTool } from "@/lib/ai/anthropic-cache"
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY!,
@@ -341,7 +342,7 @@ ${formatSpec}`
         max_tokens: 4096,
         temperature: 0.5,
         system: systemPrompt,
-        tools: TOOLS,
+        tools: withCachedFinalTool(TOOLS),
         messages: apiMessages,
       },
       { signal: request.signal }

--- a/app/api/admin/youtube/distill-idea/route.ts
+++ b/app/api/admin/youtube/distill-idea/route.ts
@@ -30,6 +30,7 @@ import {
   createRateLimitResponse,
   RATE_LIMITS,
 } from "@/lib/rate-limit"
+import { cachedSystemPrompt } from "@/lib/ai/anthropic-cache"
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY!,
@@ -144,13 +145,14 @@ export async function POST(request: NextRequest) {
     const profile = getProfile(profileSlug)
 
     const cappedContext = context.slice(0, 12_000)
+    const systemPrompt = systemPromptFor(format, profile)
 
     const response = await anthropic.messages.create(
       {
         model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 2048,
         temperature: 0.7,
-        system: systemPromptFor(format, profile),
+        system: cachedSystemPrompt(systemPrompt),
         messages: [
           {
             role: "user",

--- a/app/api/admin/youtube/generate-ideas/route.ts
+++ b/app/api/admin/youtube/generate-ideas/route.ts
@@ -31,6 +31,7 @@ import {
   createRateLimitResponse,
   RATE_LIMITS,
 } from "@/lib/rate-limit"
+import { cachedSystemPrompt } from "@/lib/ai/anthropic-cache"
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY!,
@@ -154,6 +155,7 @@ export async function POST(request: NextRequest) {
     }
 
     const profile = getProfile(profileSlug)
+    const systemPrompt = getSystemPrompt(profile)
 
     // Cap count to a reasonable range — guards against accidental large
     // generations and runaway AI cost.
@@ -174,7 +176,7 @@ export async function POST(request: NextRequest) {
         model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 4096,
         temperature: 0.9,
-        system: getSystemPrompt(profile),
+        system: cachedSystemPrompt(systemPrompt),
         messages: [
           {
             role: "user",

--- a/app/api/admin/youtube/generate-script/route.ts
+++ b/app/api/admin/youtube/generate-script/route.ts
@@ -24,6 +24,7 @@ import {
   createRateLimitResponse,
   RATE_LIMITS,
 } from "@/lib/rate-limit"
+import { cachedSystemPrompt } from "@/lib/ai/anthropic-cache"
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY!,
@@ -110,7 +111,7 @@ Generate the full script now, following the format spec exactly. Output Markdown
         model: process.env.YOUTUBE_SCRIPT_MODEL || "claude-opus-4-5-20251101",
         max_tokens: 16384,
         temperature: 0.7,
-        system: systemPrompt,
+        system: cachedSystemPrompt(systemPrompt),
         messages: [
           {
             role: "user",

--- a/app/api/admin/youtube/panel-review/route.ts
+++ b/app/api/admin/youtube/panel-review/route.ts
@@ -40,6 +40,7 @@ import {
   createRateLimitResponse,
   RATE_LIMITS,
 } from "@/lib/rate-limit"
+import { cachedSystemPrompt } from "@/lib/ai/anthropic-cache"
 import type {
   PanelReview,
   ReviewerOutput,
@@ -293,7 +294,7 @@ async function runReviewer(
       model: REVIEWER_MODEL,
       max_tokens: 2048,
       temperature: 0.3,
-      system: systemPrompt,
+      system: cachedSystemPrompt(systemPrompt),
       messages: [
         {
           role: "user",

--- a/app/api/admin/youtube/regen-from-chat/route.ts
+++ b/app/api/admin/youtube/regen-from-chat/route.ts
@@ -31,6 +31,7 @@ import {
   createRateLimitResponse,
   RATE_LIMITS,
 } from "@/lib/rate-limit"
+import { cachedSystemPrompt } from "@/lib/ai/anthropic-cache"
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY!,
@@ -236,7 +237,7 @@ Generate the improved script now, addressing every point of the rewrite brief ab
         model: process.env.YOUTUBE_SCRIPT_MODEL || "claude-opus-4-5-20251101",
         max_tokens: 16_384,
         temperature: 0.7,
-        system: systemPrompt,
+        system: cachedSystemPrompt(systemPrompt),
         messages: [{ role: "user", content: userMessage }],
       },
       { signal: request.signal }

--- a/app/api/admin/youtube/validate-script/route.ts
+++ b/app/api/admin/youtube/validate-script/route.ts
@@ -28,6 +28,7 @@ import {
   createRateLimitResponse,
   RATE_LIMITS,
 } from "@/lib/rate-limit"
+import { cachedSystemPrompt } from "@/lib/ai/anthropic-cache"
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY!,
@@ -243,7 +244,7 @@ ${getBrandGuide(profile)}
         model: process.env.CLAUDE_MODEL || "claude-sonnet-4-5-20250929",
         max_tokens: 4096,
         temperature: 0.3,
-        system: systemPrompt,
+        system: cachedSystemPrompt(systemPrompt),
         messages: [
           {
             role: "user",

--- a/lib/ai/anthropic-cache.ts
+++ b/lib/ai/anthropic-cache.ts
@@ -1,0 +1,45 @@
+/**
+ * CATALYST - Anthropic Prompt Caching Helpers
+ */
+
+import type Anthropic from "@anthropic-ai/sdk"
+
+const FIVE_MINUTE_CACHE_CONTROL = {
+  type: "ephemeral",
+  ttl: "5m",
+} satisfies Anthropic.CacheControlEphemeral
+
+/**
+ * Anthropic can cache explicit text blocks, not the shorthand system string.
+ * Keep this tiny so route handlers can opt in only for stable prompt prefixes.
+ */
+export function cachedSystemPrompt(systemPrompt: string): Anthropic.TextBlockParam[] {
+  return [
+    {
+      type: "text",
+      text: systemPrompt,
+      cache_control: FIVE_MINUTE_CACHE_CONTROL,
+    },
+  ]
+}
+
+/**
+ * Place one cache breakpoint on the final custom function tool. Provider tools
+ * such as web_search are intentionally skipped.
+ */
+export function withCachedFinalTool<T extends Anthropic.ToolUnion>(tools: readonly T[]): T[] {
+  const next = tools.map((tool) => ({ ...tool })) as T[]
+
+  for (let index = next.length - 1; index >= 0; index--) {
+    const tool = next[index]
+    if (!("input_schema" in tool)) continue
+
+    next[index] = {
+      ...tool,
+      cache_control: tool.cache_control ?? FIVE_MINUTE_CACHE_CONTROL,
+    } as T
+    break
+  }
+
+  return next
+}

--- a/scripts/generate-all-essentials.ts
+++ b/scripts/generate-all-essentials.ts
@@ -21,6 +21,7 @@
 
 import { createClient } from "@supabase/supabase-js"
 import Anthropic from "@anthropic-ai/sdk"
+import { cachedSystemPrompt } from "../lib/ai/anthropic-cache"
 import { config } from "dotenv"
 import {
   ESSENTIALS_PROMPT_VERSION,
@@ -45,6 +46,11 @@ const API_DELAY_MS = 2000
 
 /** Maximum retries per module */
 const MAX_RETRIES = 3
+
+const SONNET_INPUT_COST_PER_MILLION = 3
+const SONNET_OUTPUT_COST_PER_MILLION = 15
+const CLAUDE_CACHE_WRITE_MULTIPLIER = 1.25
+const CLAUDE_CACHE_READ_MULTIPLIER = 0.1
 
 // =============================================================================
 // TYPES
@@ -82,7 +88,13 @@ interface GenerationResult {
   moduleSlug: string
   moduleTitle: string
   error?: string
-  tokensUsed?: { input: number; output: number }
+  tokensUsed?: {
+    input: number
+    output: number
+    freshInput: number
+    cacheWrite: number
+    cacheRead: number
+  }
   timeMs?: number
 }
 
@@ -226,7 +238,7 @@ async function generateEssentialsForModule(
     const response = await anthropic.messages.create({
       model: "claude-sonnet-4-20250514",
       max_tokens: 4000,
-      system: systemPrompt,
+      system: cachedSystemPrompt(systemPrompt),
       messages: [{ role: "user", content: userPrompt }],
     })
 
@@ -259,6 +271,13 @@ async function generateEssentialsForModule(
       throw new Error(`Database update failed: ${updateError.message}`)
     }
 
+    const cacheWrite = response.usage.cache_creation_input_tokens ?? 0
+    const cacheRead = response.usage.cache_read_input_tokens ?? 0
+    const freshInput = Math.max(
+      0,
+      response.usage.input_tokens - cacheWrite - cacheRead
+    )
+
     return {
       success: true,
       moduleSlug: module.slug,
@@ -266,6 +285,9 @@ async function generateEssentialsForModule(
       tokensUsed: {
         input: response.usage.input_tokens,
         output: response.usage.output_tokens,
+        freshInput,
+        cacheWrite,
+        cacheRead,
       },
       timeMs: Date.now() - startTime,
     }
@@ -411,6 +433,9 @@ async function main() {
   const results: GenerationResult[] = []
   let totalTokensIn = 0
   let totalTokensOut = 0
+  let totalFreshInputTokens = 0
+  let totalCacheWriteTokens = 0
+  let totalCacheReadTokens = 0
 
   for (let i = 0; i < modulesToProcess.length; i++) {
     const module = modulesToProcess[i]
@@ -449,6 +474,9 @@ async function main() {
       if (result.tokensUsed) {
         totalTokensIn += result.tokensUsed.input
         totalTokensOut += result.tokensUsed.output
+        totalFreshInputTokens += result.tokensUsed.freshInput
+        totalCacheWriteTokens += result.tokensUsed.cacheWrite
+        totalCacheReadTokens += result.tokensUsed.cacheRead
         console.log(`✅ (${formatDuration(result.timeMs || 0)}, ${result.tokensUsed.input + result.tokensUsed.output} tokens)`)
       } else {
         console.log(`✅ (dry run)`)
@@ -479,12 +507,22 @@ async function main() {
   if (!args.dryRun && totalTokensIn > 0) {
     console.log(`\n📊 Token Usage:`)
     console.log(`   Input tokens: ${totalTokensIn.toLocaleString()}`)
+    console.log(`   Fresh input tokens: ${totalFreshInputTokens.toLocaleString()}`)
+    console.log(`   Cache write tokens: ${totalCacheWriteTokens.toLocaleString()}`)
+    console.log(`   Cache read tokens: ${totalCacheReadTokens.toLocaleString()}`)
     console.log(`   Output tokens: ${totalTokensOut.toLocaleString()}`)
     console.log(`   Total tokens: ${(totalTokensIn + totalTokensOut).toLocaleString()}`)
 
-    // Rough cost estimate (Claude Sonnet pricing as of 2024)
-    const inputCost = (totalTokensIn / 1_000_000) * 3
-    const outputCost = (totalTokensOut / 1_000_000) * 15
+    const inputCost =
+      (totalFreshInputTokens / 1_000_000) * SONNET_INPUT_COST_PER_MILLION +
+      (totalCacheWriteTokens / 1_000_000) *
+        SONNET_INPUT_COST_PER_MILLION *
+        CLAUDE_CACHE_WRITE_MULTIPLIER +
+      (totalCacheReadTokens / 1_000_000) *
+        SONNET_INPUT_COST_PER_MILLION *
+        CLAUDE_CACHE_READ_MULTIPLIER
+    const outputCost =
+      (totalTokensOut / 1_000_000) * SONNET_OUTPUT_COST_PER_MILLION
     console.log(`   Estimated cost: ~$${(inputCost + outputCost).toFixed(2)}`)
   }
 

--- a/tests/lib/anthropic-cache.test.ts
+++ b/tests/lib/anthropic-cache.test.ts
@@ -1,0 +1,98 @@
+/**
+ * CATALYST - Anthropic Prompt Caching Helper Tests
+ */
+
+import type Anthropic from "@anthropic-ai/sdk"
+import { describe, expect, it } from "vitest"
+import {
+  cachedSystemPrompt,
+  withCachedFinalTool,
+} from "@/lib/ai/anthropic-cache"
+
+describe("anthropic-cache helpers", () => {
+  it("wraps a system prompt as a cacheable text block", () => {
+    expect(cachedSystemPrompt("Stable instructions")).toEqual([
+      {
+        type: "text",
+        text: "Stable instructions",
+        cache_control: {
+          type: "ephemeral",
+          ttl: "5m",
+        },
+      },
+    ])
+  })
+
+  it("adds a 5 minute cache breakpoint to the final custom tool", () => {
+    const tools: Anthropic.ToolUnion[] = [
+      {
+        name: "replace_section",
+        description: "Replace one section.",
+        input_schema: {
+          type: "object",
+          properties: {},
+        },
+      },
+      {
+        name: "web_search",
+        type: "web_search_20250305",
+      },
+      {
+        name: "request_regen",
+        description: "Request regeneration.",
+        input_schema: {
+          type: "object",
+          properties: {},
+        },
+      },
+    ]
+
+    const cached = withCachedFinalTool(tools)
+
+    expect(cached).not.toBe(tools)
+    expect(cached[0]).not.toHaveProperty("cache_control")
+    expect(cached[1]).not.toHaveProperty("cache_control")
+    expect(cached[2]).toMatchObject({
+      cache_control: {
+        type: "ephemeral",
+        ttl: "5m",
+      },
+    })
+    expect(tools[2]).not.toHaveProperty("cache_control")
+  })
+
+  it("preserves existing cache control on the final custom tool", () => {
+    const tools: Anthropic.ToolUnion[] = [
+      {
+        name: "replace_entire_script",
+        description: "Replace the script.",
+        cache_control: {
+          type: "ephemeral",
+          ttl: "1h",
+        },
+        input_schema: {
+          type: "object",
+          properties: {},
+        },
+      },
+    ]
+
+    expect(withCachedFinalTool(tools)[0]).toMatchObject({
+      cache_control: {
+        type: "ephemeral",
+        ttl: "1h",
+      },
+    })
+  })
+
+  it("skips provider tools when no custom tool is present", () => {
+    const tools: Anthropic.ToolUnion[] = [
+      {
+        name: "web_search",
+        type: "web_search_20250305",
+      },
+    ]
+
+    expect(withCachedFinalTool(tools)[0]).not.toHaveProperty("cache_control")
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowArbitraryExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Adds a shared Anthropic prompt caching helper and wires cacheable system prompts into high-value YouTube generation and review routes, with tool-schema caching for chat edit. Updates the essentials generation script to report fresh input, cache write, and cache read tokens with cache-aware cost math. Enables TypeScript arbitrary extension resolution so standalone tsc accepts existing static image imports. Validated with pnpm exec tsc --noEmit, pnpm lint, pnpm test:run, pnpm build, and git diff --check.