### PR TITLE
Default properties browse to off-plan

### DIFF
--- a/app/(web)/properties/_components/properties-filter-bar.tsx
+++ b/app/(web)/properties/_components/properties-filter-bar.tsx
@@ -28,6 +28,7 @@ import {
   type PublicPropertyFacetOption,
   type PublicPropertyFacets,
 } from "@/lib/crm"
+import { DEFAULT_BROWSE_LISTING_TYPE } from "@/lib/crm/browse-filters"
 
 interface PropertiesFilterBarProps {
   facets: PublicPropertyFacets
@@ -82,7 +83,7 @@ export function PropertiesFilterBar({ facets, resultCount }: PropertiesFilterBar
 
   const currentArea = searchParams.get("area") ?? ""
   const currentType = searchParams.get("property_type") ?? ""
-  const currentListing = searchParams.get("listing_type") ?? ""
+  const currentListing = searchParams.get("listing_type") ?? DEFAULT_BROWSE_LISTING_TYPE
   const currentBedrooms = bedroomBucketFromParams(
     searchParams.get("bedrooms_min"),
     searchParams.get("bedrooms_max"),

--- a/lib/crm/browse-filters.ts
+++ b/lib/crm/browse-filters.ts
@@ -5,9 +5,9 @@
  * Shared by the /properties server page (initial render) and the
  * /api/properties route (load-more pagination) so both stay in lockstep.
  *
- * No promotion_status default: the public browse shows the agency's full
- * inventory. Callers that want the curated subset pass promotion_status
- * explicitly.
+ * No promotion_status default: callers that want the curated subset pass
+ * promotion_status explicitly. The public browse defaults to off-plan
+ * listings so the initial portfolio view leads with primary opportunities.
  */
 
 import type {
@@ -21,6 +21,7 @@ import type {
 
 /** Max rows the CRM returns per request; also our page size for load-more. */
 export const BROWSE_PAGE_SIZE = 50
+export const DEFAULT_BROWSE_LISTING_TYPE: CrmListingType = "off_plan"
 
 const ALLOWED_SORTS: CrmSort[] = ["price_asc", "price_desc", "newest", "oldest"]
 
@@ -51,7 +52,7 @@ export function parseBrowseFilters(sp: URLSearchParams): CrmListFilters {
     propertyType:
       propertyType && propertyType !== "all" ? (propertyType as CrmPropertyType) : undefined,
     area: textValue(sp, "area"),
-    listingType: (sp.get("listing_type") as CrmListingType | null) ?? undefined,
+    listingType: (sp.get("listing_type") as CrmListingType | null) ?? DEFAULT_BROWSE_LISTING_TYPE,
     bedroomsMin: numericValue(sp, "bedrooms_min"),
     bedroomsMax: numericValue(sp, "bedrooms_max"),
     priceMin: numericValue(sp, "price_min"),


### PR DESCRIPTION
## Summary
- Default the public properties browse filter to off-plan listings when no listing_type query param is present
- Keep the listing type toggle visually aligned with the shared default

## Validation
- pnpm lint
- pnpm exec tsc --noEmit
- Playwright smoke check at /properties: Off-plan active by default; Secondary toggle still routes to ?listing_type=secondary