### PR TITLE
Fix LMS progress undercount from PostgREST 1000-row cap

### DIFF
--- a/app/api/feedback/export/route.ts
+++ b/app/api/feedback/export/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
+import { fetchAllRows } from "@/lib/supabase/fetch-all"
 import { type Feedback } from "@/lib/lms/feedback"
 
 export async function GET(request: NextRequest) {
@@ -35,28 +36,33 @@ export async function GET(request: NextRequest) {
   const status = searchParams.get("status")
   const type = searchParams.get("type")
 
-  // Fetch feedback
-  let query = supabase
-    .from("lms_feedback")
-    .select("*")
-    .order("created_at", { ascending: false })
+  // Fetch feedback, paged past the 1000-row cap so exports are never truncated.
+  let feedback: Feedback[]
+  try {
+    feedback = await fetchAllRows<Feedback>((from, to) => {
+      let query = supabase
+        .from("lms_feedback")
+        .select("*")
+        .order("created_at", { ascending: false })
+        .order("id")
+        .range(from, to)
 
-  if (status && status !== "all") {
-    query = query.eq("status", status)
-  }
+      if (status && status !== "all") {
+        query = query.eq("status", status)
+      }
 
-  if (type && type !== "all") {
-    query = query.eq("feedback_type", type)
-  }
+      if (type && type !== "all") {
+        query = query.eq("feedback_type", type)
+      }
 
-  const { data: feedback, error } = await query
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+      return query
+    })
+  } catch (err) {
+    return NextResponse.json({ error: (err as Error).message }, { status: 500 })
   }
 
   // Generate Markdown
-  const markdown = generateMarkdown((feedback as Feedback[]) || [])
+  const markdown = generateMarkdown(feedback)
 
   // Return as downloadable file
   return new NextResponse(markdown, {

--- a/app/learn/admin/certification/page.tsx
+++ b/app/learn/admin/certification/page.tsx
@@ -183,20 +183,25 @@ async function getStats() {
     .eq("role", "learner")
     .in("certification_status", ["ready", "in_progress"])
   
-  // Get pass rate from attempts (if table exists)
-  const { data: attempts } = await supabase
+  // Get pass rate from attempts (if table exists). Counted server-side so the ratio
+  // stays correct past the 1000-row cap instead of fetching and counting rows in JS.
+  const { count: totalAttempts } = await supabase
     .from("certification_attempts")
-    .select("outcome")
-  
-  const passRate = attempts && attempts.length > 0
-    ? Math.round((attempts.filter(a => a.outcome === 'passed').length / attempts.length) * 100)
+    .select("*", { count: "exact", head: true })
+  const { count: passedAttempts } = await supabase
+    .from("certification_attempts")
+    .select("*", { count: "exact", head: true })
+    .eq("outcome", "passed")
+
+  const passRate = totalAttempts && totalAttempts > 0
+    ? Math.round(((passedAttempts || 0) / totalAttempts) * 100)
     : null
   
   return {
     certified: certifiedCount || 0,
     pending: pendingCount || 0,
     passRate,
-    totalAttempts: attempts?.length || 0,
+    totalAttempts: totalAttempts || 0,
   }
 }
 

--- a/app/learn/admin/feedback/feedback-list.tsx
+++ b/app/learn/admin/feedback/feedback-list.tsx
@@ -6,6 +6,7 @@
  */
 
 import { createClient } from "@/lib/supabase/server"
+import { fetchAllRows } from "@/lib/supabase/fetch-all"
 import { FeedbackCard } from "./feedback-card"
 import { type Feedback, getFeedbackFileUrls } from "@/lib/lms/feedback"
 import { MessageSquareIcon } from "lucide-react"
@@ -18,27 +19,32 @@ type Props = {
 export async function FeedbackList({ status, type }: Props) {
   const supabase = await createClient()
 
-  let query = supabase
-    .from("lms_feedback")
-    .select(`
-      *,
-      user_profiles:user_id (full_name)
-    `)
-    .order("created_at", { ascending: false })
+  // Paged past the 1000-row cap so no feedback silently disappears from the list.
+  const feedback = await fetchAllRows<Feedback & { user_profiles: { full_name: string } | null }>((from, to) => {
+    let query = supabase
+      .from("lms_feedback")
+      .select(`
+        *,
+        user_profiles:user_id (full_name)
+      `)
+      .order("created_at", { ascending: false })
+      .order("id")
+      .range(from, to)
 
-  if (status && status !== "all") {
-    // Show specific status
-    query = query.eq("status", status)
-  } else {
-    // Default: exclude archived feedback
-    query = query.neq("status", "archived")
-  }
+    if (status && status !== "all") {
+      // Show specific status
+      query = query.eq("status", status)
+    } else {
+      // Default: exclude archived feedback
+      query = query.neq("status", "archived")
+    }
 
-  if (type && type !== "all") {
-    query = query.eq("feedback_type", type)
-  }
+    if (type && type !== "all") {
+      query = query.eq("feedback_type", type)
+    }
 
-  const { data: feedback } = await query
+    return query
+  })
 
   if (!feedback?.length) {
     return (

--- a/lib/actions/learning.ts
+++ b/lib/actions/learning.ts
@@ -9,6 +9,7 @@
 "use server"
 
 import { createClient } from "@/lib/supabase/server"
+import { fetchAllRows } from "@/lib/supabase/fetch-all"
 import { revalidatePath } from "next/cache"
 import { config } from "@/lib/config"
 import { trackActionError } from "@/lib/error-tracking"
@@ -350,11 +351,17 @@ export async function getProgressStats(): Promise<ProgressStats> {
   const completedModules = progressRecords?.filter((p) => p.status === "completed").length || 0
   const inProgressModules = progressRecords?.filter((p) => p.status === "in_progress").length || 0
   
-  // Get total quizzes (count unique module_id from quiz_questions)
-  const { data: quizModules } = await supabase
-    .from("quiz_questions")
-    .select("module_id")
-  
+  // Get total quizzes (count unique module_id from quiz_questions). Paged past the
+  // 1000-row cap so the distinct count stays correct as the question bank grows.
+  const quizModules = await fetchAllRows<{ module_id: string }>(
+    (from, to) =>
+      supabase
+        .from("quiz_questions")
+        .select("module_id")
+        .order("id")
+        .range(from, to),
+  )
+
   const uniqueQuizModules = new Set(quizModules?.map((q) => q.module_id) || [])
   const totalQuizzes = uniqueQuizModules.size
   

--- a/lib/lms/admin-queries.ts
+++ b/lib/lms/admin-queries.ts
@@ -5,7 +5,9 @@
  * All queries respect RLS and require admin role.
  */
 
+import { cache } from "react"
 import { createClient } from "@/lib/supabase/server"
+import { fetchAllRows } from "@/lib/supabase/fetch-all"
 
 // =============================================================================
 // Types
@@ -93,8 +95,12 @@ export interface ProgressStats {
 
 /**
  * Get all learners with their progress summary.
+ *
+ * Wrapped in React's `cache()` so multiple callers in the same request (e.g. the team
+ * page calls this directly AND via getProgressStats) share one paginated fetch instead
+ * of hitting the database twice.
  */
-export async function getAllLearnersWithProgress(): Promise<LearnerSummary[]> {
+export const getAllLearnersWithProgress = cache(async function getAllLearnersWithProgress(): Promise<LearnerSummary[]> {
   const supabase = await createClient()
 
   // Get all user profiles (admins + learners)
@@ -121,27 +127,47 @@ export async function getAllLearnersWithProgress(): Promise<LearnerSummary[]> {
     }
   }
 
-  // Get all learning progress
-  const { data: allProgress } = await supabase
-    .from("learning_progress")
-    .select("user_id, status, completed_at")
-
-  // Get all quiz attempts for last activity
-  const { data: allQuizAttempts } = await supabase
-    .from("quiz_attempts")
-    .select("user_id, attempted_at")
-
-  // Get all scenario progress for last activity
-  const { data: allScenarioProgress } = await supabase
-    .from("scenario_progress")
-    .select("user_id, completed_at")
+  // Get all learning progress, quiz attempts and scenario progress across every learner.
+  // These tables exceed PostgREST's 1000-row cap, so they must be paged (ordered by id) —
+  // a single unpaginated read silently drops rows and undercounts completion for whoever
+  // falls in the truncated tail. The three reads are independent, so run them in parallel.
+  const [allProgress, allQuizAttempts, allScenarioProgress] = await Promise.all([
+    fetchAllRows<{ user_id: string; module_id: string; status: string; completed_at: string | null }>(
+      (from, to) =>
+        supabase
+          .from("learning_progress")
+          .select("user_id, module_id, status, completed_at")
+          .order("id")
+          .range(from, to),
+    ),
+    fetchAllRows<{ user_id: string; attempted_at: string }>(
+      (from, to) =>
+        supabase
+          .from("quiz_attempts")
+          .select("user_id, attempted_at")
+          .order("id")
+          .range(from, to),
+    ),
+    fetchAllRows<{ user_id: string; completed_at: string | null }>(
+      (from, to) =>
+        supabase
+          .from("scenario_progress")
+          .select("user_id, completed_at")
+          .order("id")
+          .range(from, to),
+    ),
+  ])
 
   // Build learner summaries
   const learners: LearnerSummary[] = (profiles || []).map((profile) => {
     const userProgress = allProgress?.filter((p) => p.user_id === profile.id) || []
-    const completedModules = userProgress.filter((p) => p.status === "completed").length
+    // Count distinct completed modules — robust to a row being read twice across a
+    // pagination boundary during a concurrent write, and can never exceed totalModules.
+    const completedModules = new Set(
+      userProgress.filter((p) => p.status === "completed").map((p) => p.module_id),
+    ).size
     const overallProgress = totalModules && totalModules > 0
-      ? Math.round((completedModules / totalModules) * 100)
+      ? Math.min(100, Math.round((completedModules / totalModules) * 100))
       : 0
 
     // Calculate last activity from all sources
@@ -155,7 +181,7 @@ export async function getAllLearnersWithProgress(): Promise<LearnerSummary[]> {
 
     const scenarioDates = (allScenarioProgress || [])
       .filter((s) => s.user_id === profile.id && s.completed_at)
-      .map((s) => new Date(s.completed_at).getTime())
+      .map((s) => new Date(s.completed_at!).getTime())
 
     const allDates = [...progressDates, ...quizDates, ...scenarioDates]
     const lastActivityDate = allDates.length > 0 ? Math.max(...allDates) : null
@@ -181,7 +207,7 @@ export async function getAllLearnersWithProgress(): Promise<LearnerSummary[]> {
   })
 
   return learners
-}
+})
 
 /**
  * Get progress statistics summary.

--- a/lib/lms/feedback.ts
+++ b/lib/lms/feedback.ts
@@ -8,6 +8,7 @@
 "use server"
 
 import { createClient } from "@/lib/supabase/server"
+import { fetchAllRows } from "@/lib/supabase/fetch-all"
 import { revalidatePath } from "next/cache"
 import type { Feedback, FeedbackInput } from "./feedback-types"
 
@@ -125,23 +126,27 @@ export async function getAllFeedback(filters?: {
 }): Promise<Feedback[]> {
   const supabase = await createClient()
 
-  let query = supabase
-    .from("lms_feedback")
-    .select("*")
-    .order("created_at", { ascending: false })
+  // Paged past the 1000-row cap so the admin list never silently drops feedback.
+  const data = await fetchAllRows<Feedback>((from, to) => {
+    let query = supabase
+      .from("lms_feedback")
+      .select("*")
+      .order("created_at", { ascending: false })
+      .order("id")
+      .range(from, to)
 
-  if (filters?.status && filters.status !== "all") {
-    query = query.eq("status", filters.status)
-  }
+    if (filters?.status && filters.status !== "all") {
+      query = query.eq("status", filters.status)
+    }
 
-  if (filters?.type && filters.type !== "all") {
-    query = query.eq("feedback_type", filters.type)
-  }
+    if (filters?.type && filters.type !== "all") {
+      query = query.eq("feedback_type", filters.type)
+    }
 
-  const { data, error } = await query
-  if (error) throw error
+    return query
+  })
 
-  return (data as Feedback[]) || []
+  return data
 }
 
 // -----------------------------------------------------------------------------

--- a/lib/supabase/fetch-all.ts
+++ b/lib/supabase/fetch-all.ts
@@ -1,0 +1,56 @@
+/**
+ * CATALYST - Paginated Supabase reads
+ *
+ * WHY: PostgREST caps every response at `db.max_rows` (default 1000). Any query
+ * that fetches a whole table and then counts/filters/aggregates in JS is silently
+ * truncated once the table grows past that cap, producing wrong totals (e.g. a
+ * learner who completed every module reported as only partially done). This helper
+ * pages through the full result set so callers get every row regardless of table size.
+ *
+ * IMPORTANT: the page factory MUST apply a stable, unique ordering (e.g. `.order("id")`)
+ * so consecutive pages tile the dataset without overlapping or skipping rows. Range
+ * pagination over an unordered query is not safe.
+ */
+
+/**
+ * Rows requested per page. This is only the request window — the helper advances by
+ * the number of rows the server actually returns and stops on the first empty page,
+ * so it stays correct even if the server's `db.max_rows` is lower than this value.
+ */
+const REQUEST_WINDOW = 1000
+
+/**
+ * Safety valve: the maximum number of pages to fetch before giving up. At the
+ * request window above this bounds a single call to ~1,000,000 rows, which is far
+ * beyond any table this helper is used on and guards against an unexpected
+ * non-terminating loop (e.g. a server that never returns an empty page).
+ */
+const MAX_PAGES = 1000
+
+type PageResult<T> = { data: T[] | null; error: { message: string } | null }
+
+/**
+ * Fetch every row for a select query, transparently paginating past the row cap.
+ *
+ * @param makePage builds the query for an inclusive [from, to] range. Must include a
+ *                 stable `.order(...)` on a unique column and end with `.range(from, to)`.
+ */
+export async function fetchAllRows<T>(
+  makePage: (from: number, to: number) => PromiseLike<PageResult<T>>,
+): Promise<T[]> {
+  const rows: T[] = []
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const from = rows.length
+    const { data, error } = await makePage(from, from + REQUEST_WINDOW - 1)
+    if (error) throw new Error(error.message)
+
+    // An empty page means we've read past the last row — we're done. We advance by
+    // the actual number of rows returned (not a fixed page size), so a server cap
+    // smaller than REQUEST_WINDOW just means more, smaller pages — never a silent stop.
+    if (!data || data.length === 0) break
+    rows.push(...data)
+  }
+
+  return rows
+}


### PR DESCRIPTION
## Problem

A fully-complete learner (Insharah, 81/81 modules) showed **78%** on the admin progress dashboard. Root cause: `getAllLearnersWithProgress` read `learning_progress` and `quiz_attempts` in single **unpaginated** queries, but both tables now exceed PostgREST's **1000-row response cap** (1039 and 1218 rows). Excess rows are silently dropped, so any learner whose completions land in the truncated tail is undercounted. Because the dropped set is unordered heap order, the number **drifts between page loads**.

`63 / 81 = 78%` — reproduced exactly against live data. The learner's own portal was always correct (it queries only their rows); only the admin aggregate was wrong. At the time of investigation this misreported **4 learners**.

## Fix

- New `lib/supabase/fetch-all.ts` — `fetchAllRows()` pages past the row cap with a stable `.order("id")`.
- Applied to every unbounded read that aggregates in JS:
  - admin progress (`learning_progress`, `quiz_attempts`, `scenario_progress`)
  - learner-facing quiz count (`quiz_questions`, latent — breaks once the bank passes 1000)
  - admin feedback list + CSV export (`lms_feedback`)
- Certification pass-rate switched to a server-side `count` (no rows fetched).

## Hardening

- **Cap-agnostic helper**: advances by rows actually returned and stops on an empty page, so it can't silently under-read if the server cap ever changes. `MAX_PAGES` safety valve.
- **Concurrency-safe count**: counts *distinct* completed modules per user (`Set`) + clamps to 100, immune to a row being read twice across a page boundary during a live write (which the unique `(user_id, module_id)` constraint would otherwise surface as >100%).
- **No doubled fetch**: `cache()` on `getAllLearnersWithProgress` (the team page calls it directly *and* via `getProgressStats`); its three reads now run in parallel.

## Not changed (deliberately)

- Insharah's `certification_status: in_progress` is correct — that's the separate manual RERA-exam flag, not training completion.
- `certification_attempts` list `.limit(50)` is an intentional product cap.

## Verification

- `tsc --noEmit` clean (only pre-existing `.jpg` import errors on untouched `(web)/` pages)
- `eslint` clean on all touched files
- **`pnpm build` exit 0**
- Live replay of the final algorithm: all 20 learners read their exact true counts; **Insharah 81/81 = 100%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)