### PR TITLE
Fix LMS certificate block: self-serve module completion

### DIFF
--- a/app/learn/[competency]/[module]/page.tsx
+++ b/app/learn/[competency]/[module]/page.tsx
@@ -18,6 +18,7 @@ import { ReadingProgress } from "@/components/lms"
 import { ModuleContentSwitcher } from "@/components/lms/module-content-switcher"
 import { ModuleToCSwitcher } from "@/components/lms/module-toc-switcher"
 import { KnowledgeCheckCTA } from "@/components/lms/knowledge-check-cta"
+import { ModuleCompleteButton } from "@/components/lms/module-complete-button"
 import { ModuleMarketData, hasModuleMarketData } from "@/components/lms/module-market-data"
 import { 
   ChevronLeftIcon,
@@ -161,6 +162,28 @@ async function getRelatedQuiz(
 }
 
 /**
+ * Whether the current user has already completed this module.
+ * Drives the header badge and the "Mark as complete" control's initial state.
+ */
+async function getModuleCompletion(moduleId: string): Promise<boolean> {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return false
+
+  const { data } = await supabase
+    .from("learning_progress")
+    .select("status")
+    .eq("user_id", user.id)
+    .eq("module_id", moduleId)
+    .maybeSingle()
+
+  return data?.status === "completed"
+}
+
+/**
  * Get scenarios linked to a competency for the Practice with AI section.
  */
 async function getScenariosForCompetency(
@@ -222,10 +245,11 @@ export default async function ModulePage({ params, searchParams }: PageProps) {
   const deepDiveDuration = currentModule.duration_minutes ? `${currentModule.duration_minutes} min` : "25 min"
   const essentialsDuration = "15 min" // TODO: Calculate from essentials content
   
-  // Get related quiz and scenarios for this module
-  const [relatedQuiz, linkedScenarios] = await Promise.all([
+  // Get related quiz, scenarios, and this user's completion state for the module
+  const [relatedQuiz, linkedScenarios, isCompleted] = await Promise.all([
     getRelatedQuiz(competencySlug, moduleSlug),
     getScenariosForCompetency(competencySlug),
+    getModuleCompletion(currentModule.id),
   ])
   
   // Get audio tracks for this module
@@ -261,6 +285,15 @@ export default async function ModulePage({ params, searchParams }: PageProps) {
                   <span style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
                     <ClockIcon className="h-3.5 w-3.5" />
                     {mode === "essentials" ? essentialsDuration : deepDiveDuration}
+                  </span>
+                </>
+              )}
+              {isCompleted && (
+                <>
+                  <span>•</span>
+                  <span style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', color: 'var(--success-600)' }}>
+                    <CheckCircleIcon className="h-3.5 w-3.5" />
+                    Completed
                   </span>
                 </>
               )}
@@ -307,7 +340,15 @@ export default async function ModulePage({ params, searchParams }: PageProps) {
               <KnowledgeCheckCTA quizId={relatedQuiz.slug} />
             </section>
           )}
-        
+
+          {/* Mark as complete - quiz-independent completion toward the certificate */}
+          <section className="mt-8">
+            <ModuleCompleteButton
+              moduleId={currentModule.id}
+              initialCompleted={isCompleted}
+            />
+          </section>
+
           {/* Navigation */}
           <nav className="lms-nav">
             <div className="lms-nav__prev">

--- a/app/learn/[competency]/page.tsx
+++ b/app/learn/[competency]/page.tsx
@@ -11,14 +11,15 @@ import Link from "next/link"
 import { notFound } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Stack, Row, Text } from "@/components/core"
-import { 
-  ClockIcon, 
+import {
+  ClockIcon,
   PlayIcon,
   ArrowRightIcon,
   ClipboardCheckIcon,
   SparklesIcon,
   MessageSquareIcon,
   HeadphonesIcon,
+  CheckIcon,
 } from "lucide-react"
 import { createClient } from "@/lib/supabase/server"
 import { AudioPlayer, type AudioTrack } from "@/components/lms/audio-player"
@@ -124,6 +125,27 @@ interface ScenarioCategory {
   scenario_count: number | null
 }
 
+/**
+ * Module IDs the current user has completed. Lets the module list show which
+ * modules are done and how many remain.
+ */
+async function getCompletedModuleIds(): Promise<Set<string>> {
+  const supabase = await createClient()
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return new Set()
+
+  const { data } = await supabase
+    .from("learning_progress")
+    .select("module_id")
+    .eq("user_id", user.id)
+    .eq("status", "completed")
+
+  return new Set((data || []).map((r) => r.module_id))
+}
+
 async function getQuizzesForCompetency(competencySlug: string): Promise<Quiz[]> {
   const supabase = await createClient()
   
@@ -203,12 +225,17 @@ export default async function CompetencyPage({ params }: PageProps) {
   
   const firstModule = currentCompetency.modules[0]
   
-  // Get quizzes, scenarios, and audio for this competency
-  const [quizzes, scenarios, competencyAudio] = await Promise.all([
+  // Get quizzes, scenarios, audio, and the user's completed modules for this competency
+  const [quizzes, scenarios, competencyAudio, completedModuleIds] = await Promise.all([
     getQuizzesForCompetency(slug),
     getScenariosForCompetency(slug),
     getCompetencyAudio(currentCompetency.id),
+    getCompletedModuleIds(),
   ])
+
+  const completedCount = currentCompetency.modules.filter((m) =>
+    completedModuleIds.has(m.id)
+  ).length
   
   return (
     <div className="learn-content">
@@ -272,34 +299,42 @@ export default async function CompetencyPage({ params }: PageProps) {
         <div className="lms-section__header">
           <h2 className="lms-section__title">Modules</h2>
           <span className="lms-section__subtitle">
-            {currentCompetency.modules.length} lessons
+            {completedCount} of {currentCompetency.modules.length} complete
           </span>
         </div>
-        
+
         <div className="lms-list">
-          {currentCompetency.modules.map((module, index) => (
-            <Link
-              key={module.id}
-              href={`/learn/${currentCompetency.slug}/${module.slug}`}
-              className="lms-card lms-card--clickable competency-card"
-            >
-              <div className="competency-card__index">
-                {index + 1}
-              </div>
-              <div className="competency-card__body">
-                <h3 className="competency-card__title">{module.title}</h3>
-                <div className="competency-card__meta">
-                  <span className="competency-card__meta-item">
-                    <ClockIcon className="h-3 w-3" />
-                    {module.duration_minutes ? `${module.duration_minutes} min` : '5-10 min read'}
-                  </span>
+          {currentCompetency.modules.map((module, index) => {
+            const isComplete = completedModuleIds.has(module.id)
+            return (
+              <Link
+                key={module.id}
+                href={`/learn/${currentCompetency.slug}/${module.slug}`}
+                className={`lms-card lms-card--clickable competency-card${isComplete ? ' competency-card--complete' : ''}`}
+              >
+                <div className="competency-card__index">
+                  {isComplete ? <CheckIcon className="h-5 w-5" /> : index + 1}
                 </div>
-              </div>
-              <div className="competency-card__action">
-                <ArrowRightIcon className="h-4 w-4" />
-              </div>
-            </Link>
-          ))}
+                <div className="competency-card__body">
+                  <h3 className="competency-card__title">{module.title}</h3>
+                  <div className="competency-card__meta">
+                    <span className="competency-card__meta-item">
+                      <ClockIcon className="h-3 w-3" />
+                      {module.duration_minutes ? `${module.duration_minutes} min` : '5-10 min read'}
+                    </span>
+                    {isComplete && (
+                      <span className="competency-card__meta-item competency-card__meta-item--complete">
+                        Completed
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="competency-card__action">
+                  <ArrowRightIcon className="h-4 w-4" />
+                </div>
+              </Link>
+            )
+          })}
         </div>
       </section>
       

--- a/app/learn/learn.css
+++ b/app/learn/learn.css
@@ -10737,3 +10737,93 @@
 .cert-admin-cert-row__status--revoked {
   color: var(--color-destructive);
 }
+
+/* =============================================================================
+   Module Complete — explicit "Mark as complete" control (quiz-independent)
+   ============================================================================= */
+
+.module-complete {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: var(--lms-radius-lg);
+  border: 1px solid var(--gray-300);
+  background: var(--color-background);
+  box-shadow: var(--lms-shadow-sm);
+}
+
+.module-complete--done {
+  flex-direction: column;
+  align-items: stretch;
+  border-color: var(--success-200);
+  background: var(--success-50);
+}
+
+.module-complete__lead {
+  min-width: 0;
+}
+
+.module-complete__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: var(--lms-radius-md);
+  background: var(--primary-100);
+  color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.module-complete__icon--done {
+  background: var(--success-100);
+  color: var(--success-600);
+}
+
+.module-complete__icon--cert {
+  background: oklch(from var(--color-primary) l c h / 0.12);
+  color: var(--color-primary);
+}
+
+.module-complete__action {
+  flex-shrink: 0;
+}
+
+/* Certificate-issued callout shown when the final module is completed */
+.module-complete__cert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.25rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--success-200);
+}
+
+@media (max-width: 640px) {
+  .module-complete__action,
+  .module-complete__action .ui-button {
+    width: 100%;
+  }
+}
+
+/* Completed module in the competency module list */
+.competency-card--complete .competency-card__index {
+  background: var(--success-100);
+  color: var(--success-600);
+}
+
+.lms-card--clickable.competency-card--complete:hover .competency-card__index {
+  background: var(--success-600);
+  color: white;
+  box-shadow: 0 4px 12px oklch(from var(--success-600) l c h / 0.3);
+}
+
+.competency-card__meta-item--complete {
+  color: var(--success-600);
+  font-weight: 600;
+}

--- a/components/lms/module-complete-button.tsx
+++ b/components/lms/module-complete-button.tsx
@@ -1,0 +1,140 @@
+/**
+ * CATALYST - Module Complete Button
+ *
+ * Explicit "Mark as complete" control for a learning module. Completion is
+ * quiz-independent by design: passing a module's quiz still auto-completes it,
+ * but every module can also be finished directly here so progress toward the
+ * completion certificate never depends on a quiz existing or its link resolving.
+ *
+ * On the final module, marking complete auto-issues the certificate
+ * (markModuleComplete -> issueCertificateForUser) and we surface it inline.
+ */
+
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Stack, Row, Text } from "@/components/core"
+import {
+  CheckCircle2Icon,
+  CircleDashedIcon,
+  Loader2Icon,
+  AwardIcon,
+} from "lucide-react"
+import { markModuleComplete } from "@/lib/actions/learning"
+
+interface ModuleCompleteButtonProps {
+  moduleId: string
+  initialCompleted: boolean
+}
+
+export function ModuleCompleteButton({
+  moduleId,
+  initialCompleted,
+}: ModuleCompleteButtonProps) {
+  const router = useRouter()
+  const [completed, setCompleted] = useState(initialCompleted)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [certificateId, setCertificateId] = useState<string | null>(null)
+
+  const handleComplete = async () => {
+    setLoading(true)
+    setError(null)
+
+    const result = await markModuleComplete(moduleId)
+
+    if (result.success) {
+      setCompleted(true)
+      setCertificateId(result.data.certificateId ?? null)
+      // Refresh so the header badge, sidebar, and progress counts update.
+      router.refresh()
+    } else {
+      setError(result.error)
+    }
+
+    setLoading(false)
+  }
+
+  if (completed) {
+    return (
+      <div className="module-complete module-complete--done">
+        <Row gap="md" align="center">
+          <div className="module-complete__icon module-complete__icon--done">
+            <CheckCircle2Icon className="h-6 w-6" />
+          </div>
+          <Stack gap="xs">
+            <Text weight="semibold" className="text-foreground">
+              Module complete
+            </Text>
+            <Text size="sm" className="text-muted-foreground">
+              Nice work — this module counts toward your completion certificate.
+            </Text>
+          </Stack>
+        </Row>
+
+        {certificateId && (
+          <div className="module-complete__cert">
+            <Row gap="md" align="center">
+              <div className="module-complete__icon module-complete__icon--cert">
+                <AwardIcon className="h-6 w-6" />
+              </div>
+              <Stack gap="xs">
+                <Text weight="semibold" className="text-foreground">
+                  You&apos;ve finished the programme — certificate issued!
+                </Text>
+                <Text size="sm" className="text-muted-foreground">
+                  Your completion certificate is ready.
+                </Text>
+              </Stack>
+            </Row>
+            <Button render={<Link href="/learn/certification" />}>
+              View certificate
+            </Button>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="module-complete">
+      <Row gap="md" align="center" className="module-complete__lead">
+        <div className="module-complete__icon">
+          <CircleDashedIcon className="h-6 w-6" />
+        </div>
+        <Stack gap="xs">
+          <Text weight="semibold" className="text-foreground">
+            Finished this module?
+          </Text>
+          <Text size="sm" className="text-muted-foreground">
+            Mark it complete to track your progress toward your certificate.
+          </Text>
+        </Stack>
+      </Row>
+
+      <Stack gap="sm" className="module-complete__action">
+        <Button size="lg" className="gap-2" onClick={handleComplete} disabled={loading}>
+          {loading ? (
+            <>
+              <Loader2Icon className="h-4 w-4 animate-spin" />
+              Saving...
+            </>
+          ) : (
+            <>
+              <CheckCircle2Icon className="h-4 w-4" />
+              Mark as complete
+            </>
+          )}
+        </Button>
+        {error && (
+          <Text size="sm" className="text-red-600 dark:text-red-400">
+            {error}
+          </Text>
+        )}
+      </Stack>
+    </div>
+  )
+}

--- a/scripts/reconcile-module-completions.ts
+++ b/scripts/reconcile-module-completions.ts
@@ -1,0 +1,156 @@
+/**
+ * CATALYST - Reconcile module completions from passed quiz attempts
+ *
+ * Repairs the historical damage from the brittle quiz->module link: cases where
+ * a learner PASSED a module's quiz but the module was never marked "completed"
+ * (the quiz->module lookup silently returned null at submit time, so
+ * markModuleComplete never fired). For every passed quiz attempt we resolve the
+ * module (attempt.module_id, else quizzes.related_module -> learning_modules.slug)
+ * and ensure a learning_progress row exists with status='completed'.
+ *
+ * Idempotent: rows already 'completed' are left untouched; completed_at is set to
+ * the earliest passing attempt so history stays truthful.
+ *
+ * Usage:
+ *   npx tsx scripts/reconcile-module-completions.ts --dry-run   # report only
+ *   npx tsx scripts/reconcile-module-completions.ts             # apply
+ *
+ * After applying, run scripts/backfill-certificates.ts to issue certificates to
+ * anyone the reconciliation pushes to 100%.
+ */
+
+import { config as loadEnv } from "dotenv"
+loadEnv({ path: ".env.local" })
+
+import { createClient } from "@supabase/supabase-js"
+
+const DRY_RUN = process.argv.includes("--dry-run")
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+if (!supabaseUrl || !supabaseServiceKey) {
+  console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+  process.exit(1)
+}
+
+// Service-role client — bypasses RLS. Trusted maintenance script.
+const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+  auth: { persistSession: false },
+})
+
+async function main() {
+  console.log(`Reconcile module completions — ${DRY_RUN ? "DRY RUN (no writes)" : "LIVE"}\n`)
+
+  // quiz_slug -> module_id, via quizzes.related_module = learning_modules.slug
+  const { data: modules, error: modErr } = await supabase
+    .from("learning_modules")
+    .select("id, slug")
+  if (modErr) throw modErr
+  const slugToModuleId = new Map((modules || []).map((m) => [m.slug, m.id]))
+
+  const { data: quizzes, error: qErr } = await supabase
+    .from("quizzes")
+    .select("slug, related_module")
+  if (qErr) throw qErr
+  const quizSlugToModuleId = new Map<string, string>()
+  for (const q of quizzes || []) {
+    const mid = q.related_module ? slugToModuleId.get(q.related_module) : undefined
+    if (mid) quizSlugToModuleId.set(q.slug, mid)
+  }
+
+  // Existing progress: which (user, module) are already completed / present
+  const { data: progress, error: pErr } = await supabase
+    .from("learning_progress")
+    .select("user_id, module_id, status")
+  if (pErr) throw pErr
+  const completed = new Set((progress || []).filter((p) => p.status === "completed").map((p) => `${p.user_id}:${p.module_id}`))
+  const existing = new Set((progress || []).map((p) => `${p.user_id}:${p.module_id}`))
+
+  // All passing attempts -> earliest attempted_at per (user, module)
+  const { data: attempts, error: aErr } = await supabase
+    .from("quiz_attempts")
+    .select("user_id, quiz_slug, module_id, passed, attempted_at")
+    .eq("passed", true)
+  if (aErr) throw aErr
+
+  let unresolved = 0
+  const earliestPass = new Map<string, { userId: string; moduleId: string; at: string }>()
+  for (const a of attempts || []) {
+    const moduleId = a.module_id || (a.quiz_slug ? quizSlugToModuleId.get(a.quiz_slug) : undefined)
+    if (!moduleId) {
+      unresolved++
+      continue
+    }
+    const key = `${a.user_id}:${moduleId}`
+    const at = a.attempted_at || new Date().toISOString()
+    const prev = earliestPass.get(key)
+    if (!prev || at < prev.at) earliestPass.set(key, { userId: a.user_id, moduleId, at })
+  }
+
+  // Rows to repair: passed but not completed
+  const toRepair = [...earliestPass.entries()]
+    .filter(([key]) => !completed.has(key))
+    .map(([key, v]) => ({ ...v, isInsert: !existing.has(key) }))
+
+  console.log(`Passing attempts resolved to modules: ${earliestPass.size}`)
+  console.log(`Unresolvable passing attempts (no module link): ${unresolved}`)
+  console.log(`Module completions to repair: ${toRepair.length}\n`)
+
+  if (toRepair.length === 0) {
+    console.log("Nothing to reconcile.")
+    return
+  }
+
+  // Names for a readable report
+  const affectedUsers = [...new Set(toRepair.map((r) => r.userId))]
+  const { data: profs } = await supabase
+    .from("user_profiles")
+    .select("id, full_name")
+    .in("id", affectedUsers)
+  const nameById = new Map((profs || []).map((p) => [p.id, p.full_name || "(no name)"]))
+  const slugById = new Map((modules || []).map((m) => [m.id, m.slug]))
+
+  const byUser = new Map<string, string[]>()
+  for (const r of toRepair) {
+    if (!byUser.has(r.userId)) byUser.set(r.userId, [])
+    byUser.get(r.userId)!.push(slugById.get(r.moduleId) || r.moduleId)
+  }
+  for (const [uid, slugs] of byUser) {
+    console.log(`  ${nameById.get(uid) || uid}: +${slugs.length} [${slugs.join(", ")}]`)
+  }
+
+  if (DRY_RUN) {
+    console.log(`\n[dry run] Would mark ${toRepair.length} module(s) complete across ${byUser.size} user(s).`)
+    return
+  }
+
+  let ok = 0
+  let failed = 0
+  for (const r of toRepair) {
+    const { error } = await supabase.from("learning_progress").upsert(
+      {
+        user_id: r.userId,
+        module_id: r.moduleId,
+        status: "completed",
+        started_at: r.at,
+        completed_at: r.at,
+      },
+      { onConflict: "user_id,module_id", ignoreDuplicates: false }
+    )
+    if (error) {
+      console.error(`  x ${nameById.get(r.userId)} / ${slugById.get(r.moduleId)}:`, error.message)
+      failed++
+    } else {
+      ok++
+    }
+  }
+
+  console.log(`\nDone. Reconciled: ${ok}${failed ? `, failed: ${failed}` : ""}`)
+  console.log("Next: npx tsx scripts/backfill-certificates.ts --dry-run")
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Problem

Certificate generation was reported as broken ("users currently cannot generate them"). Investigation against production found issuance is fine — every user at 100% already has a certificate. The real block: **module completion required passing that module's quiz**, and certification needs 100% of all 81 modules. Learners stranded below 100% (80/81, 74/81, …) had no quiz-independent way to finish and no visibility into what was left.

## Changes

- **"Mark as complete" button on every module** (`module-complete-button.tsx`), quiz-independent. Passing a quiz still auto-completes. Reaching 100% auto-issues the certificate via the existing `markModuleComplete → issueCertificateForUser` path (`auth.uid()`-scoped, RLS-protected, idempotent).
- **Progress visibility**: per-module checkmarks + "X of Y complete" on the competency page; "Completed" badge on the module header.
- **`scripts/reconcile-module-completions.ts`**: marks modules complete for historical passed-but-unrecorded quiz attempts. Already run against prod (4 completions across 2 users). Backfill confirmed nobody is stranded at 100% without a cert.

## Why the linkage was brittle

Completion hung on an unenforced string join (`quizzes.related_module` TEXT = `learning_modules.slug`, derived by regex in two places, slug not globally unique), and certification is all-or-nothing. This PR removes completion's dependency on that join.

## Product note

Completion is now self-serve — a certificate attests to "marked all modules complete," not "passed all quizzes." This was an explicit product decision.

## Verification

- `pnpm build` passes (exit 0), both `/learn/[competency]` routes compile clean.
- `tsc` 0 errors, eslint clean.
- Data repair run + verified against production.
- Not yet exercised via a live authenticated click-through (auth middleware blocks headless access) — recommend one learner click-through post-deploy.