### PR TITLE
Auto-issue LMS completion certificates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,7 +146,9 @@ PERPLEXITY_API_KEY=
 ZAPIER_LEAD_WEBHOOK_URL=
 # Zapier webhook URL for returning lead submissions (with Bitrix Lead ID)
 ZAPIER_BID_WEBHOOK_URL=
-# Zapier webhook URL for general events (certificate issuance, etc.)
+# Zapier webhook URL for general events.
+# Used for certificate_issued events; configure Zapier to email the learner using
+# recipientEmail, certificateUrl, and certificatePdfUrl from the payload.
 ZAPIER_WEBHOOK_URL=
 
 # Calendly scheduling URL (for contact form scheduling step)

--- a/app/api/certificate/[certificateId]/pdf/route.ts
+++ b/app/api/certificate/[certificateId]/pdf/route.ts
@@ -12,6 +12,8 @@ import {
   Page,
   Text,
   View,
+  Svg,
+  Path,
   StyleSheet,
   renderToBuffer,
 } from "@react-pdf/renderer"
@@ -32,6 +34,7 @@ import { config } from "@/lib/config"
 const SPRUCE = "#576C75"
 const ASH = "#3F4142"
 const SERENITY = "#A6B5B0"
+const LOGO_MARK_PATH = "M55.45,11.29c-3.44-2.54-8.34-3.81-14.69-3.81h-15.38v.66c1.03.49,1.77,1.31,2.23,2.45.46,1.15.7,2.85.7,5.09v32.96c0,2.3-.23,4-.7,5.13-.17.41-.38.77-.62,1.1h-1.86c-4.59,0-8.15-1.05-10.69-3.15-2.54-2.1-3.81-5.32-3.81-9.67,0-8.59,4.98-13.23,14.94-13.92v-.73c-1.12-.2-2.39-.29-3.81-.29-4,.05-7.4.73-10.18,2.05-2.78,1.32-4.91,3.09-6.37,5.31-1.46,2.22-2.2,4.87-2.2,7.95,0,4.54,1.72,8.08,5.16,10.62,3.44,2.54,8.34,3.81,14.69,3.81h15.19v-.66c-1.27-.59-2.08-1.56-2.42-2.93-.34-1.37-.51-2.9-.51-4.62V9.46h3.37c4.59,0,8.15,1.05,10.69,3.15,2.54,2.1,3.81,5.32,3.81,9.67,0,8.59-4.98,13.23-14.94,13.92v.73c1.12.2,2.39.29,3.81.29,4-.05,7.4-.73,10.18-2.05,2.78-1.32,4.91-3.09,6.37-5.31,1.46-2.22,2.2-4.87,2.2-7.95,0-4.54-1.72-8.08-5.16-10.62Z"
 
 const styles = StyleSheet.create({
   page: {
@@ -60,6 +63,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 40,
+  },
+  logoMark: {
+    width: 34,
+    height: 34,
+    marginBottom: 12,
   },
   companyName: {
     fontSize: 14,
@@ -161,6 +169,14 @@ const styles = StyleSheet.create({
   },
 })
 
+function LogoMark() {
+  return React.createElement(
+    Svg,
+    { viewBox: "0 0 64 64", style: styles.logoMark },
+    React.createElement(Path, { d: LOGO_MARK_PATH, fill: SPRUCE })
+  )
+}
+
 // =============================================================================
 // PDF Document
 // =============================================================================
@@ -201,6 +217,7 @@ function CertificateDocument({
       React.createElement(
         View,
         { style: styles.content },
+        React.createElement(LogoMark),
         React.createElement(Text, { style: styles.companyName }, config.app.name),
         React.createElement(View, { style: styles.dividerTop }),
         React.createElement(Text, { style: styles.title }, "Certificate of Completion"),

--- a/app/learn/_surface/learn-layout-shell.tsx
+++ b/app/learn/_surface/learn-layout-shell.tsx
@@ -8,6 +8,7 @@
 
 import { getUserRole, getUserForMenu } from "@/lib/auth/require-auth"
 import { getCompetenciesForSidebar } from "@/lib/learning"
+import { getMyCertificate } from "@/lib/lms/certificate-queries"
 import { LearnShellClient } from "./learn-shell-client"
 
 interface LearnLayoutShellProps {
@@ -16,10 +17,11 @@ interface LearnLayoutShellProps {
 
 export async function LearnLayoutShell({ children }: LearnLayoutShellProps) {
   // Fetch shell data in parallel
-  const [competencies, userRole, userMenu] = await Promise.all([
+  const [competencies, userRole, userMenu, certificate] = await Promise.all([
     getCompetenciesForSidebar(),
     getUserRole(),
     getUserForMenu(),
+    getMyCertificate(),
   ])
 
   return (
@@ -27,6 +29,7 @@ export async function LearnLayoutShell({ children }: LearnLayoutShellProps) {
       competencies={competencies}
       userRole={userRole}
       user={userMenu ?? undefined}
+      certificateAvailable={Boolean(certificate && !certificate.revokedAt)}
     >
       {children}
     </LearnShellClient>

--- a/app/learn/_surface/learn-shell-client.tsx
+++ b/app/learn/_surface/learn-shell-client.tsx
@@ -56,6 +56,7 @@ interface LearnShellClientProps {
   competencies?: Competency[]
   userRole?: "learner" | "marketing" | "youtube_editor" | "admin"
   user?: UserMenuUser
+  certificateAvailable?: boolean
 }
 
 // -----------------------------------------------------------------------------
@@ -103,6 +104,7 @@ export function LearnShellClient({
   competencies = [],
   userRole = "learner",
   user,
+  certificateAvailable = false,
 }: LearnShellClientProps) {
   const pathname = usePathname()
   const [drawerOpen, setDrawerOpen] = React.useState(false)
@@ -229,6 +231,7 @@ export function LearnShellClient({
               currentCompetency={currentCompetency}
               currentModule={currentModule}
               userRole={userRole}
+              certificateAvailable={certificateAvailable}
             />
             
             {/* Mobile drawer */}
@@ -259,6 +262,7 @@ export function LearnShellClient({
                   currentCompetency={currentCompetency}
                   currentModule={currentModule}
                   userRole={userRole}
+                  certificateAvailable={certificateAvailable}
                   onNavigate={() => setDrawerOpen(false)}
                 />
               </div>

--- a/app/learn/_surface/learn-sidebar.tsx
+++ b/app/learn/_surface/learn-sidebar.tsx
@@ -59,6 +59,8 @@ interface LearnSidebarProps {
   currentModule?: string
   /** User role for admin visibility */
   userRole?: "learner" | "marketing" | "youtube_editor" | "admin"
+  /** Whether the learner has an issued active completion certificate */
+  certificateAvailable?: boolean
   /** Callback for mobile drawer close */
   onNavigate?: () => void
 }
@@ -73,6 +75,7 @@ export function LearnSidebar({
   currentCompetency,
   currentModule,
   userRole = "learner",
+  certificateAvailable = false,
   onNavigate,
 }: LearnSidebarProps) {
   const [courseExpanded, setCourseExpanded] = React.useState(activeSection === "course")
@@ -294,7 +297,10 @@ export function LearnSidebar({
             onClick={onNavigate}
           >
             <AwardIcon className="learn-sidebar__nav-icon" />
-            <span>Certification Prep</span>
+            <span>{certificateAvailable ? "Certificate Available" : "Certification Prep"}</span>
+            {certificateAvailable && (
+              <span className="learn-sidebar__status-badge">Ready</span>
+            )}
           </Link>
         </nav>
       </div>

--- a/app/learn/certification/_components/claim-certificate.tsx
+++ b/app/learn/certification/_components/claim-certificate.tsx
@@ -6,18 +6,19 @@
 
 "use client"
 
-import { useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { AwardIcon, Loader2Icon } from "lucide-react"
+import { AwardIcon, Loader2Icon, RotateCcwIcon } from "lucide-react"
 import { issueCertificate } from "@/lib/actions/certificate"
 
 export function ClaimCertificate() {
-  const [loading, setLoading] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const router = useRouter()
+  const hasRequested = useRef(false)
 
-  async function handleClaim() {
+  const handleIssue = useCallback(async () => {
     setLoading(true)
     setError(null)
 
@@ -30,7 +31,15 @@ export function ClaimCertificate() {
     }
 
     setLoading(false)
-  }
+  }, [router])
+
+  useEffect(() => {
+    if (hasRequested.current) return
+    hasRequested.current = true
+    queueMicrotask(() => {
+      void handleIssue()
+    })
+  }, [handleIssue])
 
   return (
     <div className="cert-claim">
@@ -39,15 +48,15 @@ export function ClaimCertificate() {
       </div>
       <h2 className="cert-claim__title">You&apos;re Ready!</h2>
       <p className="cert-claim__description">
-        You&apos;ve completed all modules and passed all quizzes.
-        Claim your certificate of completion.
+        You&apos;ve completed all LMS modules.
+        Your certificate is being issued automatically.
       </p>
       {error && (
         <p className="cert-claim__error">{error}</p>
       )}
       <Button
         size="lg"
-        onClick={handleClaim}
+        onClick={handleIssue}
         disabled={loading}
       >
         {loading ? (
@@ -57,8 +66,8 @@ export function ClaimCertificate() {
           </>
         ) : (
           <>
-            <AwardIcon className="h-4 w-4 mr-2" />
-            Claim Your Certificate
+            <RotateCcwIcon className="h-4 w-4 mr-2" />
+            Try Again
           </>
         )}
       </Button>

--- a/app/learn/certification/page.tsx
+++ b/app/learn/certification/page.tsx
@@ -47,13 +47,10 @@ interface Competency {
 }
 
 interface UserProgress {
-  competenciesCompleted: number
-  totalCompetencies: number
   modulesCompleted: number
   totalModules: number
   quizzesCompleted: number
   totalQuizzes: number
-  averageQuizScore: number | null
 }
 
 interface UserProfile {
@@ -122,36 +119,6 @@ async function getCompetencies(): Promise<Competency[]> {
   return competenciesWithCounts
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- userId reserved for future per-user filtering
-async function getUserProgress(_userId: string): Promise<UserProgress> {
-  const supabase = await createClient()
-  
-  // Get total counts
-  const { count: totalModules } = await supabase
-    .from("learning_modules")
-    .select("*", { count: "exact", head: true })
-  
-  const { count: totalQuizzes } = await supabase
-    .from("quizzes")
-    .select("*", { count: "exact", head: true })
-  
-  const { count: totalCompetencies } = await supabase
-    .from("competencies")
-    .select("*", { count: "exact", head: true })
-  
-  // Get user progress (simplified - in production would track actual progress)
-  // For now, return mock data
-  return {
-    competenciesCompleted: 0,
-    totalCompetencies: totalCompetencies || 0,
-    modulesCompleted: 0,
-    totalModules: totalModules || 0,
-    quizzesCompleted: 0,
-    totalQuizzes: totalQuizzes || 0,
-    averageQuizScore: null,
-  }
-}
-
 // =============================================================================
 // Components
 // =============================================================================
@@ -164,21 +131,9 @@ function ReadinessChecklist({ progress }: { progress: UserProgress }) {
       detail: `${progress.modulesCompleted}/${progress.totalModules} modules completed`,
     },
     {
-      label: "Pass all quizzes",
-      done: progress.quizzesCompleted >= progress.totalQuizzes,
-      detail: `${progress.quizzesCompleted}/${progress.totalQuizzes} quizzes passed`,
-    },
-    {
-      label: "Average quiz score ≥80%",
-      done: (progress.averageQuizScore ?? 0) >= 80,
-      detail: progress.averageQuizScore 
-        ? `Current average: ${Math.round(progress.averageQuizScore)}%`
-        : "Complete quizzes to see average",
-    },
-    {
-      label: "Practice with scenarios",
-      done: false, // Would track scenario practice
-      detail: "Recommended: Practice 3+ scenarios per category",
+      label: "Completion certificate",
+      done: progress.modulesCompleted >= progress.totalModules,
+      detail: "Issued automatically when training is complete",
     },
   ]
   
@@ -315,23 +270,15 @@ export default async function CertificationPage() {
     checkCertificateEligibility(),
   ])
 
-  // Get progress (would be real progress tracking in production)
-  const progress = profile
-    ? await getUserProgress(profile.id)
-    : {
-        competenciesCompleted: 0,
-        totalCompetencies: competencies.length,
-        modulesCompleted: 0,
-        totalModules: competencies.reduce((sum, c) => sum + c.module_count, 0),
-        quizzesCompleted: 0,
-        totalQuizzes: competencies.reduce((sum, c) => sum + c.quiz_count, 0),
-        averageQuizScore: null,
-      }
+  const progress = {
+    modulesCompleted: eligibility.modulesCompleted,
+    totalModules: eligibility.totalModules || competencies.reduce((sum, c) => sum + c.module_count, 0),
+    quizzesCompleted: eligibility.quizzesPassed,
+    totalQuizzes: eligibility.totalQuizzes || competencies.reduce((sum, c) => sum + c.quiz_count, 0),
+  }
 
   const isReadyForCertification =
-    progress.modulesCompleted >= progress.totalModules &&
-    progress.quizzesCompleted >= progress.totalQuizzes &&
-    (progress.averageQuizScore ?? 0) >= 80
+    progress.modulesCompleted >= progress.totalModules
 
   const isCertified = profile?.certification_status === 'certified'
   const hasCertificate = myCertificate && !myCertificate.revokedAt

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -359,6 +359,18 @@
   opacity: 1;
 }
 
+.learn-sidebar__status-badge {
+  margin-left: auto;
+  padding: 0.125rem 0.375rem;
+  border-radius: 999px;
+  background: oklch(from var(--color-primary) l c h / 0.1);
+  color: var(--color-primary);
+  font-size: 0.625rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
 /* Competency list in Course Content section */
 .learn-sidebar__competencies {
   display: flex;
@@ -10725,4 +10737,3 @@
 .cert-admin-cert-row__status--revoked {
   color: var(--color-destructive);
 }
-

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -207,7 +207,7 @@ export default async function LearnDashboardPage() {
             <div className="lms-certificate-banner__content">
               <h3 className="lms-certificate-banner__title">Your Certificate is Ready</h3>
               <p className="lms-certificate-banner__description">
-                You&apos;ve completed all modules. View and download your completion certificate.
+                You&apos;ve completed the training. View and download your completion certificate.
               </p>
             </div>
             <div className="lms-certificate-banner__action">

--- a/app/learn/quiz/[quizId]/quiz-page-client.tsx
+++ b/app/learn/quiz/[quizId]/quiz-page-client.tsx
@@ -28,6 +28,7 @@ import {
   LightbulbIcon,
   ChevronDownIcon,
   ChevronUpIcon,
+  AwardIcon,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { submitQuizAttempt, type QuizAnswer } from "@/lib/actions/learning"
@@ -162,6 +163,7 @@ export function QuizPageClient({ quiz, questions, returnTo, showImmediateFeedbac
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [lastAnswerCorrect, setLastAnswerCorrect] = useState(false)
   const [expandedQuestions, setExpandedQuestions] = useState<Set<string>>(new Set())
+  const [issuedCertificateId, setIssuedCertificateId] = useState<string | null>(null)
   
   const currentQuestion = questions[currentIndex]
   const totalQuestions = questions.length
@@ -227,7 +229,8 @@ export function QuizPageClient({ quiz, questions, returnTo, showImmediateFeedbac
         questionId: qId,
         selectedOption: opt,
       }))
-      await submitQuizAttempt(quiz.slug, quizAnswers)
+      const result = await submitQuizAttempt(quiz.slug, quizAnswers)
+      setIssuedCertificateId(result.certificateId ?? null)
     } catch (error) {
       console.error("Failed to save quiz attempt:", error)
     }
@@ -244,6 +247,7 @@ export function QuizPageClient({ quiz, questions, returnTo, showImmediateFeedbac
     setState("in-progress")
     setLastAnswerCorrect(false)
     setExpandedQuestions(new Set())
+    setIssuedCertificateId(null)
   }
   
   const handleDownloadResults = () => {
@@ -346,6 +350,35 @@ export function QuizPageClient({ quiz, questions, returnTo, showImmediateFeedbac
               </Stack>
             </CardContent>
           </Card>
+
+          {issuedCertificateId && (
+            <Card className="w-full border-primary/30 bg-primary/5">
+              <CardContent className="py-5">
+                <Stack gap="md" align="center" className="text-center">
+                  <div className="w-12 h-12 rounded-full bg-primary/10 text-primary flex items-center justify-center">
+                    <AwardIcon className="h-6 w-6" />
+                  </div>
+                  <Stack gap="xs" align="center">
+                    <Title size="h4">Certificate issued</Title>
+                    <Text size="sm" className="text-muted-foreground max-w-md">
+                      Your completion certificate is ready and available from the LMS sidebar.
+                    </Text>
+                  </Stack>
+                  <Row gap="sm" className="flex-wrap justify-center">
+                    <Button render={<Link href="/learn/certification" />}>
+                      View in LMS
+                    </Button>
+                    <Button
+                      variant="outline"
+                      render={<Link href={`/certificate/${issuedCertificateId}`} target="_blank" />}
+                    >
+                      Open Certificate
+                    </Button>
+                  </Row>
+                </Stack>
+              </CardContent>
+            </Card>
+          )}
           
           {/* Action Buttons */}
           <Row gap="sm" className="w-full max-w-sm flex-wrap justify-center">

--- a/components/lms/quiz-sheet.tsx
+++ b/components/lms/quiz-sheet.tsx
@@ -10,6 +10,7 @@
 "use client"
 
 import * as React from "react"
+import Link from "next/link"
 import { Stack, Row, Text, Title } from "@/components/core"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -28,6 +29,7 @@ import {
   ArrowRightIcon,
   XIcon,
   CheckIcon,
+  AwardIcon,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { submitQuizAttempt, type QuizAnswer } from "@/lib/actions/learning"
@@ -78,6 +80,7 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const [lastAnswerCorrect, setLastAnswerCorrect] = React.useState(false)
   const [submitError, setSubmitError] = React.useState<string | null>(null)
+  const [issuedCertificateId, setIssuedCertificateId] = React.useState<string | null>(null)
   
   const currentQuestion = questions[currentIndex]
   const totalQuestions = questions.length
@@ -125,7 +128,8 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
           questionId: qId,
           selectedOption: opt,
         }))
-        await submitQuizAttempt(quiz.slug, quizAnswers)
+        const result = await submitQuizAttempt(quiz.slug, quizAnswers)
+        setIssuedCertificateId(result.certificateId ?? null)
         setIsSubmitting(false)
         setState("complete")
 
@@ -153,6 +157,7 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
     setState("in-progress")
     setLastAnswerCorrect(false)
     setSubmitError(null)
+    setIssuedCertificateId(null)
   }
 
   const handleClose = () => {
@@ -239,6 +244,7 @@ export function QuizSheet({ quiz, questions, trigger, onComplete }: QuizSheetPro
               score={getFinalScore()}
               totalQuestions={totalQuestions}
               passingScore={quiz.passing_score}
+              certificateId={issuedCertificateId}
               onRetry={handleRetry}
               onClose={handleClose}
             />
@@ -454,6 +460,7 @@ interface QuizResultsProps {
   score: number
   totalQuestions: number
   passingScore: number
+  certificateId: string | null
   onRetry: () => void
   onClose: () => void
 }
@@ -462,6 +469,7 @@ function QuizResults({
   score,
   totalQuestions,
   passingScore,
+  certificateId,
   onRetry,
   onClose,
 }: QuizResultsProps) {
@@ -519,6 +527,27 @@ function QuizResults({
             </Stack>
           </CardContent>
         </Card>
+
+        {certificateId && (
+          <Card className="w-full border-primary/30 bg-primary/5">
+            <CardContent className="py-5">
+              <Stack gap="md" align="center">
+                <div className="w-12 h-12 rounded-full bg-primary/10 text-primary flex items-center justify-center">
+                  <AwardIcon className="h-6 w-6" />
+                </div>
+                <Stack gap="xs" align="center">
+                  <Title size="h4">Certificate issued</Title>
+                  <Text size="sm" className="text-muted-foreground max-w-xs">
+                    Your completion certificate is ready in the LMS sidebar.
+                  </Text>
+                </Stack>
+                <Button render={<Link href="/learn/certification" />}>
+                  View Certificate
+                </Button>
+              </Stack>
+            </CardContent>
+          </Card>
+        )}
         
         {/* Actions */}
         <Stack gap="sm" className="w-full">

--- a/lib/actions/certificate.ts
+++ b/lib/actions/certificate.ts
@@ -22,6 +22,11 @@ type ActionResult<T = void> =
   | { success: true; data: T }
   | { success: false; error: string }
 
+interface IssueCertificateForUserOptions {
+  userId: string
+  userEmail?: string | null
+}
+
 // =============================================================================
 // Eligibility Check
 // =============================================================================
@@ -85,9 +90,7 @@ export async function checkCertificateEligibility(
 
   const eligible =
     safeTotal > 0 &&
-    safeCompleted >= safeTotal &&
-    safeTotalQuizzes > 0 &&
-    quizzesPassed >= safeTotalQuizzes
+    safeCompleted >= safeTotal
 
   return {
     eligible,
@@ -117,11 +120,32 @@ export async function issueCertificate(): Promise<ActionResult<CertificateWithPr
       return { success: false, error: "Not authenticated" }
     }
 
-    // Check for existing active certificate
+    return await issueCertificateForUser({
+      userId: user.id,
+      userEmail: user.email,
+    })
+  } catch (error) {
+    trackActionError(error, "issueCertificate")
+    return { success: false, error: "Failed to issue certificate" }
+  }
+}
+
+/**
+ * Issue a completion certificate for a specific user.
+ * Used by module/quiz completion so certificates are created automatically.
+ */
+export async function issueCertificateForUser({
+  userId,
+  userEmail,
+}: IssueCertificateForUserOptions): Promise<ActionResult<CertificateWithProfile>> {
+  try {
+    const supabase = await createClient()
+
+    // Check for existing active certificate first so completion hooks are idempotent.
     const { data: existing } = await supabase
       .from("completion_certificates")
       .select("*, user_profiles!completion_certificates_user_id_fkey(full_name)")
-      .eq("user_id", user.id)
+      .eq("user_id", userId)
       .is("revoked_at", null)
       .limit(1)
       .single()
@@ -129,25 +153,11 @@ export async function issueCertificate(): Promise<ActionResult<CertificateWithPr
     if (existing) {
       return {
         success: true,
-        data: {
-          id: existing.id,
-          certificateId: existing.certificate_id,
-          userId: existing.user_id,
-          issuedAt: existing.issued_at,
-          revokedAt: existing.revoked_at,
-          revokedBy: existing.revoked_by,
-          revokeReason: existing.revoke_reason,
-          modulesCompleted: existing.modules_completed,
-          quizzesPassed: existing.quizzes_passed,
-          courseName: existing.course_name,
-          createdAt: existing.created_at,
-          fullName: existing.user_profiles?.full_name || "Unknown",
-        },
+        data: mapCertificateActionRow(existing),
       }
     }
 
-    // Check eligibility
-    const eligibility = await checkCertificateEligibility(user.id)
+    const eligibility = await checkCertificateEligibility(userId)
     if (!eligibility.eligible) {
       return {
         success: false,
@@ -155,23 +165,20 @@ export async function issueCertificate(): Promise<ActionResult<CertificateWithPr
       }
     }
 
-    // Generate certificate ID atomically via database sequence
     const { data: certificateId, error: seqError } = await supabase.rpc("generate_certificate_id")
     if (seqError || !certificateId) throw seqError ?? new Error("Failed to generate certificate ID")
 
-    // Get user profile for name
     const { data: profile } = await supabase
       .from("user_profiles")
       .select("full_name")
-      .eq("id", user.id)
+      .eq("id", userId)
       .single()
 
-    // Insert certificate
     const { data: cert, error: insertError } = await supabase
       .from("completion_certificates")
       .insert({
         certificate_id: certificateId,
-        user_id: user.id,
+        user_id: userId,
         modules_completed: eligibility.modulesCompleted,
         quizzes_passed: eligibility.quizzesPassed,
         course_name: config.learning.courseName,
@@ -179,20 +186,47 @@ export async function issueCertificate(): Promise<ActionResult<CertificateWithPr
       .select()
       .single()
 
-    if (insertError) throw insertError
+    if (insertError) {
+      if (insertError.code === "23505") {
+        const { data: racedExisting } = await supabase
+          .from("completion_certificates")
+          .select("*, user_profiles!completion_certificates_user_id_fkey(full_name)")
+          .eq("user_id", userId)
+          .is("revoked_at", null)
+          .limit(1)
+          .single()
 
-    // Fire Zapier webhook (non-blocking)
+        if (racedExisting) {
+          return {
+            success: true,
+            data: mapCertificateActionRow(racedExisting),
+          }
+        }
+      }
+
+      throw insertError
+    }
+
+    const certificateUrl = `${config.app.url}/certificate/${certificateId}`
+    const certificatePdfUrl = `${config.app.url}/api/certificate/${certificateId}/pdf`
+
     triggerZapierWebhook("certificate_issued", {
       learnerName: profile?.full_name || "Unknown",
-      learnerEmail: user.email,
+      learnerEmail: userEmail,
+      recipientEmail: userEmail,
       certificateId,
-      certificateUrl: `${config.app.url}/certificate/${certificateId}`,
+      certificateUrl,
+      certificatePdfUrl,
       modulesCompleted: eligibility.modulesCompleted,
       quizzesPassed: eligibility.quizzesPassed,
+      courseName: config.learning.courseName,
+      emailSubject: `Your ${config.app.name} completion certificate is ready`,
     })
 
     revalidatePath("/learn")
+    revalidatePath("/learn", "layout")
     revalidatePath("/learn/certification")
+    revalidatePath("/learn/progress")
     revalidatePath("/learn/admin/certification")
 
     return {
@@ -213,10 +247,29 @@ export async function issueCertificate(): Promise<ActionResult<CertificateWithPr
       },
     }
   } catch (error) {
-    trackActionError(error, "issueCertificate")
+    trackActionError(error, "issueCertificateForUser", { userId })
     return { success: false, error: "Failed to issue certificate" }
   }
 }
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function mapCertificateActionRow(row: any): CertificateWithProfile {
+  return {
+    id: row.id,
+    certificateId: row.certificate_id,
+    userId: row.user_id,
+    issuedAt: row.issued_at,
+    revokedAt: row.revoked_at,
+    revokedBy: row.revoked_by,
+    revokeReason: row.revoke_reason,
+    modulesCompleted: row.modules_completed,
+    quizzesPassed: row.quizzes_passed,
+    courseName: row.course_name,
+    createdAt: row.created_at,
+    fullName: row.user_profiles?.full_name || "Unknown",
+  }
+}
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 // =============================================================================
 // Revoke Certificate (Admin)

--- a/lib/actions/learning.ts
+++ b/lib/actions/learning.ts
@@ -22,6 +22,10 @@ export type ActionResult<T = void> =
   | { success: true; data: T }
   | { success: false; error: string }
 
+interface ModuleCompletionResult {
+  certificateId?: string
+}
+
 // =============================================================================
 // PROGRESS ACTIONS
 // =============================================================================
@@ -67,7 +71,7 @@ export async function markModuleStarted(moduleId: string): Promise<ActionResult>
 /**
  * Mark a module as completed.
  */
-export async function markModuleComplete(moduleId: string): Promise<ActionResult> {
+export async function markModuleComplete(moduleId: string): Promise<ActionResult<ModuleCompletionResult>> {
   try {
     const supabase = await createClient()
 
@@ -93,8 +97,24 @@ export async function markModuleComplete(moduleId: string): Promise<ActionResult
 
     if (error) throw error
 
+    let certificateId: string | undefined
+    if (user.email) {
+      try {
+        const { issueCertificateForUser } = await import("@/lib/actions/certificate")
+        const certificateResult = await issueCertificateForUser({
+          userId: user.id,
+          userEmail: user.email,
+        })
+        if (certificateResult.success) {
+          certificateId = certificateResult.data.certificateId
+        }
+      } catch (certificateError) {
+        trackActionError(certificateError, "markModuleComplete.issueCertificate", { moduleId })
+      }
+    }
+
     revalidatePath("/learn")
-    return { success: true, data: undefined }
+    return { success: true, data: { certificateId } }
   } catch (error) {
     trackActionError(error, "markModuleComplete", { moduleId })
     return { success: false, error: "Failed to mark module as completed" }
@@ -117,6 +137,7 @@ export interface QuizResult {
   correctAnswers: string[]
   explanations: Record<string, string>
   certificateEligible?: boolean
+  certificateId?: string
 }
 
 /**
@@ -238,20 +259,37 @@ export async function submitQuizAttempt(
 
   if (saveError) throw saveError
 
-  // If passed and we have a module ID, mark module as complete
+  let certificateId: string | undefined
+
+  // If passed and we have a module ID, mark module as complete.
+  // Certificate issuance is centralized in markModuleComplete so a passing
+  // module quiz does not make a second issuance attempt.
   if (passed && moduleId) {
-    await markModuleComplete(moduleId)
+    const completionResult = await markModuleComplete(moduleId)
+    if (completionResult.success) {
+      certificateId = completionResult.data.certificateId
+    }
   }
 
   revalidatePath("/learn")
 
-  // Check certificate eligibility after a passing quiz
+  // Standalone passing quizzes without a linked module still get a final
+  // eligibility check, but issueCertificateForUser remains one-active-cert
+  // idempotent.
   let certificateEligible = false
-  if (passed) {
+  if (certificateId) {
+    certificateEligible = true
+  } else if (passed && !moduleId && user.email) {
     try {
-      const { checkCertificateEligibility } = await import("@/lib/actions/certificate")
-      const eligibility = await checkCertificateEligibility(user.id)
-      certificateEligible = eligibility.eligible
+      const { issueCertificateForUser } = await import("@/lib/actions/certificate")
+      const certificateResult = await issueCertificateForUser({
+        userId: user.id,
+        userEmail: user.email,
+      })
+      if (certificateResult.success) {
+        certificateEligible = true
+        certificateId = certificateResult.data.certificateId
+      }
     } catch {
       // Non-blocking — don't fail the quiz submission
     }
@@ -264,6 +302,7 @@ export async function submitQuizAttempt(
     correctAnswers,
     explanations,
     certificateEligible,
+    certificateId,
   }
 }
 

--- a/supabase/migrations/20260701000000_unique_active_completion_certificate.sql
+++ b/supabase/migrations/20260701000000_unique_active_completion_certificate.sql
@@ -1,0 +1,31 @@
+-- CATALYST - Unique Active Completion Certificate
+--
+-- Automatic issuance can be triggered from module completion and quiz completion.
+-- Keep the database idempotent under concurrent requests.
+
+WITH ranked_active_certificates AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id
+      ORDER BY issued_at ASC, created_at ASC, id ASC
+    ) AS active_rank
+  FROM completion_certificates
+  WHERE revoked_at IS NULL
+)
+UPDATE completion_certificates
+SET
+  revoked_at = NOW(),
+  revoke_reason = COALESCE(
+    revoke_reason,
+    'Automatically revoked duplicate active certificate during one-active-certificate migration'
+  )
+WHERE id IN (
+  SELECT id
+  FROM ranked_active_certificates
+  WHERE active_rank > 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_completion_certificates_one_active_per_user
+  ON completion_certificates(user_id)
+  WHERE revoked_at IS NULL;


### PR DESCRIPTION
## Summary
- Auto-issue one LMS completion certificate when a learner completes all modules
- Surface certificate availability in the LMS sidebar, dashboard, quiz results, and certification page
- Add certificate PDF logo mark and Zapier email payload fields
- Add a database guard for one active certificate per learner, with duplicate cleanup before indexing

## Validation
- pnpm lint
- pnpm test:run tests/learn/quiz-scoring.test.ts
- pnpm build