### PR TITLE
AgentCRM Mastery (Competency 10) rebuilt curriculum + Training Mode planning

### DIFF
--- a/app/learn/scenarios/[category]/[scenarioId]/_components/scenario-detail-client.tsx
+++ b/app/learn/scenarios/[category]/[scenarioId]/_components/scenario-detail-client.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState } from "react"
+import { List, Stack, Title } from "@/components/core"
 import { Button } from "@/components/ui/button"
 import {
   SparklesIcon,
@@ -16,6 +17,7 @@ import {
   PencilIcon,
 } from "lucide-react"
 import { ScenarioPractice } from "../../_components/scenario-practice"
+import { ScenarioReflection } from "../../_components/scenario-reflection"
 import { completeScenario } from "@/lib/actions/scenario-actions"
 
 // =============================================================================
@@ -32,6 +34,7 @@ interface ParsedScenario {
   challenges: string
   mistakes: string
   approach: string
+  crmFollowThrough: string
   aiPrompt: string
 }
 
@@ -59,6 +62,11 @@ export function ScenarioDetailClient({
   const [isCompleted, setIsCompleted] = useState(initialCompleted)
   const [copied, setCopied] = useState(false)
   const [showReflection, setShowReflection] = useState(false)
+  const isHandsOn = !scenario.aiPrompt.trim()
+  const crmFollowThrough = scenario.crmFollowThrough
+    .split("\n")
+    .map((line) => line.replace(/^[-•]\s*/, "").trim())
+    .filter(Boolean)
 
   const handleCopy = async () => {
     try {
@@ -146,46 +154,97 @@ export function ScenarioDetailClient({
         </div>
       )}
 
-      {/* Practice CTA */}
-      <div className="scenario-detail__practice-cta">
-        <div className="scenario-detail__practice-cta-content">
-          <h2 className="scenario-detail__practice-cta-title">
-            <SparklesIcon className="h-5 w-5" />
-            Ready to Practice?
-          </h2>
-          <p className="scenario-detail__practice-cta-description">
-            Start an AI roleplay session where you&apos;ll respond as the consultant.
-            The AI will play the client and evaluate your approach at the end.
-          </p>
+      {isHandsOn ? (
+        <div className="scenario-detail__practice-cta">
+          <div className="scenario-detail__practice-cta-content">
+            <h2 className="scenario-detail__practice-cta-title">
+              <CheckCircle2Icon className="h-5 w-5" />
+              Complete the Workflow Mission
+            </h2>
+            <p className="scenario-detail__practice-cta-description">
+              Perform the mission in the approved training environment, retain the
+              named evidence, then submit your reflection here.
+            </p>
+          </div>
+          <ScenarioReflection
+            category={category}
+            scenarioId={scenario.id}
+            scenarioTitle={scenario.title}
+            isCompleted={isCompleted}
+            existingReflection={existingReflection}
+            onComplete={() => setIsCompleted(true)}
+          />
         </div>
-        <Button size="lg" onClick={handleStartPractice} className="scenario-detail__practice-btn">
-          <SparklesIcon className="h-4 w-4 mr-2" />
-          Start AI Practice
-        </Button>
-      </div>
+      ) : (
+        <>
+          {/* Practice CTA */}
+          <div className="scenario-detail__practice-cta">
+            <div className="scenario-detail__practice-cta-content">
+              <h2 className="scenario-detail__practice-cta-title">
+                <SparklesIcon className="h-5 w-5" />
+                Ready to Practice?
+              </h2>
+              <p className="scenario-detail__practice-cta-description">
+                Start an AI roleplay session where you&apos;ll respond as the consultant.
+                The AI will play the client and evaluate your approach at the end.
+              </p>
+            </div>
+            <Button size="lg" onClick={handleStartPractice} className="scenario-detail__practice-btn">
+              <SparklesIcon className="h-4 w-4 mr-2" />
+              Start AI Practice
+            </Button>
+          </div>
 
-      {/* Fallback: Copy prompt */}
-      <details className="scenario-detail__prompt-fallback">
-        <summary>Or copy prompt for external AI (ChatGPT, Claude, etc.)</summary>
-        <div className="scenario-detail__prompt-content">
-          <pre className="scenario-detail__prompt-code">
-            <code>{scenario.aiPrompt}</code>
-          </pre>
-          <Button variant="outline" size="sm" onClick={handleCopy}>
-            {copied ? (
-              <>
-                <CheckIcon className="h-3.5 w-3.5 mr-1.5" />
-                Copied!
-              </>
-            ) : (
-              <>
-                <CopyIcon className="h-3.5 w-3.5 mr-1.5" />
-                Copy Prompt
-              </>
-            )}
-          </Button>
-        </div>
-      </details>
+          {/* Fallback: Copy prompt */}
+          <details className="scenario-detail__prompt-fallback">
+            <summary>Or copy prompt for external AI (ChatGPT, Claude, etc.)</summary>
+            <div className="scenario-detail__prompt-content">
+              <pre className="scenario-detail__prompt-code">
+                <code>{scenario.aiPrompt}</code>
+              </pre>
+              <Button variant="outline" size="sm" onClick={handleCopy}>
+                {copied ? (
+                  <>
+                    <CheckIcon className="h-3.5 w-3.5 mr-1.5" />
+                    Copied!
+                  </>
+                ) : (
+                  <>
+                    <CopyIcon className="h-3.5 w-3.5 mr-1.5" />
+                    Copy Prompt
+                  </>
+                )}
+              </Button>
+            </div>
+          </details>
+
+          {crmFollowThrough.length > 0 && (
+            <Stack
+              gap="md"
+              className="scenario-detail__crm-follow-through rounded-xl border bg-muted/30 p-5"
+            >
+              <Title size="h3">What changes in AgentCRM?</Title>
+              <List gap="sm" size="sm">
+                {crmFollowThrough.map((item) => {
+                  const labelledItem = item.match(/^\*\*(.+?):\*\*\s*(.+)$/)
+
+                  return (
+                    <li key={item}>
+                      {labelledItem ? (
+                        <>
+                          <strong>{labelledItem[1]}:</strong> {labelledItem[2]}
+                        </>
+                      ) : (
+                        item
+                      )}
+                    </li>
+                  )
+                })}
+              </List>
+            </Stack>
+          )}
+        </>
+      )}
     </section>
   )
 }

--- a/app/learn/scenarios/[category]/[scenarioId]/page.tsx
+++ b/app/learn/scenarios/[category]/[scenarioId]/page.tsx
@@ -41,6 +41,7 @@ export interface ParsedScenario {
   challenges: string
   mistakes: string
   approach: string
+  crmFollowThrough: string
   aiPrompt: string
 }
 
@@ -101,6 +102,7 @@ function parseScenario(content: string, scenarioId: string): ParsedScenario | nu
   const challenges = extractSection(scenarioContent, "Key Challenges")
   const mistakes = extractSection(scenarioContent, "Common Mistakes")
   const approach = extractSection(scenarioContent, "Model Approach")
+  const crmFollowThrough = extractSection(scenarioContent, "What changes in AgentCRM?")
   const aiPrompt = extractCodeBlock(scenarioContent)
 
   return {
@@ -113,12 +115,14 @@ function parseScenario(content: string, scenarioId: string): ParsedScenario | nu
     challenges,
     mistakes,
     approach,
+    crmFollowThrough,
     aiPrompt,
   }
 }
 
 function extractSection(content: string, sectionName: string): string {
-  const pattern = new RegExp(`### ${sectionName}\\s*\\n([\\s\\S]*?)(?=###|$)`, "i")
+  const escapedSectionName = sectionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const pattern = new RegExp(`### ${escapedSectionName}\\s*\\n([\\s\\S]*?)(?=###|$)`, "i")
   const match = content.match(pattern)
   return match ? match[1].trim() : ""
 }

--- a/app/learn/scenarios/[category]/page.tsx
+++ b/app/learn/scenarios/[category]/page.tsx
@@ -148,6 +148,8 @@ const competencyLabels: Record<string, string> = {
   "transaction-management": "Transaction Management",
   "objection-navigation": "Objection Navigation",
   "relationship-stewardship": "Relationship Stewardship",
+  "aml-compliance": "AML & Compliance",
+  "agentcrm-mastery": "AgentCRM Mastery",
 }
 
 // =============================================================================

--- a/app/learn/scenarios/page.tsx
+++ b/app/learn/scenarios/page.tsx
@@ -1,8 +1,8 @@
 /**
  * CATALYST - Scenario Practice Index
  * 
- * Overview of all roleplay scenario categories for practice.
- * Learners can browse and practice AI-powered conversations.
+ * Overview of all scenario categories for practice.
+ * Learners can browse AI roleplays and hands-on workflow labs.
  */
 
 import { Metadata } from "next"
@@ -22,7 +22,7 @@ import { createClient } from "@/lib/supabase/server"
 
 export const metadata: Metadata = {
   title: "Practice Scenarios | Learning Portal",
-  description: "Practice real-world client conversations with AI-powered roleplay scenarios.",
+  description: "Practice real-world client conversations and hands-on workflows in a safe training environment.",
 }
 
 // =============================================================================
@@ -68,6 +68,8 @@ const categoryIcons: Record<string, React.ReactNode> = {
   "objections": <ShieldAlertIcon className="h-5 w-5" />,
   "closing": <CheckCircleIcon className="h-5 w-5" />,
   "difficult-situations": <AlertTriangleIcon className="h-5 w-5" />,
+  "agentcrm-workflow-lab": <CheckCircleIcon className="h-5 w-5" />,
+  "agentcrm-roleplays": <MessageSquareIcon className="h-5 w-5" />,
 }
 
 const categoryColors: Record<string, string> = {
@@ -77,6 +79,8 @@ const categoryColors: Record<string, string> = {
   "objections": "from-amber-500/10 to-amber-600/5 border-amber-200/50",
   "closing": "from-green-500/10 to-green-600/5 border-green-200/50",
   "difficult-situations": "from-rose-500/10 to-rose-600/5 border-rose-200/50",
+  "agentcrm-workflow-lab": "from-cyan-500/10 to-cyan-600/5 border-cyan-200/50",
+  "agentcrm-roleplays": "from-indigo-500/10 to-indigo-600/5 border-indigo-200/50",
 }
 
 // =============================================================================
@@ -90,6 +94,8 @@ const competencyLabels: Record<string, string> = {
   "transaction-management": "Transaction Management",
   "objection-navigation": "Objection Navigation",
   "relationship-stewardship": "Relationship Stewardship",
+  "aml-compliance": "AML & Compliance",
+  "agentcrm-mastery": "AgentCRM Mastery",
 }
 
 // =============================================================================
@@ -113,8 +119,8 @@ export default async function ScenariosIndexPage() {
           </div>
           <h1 className="scenario-hero__title">Practice Scenarios</h1>
           <p className="scenario-hero__description">
-            Master client conversations through AI-powered roleplay. Practice handling 
-            real situations you&apos;ll encounter as a Prime Capital consultant.
+            Build confidence through AI roleplay and hands-on workflow labs. Practice the
+            conversations and system decisions you&apos;ll handle as a Prime Capital consultant.
           </p>
           <div className="scenario-hero__stats">
             <span className="scenario-hero__stat">
@@ -148,8 +154,8 @@ export default async function ScenariosIndexPage() {
           <div className="scenario-intro__step">
             <div className="scenario-intro__step-num">3</div>
             <div className="scenario-intro__step-content">
-              <strong>Practice with AI</strong>
-              <span>Start a live roleplay conversation and get instant feedback</span>
+              <strong>Practise safely</strong>
+              <span>Use AI roleplay or complete the named task in a training tenant</span>
             </div>
           </div>
         </div>

--- a/catalyst/briefs/_review-20260714_agentcrm-training-competency.md
+++ b/catalyst/briefs/_review-20260714_agentcrm-training-competency.md
@@ -1,0 +1,123 @@
+<!-- CATALYST - AgentCRM training competency implementation brief -->
+
+---
+title: "AgentCRM Training Competency"
+stage: mvp
+tags: [lms, agentcrm, onboarding, simulations]
+---
+
+# AgentCRM Training Competency
+
+> **Superseded (2026-07-15).** The module structure, scenarios, quizzes, and capstone from this brief were replaced by the rebuild in [_review-20260715_agentcrm-agent-mastery-rebuild.md](_review-20260715_agentcrm-agent-mastery-rebuild.md), which is the version now on disk and the one to review. This brief is retained only for its source research and product-truth rationale.
+
+## Outcome
+
+Create a practical AgentCRM competency that gets a new Prime Capital consultant from first login to safe, repeatable daily operation. Learners must be able to prioritise work, handle a lead, capture qualification, communicate in context, match property, create a proposal, maintain the pipeline, and leave every active lead with a truthful next action.
+
+The competency also includes a shared team-performance module covering evidence and handovers, with assignment, coaching, and settings actions clearly gated to manager roles.
+
+## Why this work exists
+
+AgentCRM is not a conventional record system. Its core promise is to answer two questions:
+
+1. Who needs attention now?
+2. What should happen next?
+
+A feature tour would teach navigation but not the behaviour that makes the CRM reliable. Training therefore follows the work loop and requires evidence from realistic tasks.
+
+## Research basis
+
+The curriculum was derived from the AgentCRM source repository at `/Users/thg/code/agentcrm`, verified at commit `58317aa0` dated 9 July 2026.
+
+Primary evidence reviewed:
+
+- `catalyst/specs/project-vision.md` and `project-experience.md`
+- Current app navigation and role gates in `lib/navigation.ts`
+- Onboarding flow in `app/(app)/app/onboarding/`
+- Today action queue and next-best-action rules
+- Lead pool, ownership, release, stage, and qualification services
+- Lead detail, communication, property matching, proposal, and deal surfaces
+- Manager Team and Insights navigation
+- Product guide tours and end-to-end journey tests
+- Recent product history through July 2026
+
+## Product truths the training must preserve
+
+1. **The contact is the centre of the record.** Requirements, communications, proposals, and deals attach to the person and their evolving intent.
+2. **A deal is not an early-stage lead.** Create a deal only when the client commits to progress on a specific property.
+3. **Today is a signal queue, not a static task list.** Unread inbound, fresh enquiries, engagement, proposal views, overdue follow-ups, and missing next dates can surface work.
+4. **A future follow-up date is a promise.** The engine suppresses most routine prompts until that time, while still allowing live client signals to break through.
+5. **Every interaction needs an outcome.** Capture the activity, update facts or qualification when learned, and set the next contact date or an honest terminal/parked state.
+6. **Lead ownership has meaning.** Claim, assignment, release, nurture, and do-not-contact behaviour must not be treated as interchangeable.
+7. **AI drafts are proposals, not decisions.** The consultant remains accountable for facts, suitability, tone, confidentiality, and the send action.
+8. **Channel availability is agency-configured.** Training must not promise WhatsApp or personal mailbox features when those flags are disabled.
+9. **Managers coach from evidence.** Response, activity, stuck leads, assignment, qualification, and conversion signals are inputs to coaching—not substitutes for judgement.
+
+## Competency design
+
+| Module | Observable learner outcome | Practical proof |
+|---|---|---|
+| 10.1 Operating model and setup | Explain the object model, complete setup, and locate the five core work areas | Account-readiness check and navigation drill |
+| 10.2 Running Today | Read the signal and reason, execute/defer honestly, and clear a queue without hiding work | Timed morning triage mission |
+| 10.3 Lead pool and first response | Select and claim an appropriate lead, respond quickly, and record the outcome | New-enquiry response mission |
+| 10.4 Lead workspace and qualification | Turn a conversation into structured facts, confirmed qualification, stage, and next contact | Qualification call debrief mission |
+| 10.5 Communications and follow-up | Use the correct channel, review an AI draft, send safely, and preserve context | Inbox-to-next-action mission |
+| 10.6 Matching and proposals | Translate confirmed requirements into a defensible shortlist and track proposal engagement | Three-property shortlist mission |
+| 10.7 Deals and pipeline hygiene | Create a deal at commitment, progress it truthfully, and close the daily/weekly loop | Pipeline clean-up mission |
+| 10.8 Team performance & manager control room | Interpret evidence, hand over cleanly, and—when authorised—assign and coach fairly | Team review mission using a training account or supplied report |
+
+## Assessment model
+
+- Eight knowledge checks, one per module, with five questions each and an 80% pass mark.
+- Eight hands-on missions completed in AgentCRM or a training tenant. Completion requires a reflection and named evidence.
+- Six AI roleplays that rehearse client or coaching conversations tied to correct CRM follow-through.
+- Recommended readiness standard: all core agent modules complete, all core quizzes passed, and the first six hands-on missions evidenced before unsupervised lead handling.
+- The team-performance module is shared awareness. Manager-only actions are completed only with an authorised training account; they do not block the core agent-readiness gate.
+
+## Content boundaries
+
+- Teach durable workflows and decision rules, not pixel-perfect screen coordinates.
+- Name current labels where useful, but explain that role, device, and agency feature settings can change visible options.
+- Do not include live client data in exercises. Use training records only.
+- Do not instruct learners to send external communications, publish proposals, reassign leads, or change settings in production without explicit manager approval.
+- Do not describe disabled or unverified integrations as universally available.
+- Do not duplicate full sales, market, compliance, or transaction instruction already covered by other competencies; link the CRM behaviour to those capabilities.
+
+## Deliverables
+
+- [x] Competency index at `content/lms/10-agentcrm-mastery/_index.md`
+- [x] Eight practical modules at `content/lms/10-agentcrm-mastery/`
+- [x] Eight module quizzes at `content/lms/quizzes/`
+- [x] One hands-on AgentCRM mission category at `content/lms/scenarios/agentcrm-workflow-lab.md`
+- [x] One AI roleplay category at `content/lms/scenarios/agentcrm-roleplays.md`
+- [x] Scenario index totals and mappings updated
+- [x] Project state updated for review
+
+## Acceptance criteria
+
+- [x] Markdown frontmatter matches the existing LMS sync schema.
+- [x] The competency contains eight modules in numeric order.
+- [x] Every module has an explicit outcome, workflow, practical exercise, success criteria, failure/recovery guidance, and linked quiz.
+- [x] Each quiz contains exactly five unambiguous questions, four options per question, one correct option, explanations, and an 80% pass threshold.
+- [x] Hands-on missions use training data and specify evidence without requiring unsupported LMS file uploads.
+- [x] AI roleplay headings and sections match the existing scenario parser.
+- [x] Content distinguishes Agent, Manager, and feature-gated workflows.
+- [x] Content does not contradict the July 2026 source behaviour.
+- [x] Local validation confirms all new files parse and cross-references resolve.
+
+## Completion notes
+
+- Added eight modules, eight five-question quizzes, eight workflow labs, and six AI roleplays.
+- Added a non-AI scenario path so hands-on labs use reflection completion instead of attempting to launch an empty AI session.
+- Recorded the source snapshot, curriculum rationale, product variability, and drift triggers in the competency audit.
+- Content validation passed with 8 modules, 40 questions, 8 workflow labs, 6 AI roleplays, and 113 scenarios across the full bank.
+- Targeted ESLint passed for all touched TypeScript files.
+- Repository-wide TypeScript validation remains blocked by pre-existing missing marketing hero images in eight web routes; no TypeScript errors were reported in the AgentCRM training changes.
+
+## Human review focus
+
+1. Confirm the Prime Capital production tenant uses the labels and feature gates described.
+2. Confirm which training tenant or designated practice records learners should use.
+3. Confirm whether manager training should be mandatory for senior consultants.
+4. Test the six AI roleplays for tone, evaluation quality, and realistic escalation.
+5. Review content after material AgentCRM workflow changes; the source snapshot is recorded above to make drift visible.

--- a/catalyst/briefs/_review-20260715_agentcrm-agent-mastery-rebuild.md
+++ b/catalyst/briefs/_review-20260715_agentcrm-agent-mastery-rebuild.md
@@ -1,0 +1,842 @@
+<!-- CATALYST - AgentCRM agent mastery curriculum rebuild brief -->
+
+---
+title: "AgentCRM Agent Mastery Rebuild"
+stage: mvp
+tags: [lms, agentcrm, onboarding, agent-training, practical-skills]
+---
+
+# AgentCRM Agent Mastery Rebuild
+
+> **Catalyst Brief** — Read [AGENTS.md](../../AGENTS.md) and [BRIEFS.md](../../.catalyst/BRIEFS.md) before implementing.
+
+**Phase:** MVP  
+**Status:** In review  
+**Primary learner:** Prime Capital consultant using AgentCRM  
+**Product baseline:** AgentCRM commit `58317aa0`  
+**Supersedes:** The module structure in `_review-20260714_agentcrm-training-competency.md`; accurate source-derived content may be retained and rewritten.
+
+---
+
+## 1. Summary
+
+Rebuild Competency 10 as a practical **AgentCRM agent operating playbook**. The competency must teach the tools, judgement, habits, and repeatable workflow a consultant needs to run a working day: notice priority work, find and claim the right lead, make fast first contact, qualify buyer and seller needs, maintain useful records and next actions, work with properties and proposals, progress the client through meetings and decisions, create and manage deals, upload documents correctly, and preserve the relationship after an opportunity is won or lost.
+
+The current implementation contains useful product research and several sound mental models, but its structure overweights generic assessment design, Inbox workflows that are not enabled, and manager controls that do not belong in agent mastery. This rebuild keeps the useful source-grounded material and replaces the course spine, module outcomes, scenarios, quizzes, job aids, and capstone.
+
+The competency should answer one practical question:
+
+> Can this consultant use AgentCRM to move a real prospect from first signal to investment decision quickly, consistently, and with a clear next action?
+
+This is a curriculum/content rebuild. It is not an AgentCRM product-development project or a certification-platform redesign.
+
+---
+
+## 2. Objectives and Success Criteria
+
+### Objectives
+
+1. Teach the everyday AgentCRM tools an agent must operate confidently on desktop and mobile.
+2. Build the mindsets that make CRM use effective rather than administrative.
+3. Make speed to contact and first-call quality central to the learning journey.
+4. Teach separate buyer and seller qualification paths without duplicating the full sales curriculum.
+5. Give agents a clear minimum-touchpoint and next-action discipline.
+6. Teach the ideal client progression from enquiry to investment decision and deal.
+7. Make the distinction between interest and commitment operationally unmistakable.
+8. Teach properties, proposals, deals, stages, and documents as connected parts of the client journey.
+9. Teach that a won or lost opportunity changes the current transaction, not the value of the client relationship.
+10. Provide practical job aids that agents can use while working, not only while studying.
+
+### Success criteria
+
+- A learner can explain the full AgentCRM client journey without referring to a feature menu.
+- A learner can begin from Today or a notification, find the correct lead, claim it where appropriate, and take the next action.
+- A learner can demonstrate the first-contact workflow on both a buyer and a seller case.
+- A learner can leave a useful record: correct details, concise note, qualification, outcome, and next contact date.
+- A learner can explain and apply the minimum communication-touchpoint model.
+- A learner can find and assess properties, build a shortlist, and create a proposal linked to confirmed needs.
+- A learner can distinguish an interested client from a client who has committed to progress on a named property.
+- A learner can create and manage a deal, associate the correct property, progress the stage truthfully, and upload a safe training document.
+- A learner can explain the correct ongoing relationship after a won or lost opportunity without keeping a dead transaction artificially active or overriding consent.
+- The complete experience works without Inbox content or manager-only controls.
+- Every module includes one reusable practical tool and one hands-on AgentCRM task.
+- The final capstone follows connected buyer and seller records rather than unrelated click-through exercises.
+- Course and module duration estimates reconcile and remain achievable within one working day for an experienced broker new to AgentCRM.
+
+---
+
+## 3. Users, Roles, and Permissions
+
+### In-scope learner: Agent / Consultant
+
+The learner may be:
+
+- New to Dubai real estate and AgentCRM.
+- An experienced broker who is new to AgentCRM.
+- A current consultant who needs a consistent operating standard.
+
+The agent must learn to:
+
+- Work assigned and eligible pool leads.
+- Use Today, Leads, filters, notifications, properties, proposals, deals, documents, and the mobile experience.
+- Capture buyer and seller qualification.
+- Set and honour next actions.
+- Move client work through the correct progression.
+
+### Supporting role: Manager / Coach
+
+Managers may observe the final capstone and use its simple checklist. Manager dashboards, assignment policy, performance coaching, team settings, routing configuration, and manager-only controls are **not taught in this competency**.
+
+### Permissions assumptions
+
+- Training occurs in an approved practice environment or on explicitly designated practice records.
+- Learners use normal agent permissions.
+- Practice must not require manager-only navigation.
+- Any feature that varies by role, agency setting, device, or notification permission must be labelled accurately.
+
+---
+
+## 4. Scope Definition
+
+### In scope — must deliver
+
+1. A rewritten Competency 10 overview and operating model.
+2. Eight rewritten and renamed agent-focused modules.
+3. Eight linked five-question knowledge checks.
+4. Eight workflow missions that form two connected client journeys.
+5. Six focused AI roleplays tied to the client journey.
+6. Practical quick-reference tools embedded in the modules.
+7. A simple final “run the client journey” capstone and manager checklist described in content.
+8. Correct references to Today, notifications, lead discovery, Pool, lead details, qualification, notes, next contact date, properties, proposals, pipeline, deals, documents, and mobile use.
+9. Buyer and seller variants wherever the workflow materially differs.
+10. Updated scenario indexes, counts, course audit, cross-references, module metadata, and quiz mappings.
+
+### Out of scope — must not deliver
+
+- **Inbox training.** Inbox is not enabled and must not appear as a learner workflow, learning objective, lab dependency, quiz answer, or readiness requirement.
+- Manager-control-room, team-performance, routing, assignment-policy, analytics, or settings training.
+- A new manager competency; capture it as future work only.
+- AgentCRM product feature changes, including Today, notifications, Pool, deals, documents, or mobile implementation.
+- Supabase schema changes, data seeding, LMS sync, or production data mutation.
+- Certificate-eligibility rearchitecture or a complex assessor/evidence platform.
+- New LMS upload, rubric, roleplay, or scenario infrastructure unless an existing parser defect prevents the agreed content from rendering.
+- A full sales, market, compliance, AML, transaction, or relationship-stewardship curriculum. Link to the appropriate competencies instead.
+- Instructions to send test communications, proposals, or notifications to real clients.
+- Pixel-perfect screen tours likely to drift. Teach decisions, labels, and current control locations only where useful.
+
+---
+
+## 5. Requirements
+
+### A. Competency architecture
+
+**R1. Agent operating outcome**  
+Rewrite the competency outcome around running a prospect from first signal to investment decision with speed, context, correct qualification, and a visible next action.
+
+**R2. Eight-module structure**  
+Deliver exactly these eight modules in this order:
+
+1. AgentCRM Operating Model, Navigation & Mobile
+2. Today, Notifications & Speed to Contact
+3. Finding, Filtering & Claiming Leads
+4. First Phone Call & Qualification Mastery
+5. Lead Details, Notes, Next Contact Date & Touchpoints
+6. Properties, Shortlists & Proposals
+7. The Ideal Client Journey & Pipeline
+8. Deals, Documents & Ongoing Relationships
+
+**R3. Module file names and mappings**  
+Rename the current module files to match the new structure. Update every quiz `relatedModule`, slug reference, scenario mapping, course index link, and validation assumption. Content has not been approved for sync, so clarity is preferred over retaining misleading module slugs.
+
+Recommended filenames:
+
+- `10.1-operating-model-navigation-mobile.md`
+- `10.2-today-notifications-speed.md`
+- `10.3-finding-filtering-claiming.md`
+- `10.4-first-call-qualification.md`
+- `10.5-lead-details-notes-follow-up.md`
+- `10.6-properties-shortlists-proposals.md`
+- `10.7-client-journey-pipeline.md`
+- `10.8-deals-documents-relationships.md`
+
+**R4. Consistent module pattern**  
+Every module must contain:
+
+1. Observable learner outcome.
+2. Core mindset.
+3. Why the skill matters to client service and agent performance.
+4. Product workflow and decision rules.
+5. Buyer/seller difference where relevant.
+6. Desktop and mobile guidance where relevant.
+7. A worked example.
+8. A contrast case showing a tempting wrong action.
+9. A quick-reference practical tool.
+10. A hands-on task using the connected practice journeys.
+11. Clear success criteria.
+12. Common mistakes and recovery.
+
+**R5. Working-day sequence**  
+The module order and examples must resemble an agent’s work: notice → select → contact → qualify → capture → schedule → meet → match → propose → follow up → decide → deal → documents → continue the relationship.
+
+**R6. Durable principles over feature tour**  
+Teach what decision the agent is making and what good record state looks like. Avoid long descriptions of navigation that do not contribute to performing the work.
+
+**R7. Existing content reuse**  
+Reuse accurate material from the current modules where it supports this brief. Remove or substantially reduce content that belongs to Inbox, AI theory, manager coaching, team dashboards, or generic assessment explanation.
+
+### B. Module requirements
+
+#### Module 10.1 — AgentCRM Operating Model, Navigation & Mobile
+
+**R8. Core mindset**  
+Teach that AgentCRM is the shared memory and next-action system for the client relationship, not a personal address book or an administrative reporting burden.
+
+**R9. Practical content**  
+Cover:
+
+- Contact as the centre of the relationship.
+- Buyer and seller requirements.
+- Lead/enquiry, property, proposal, deal, activity, note, task, and next contact date.
+- The difference between an opportunity and a person.
+- Core agent navigation only.
+- Notification access and settings at a high level.
+- Installing/opening the supported mobile/PWA experience.
+- What is consistent across desktop and mobile and what may move.
+
+**R10. Practical tool and task**  
+Provide a one-page “AgentCRM relationship map” and mobile quick-start checklist. The learner opens a designated record on desktop and mobile and traces contact → requirement → property/proposal → deal → next action without editing live data.
+
+#### Module 10.2 — Today, Notifications & Speed to Contact
+
+**R11. Core mindset**  
+Teach that speed to contact is a competitive and service advantage. Today and notifications exist to reduce delay between a client signal and useful human action; an empty screen is not the goal.
+
+**R12. Today rules**  
+Teach the actual pinned product behaviour for:
+
+- Which records appear on Today.
+- Signal and reason.
+- New lead and first-contact work.
+- Due and overdue next contact dates.
+- Future next contact date suppression.
+- What Done, defer, complete, or equivalent controls do and do not persist.
+- How notifications complement Today.
+
+Do not repeat the unsupported claim that all live signals break through a future NCD on Today. Verify the enabled notification behaviour and teach only what the product actually surfaces. If a product gap remains, record it in `AUDIT.md`; do not invent a training workaround.
+
+**R13. Notifications and mobile**  
+Distinguish in-app notifications, notification preferences, and native/web push only where confirmed and enabled. Show how an agent moves from a notification to the relevant lead and next action on mobile.
+
+**R14. Practical tool and task**  
+Provide a Today priority guide and speed-to-contact checklist. The learner triages a timed Today set, opens a notification, identifies the first three actions, completes one response loop, and leaves the right outcome and next date.
+
+#### Module 10.3 — Finding, Filtering & Claiming Leads
+
+**R15. Core mindset**  
+Teach: find the right opportunity, understand its context, then take responsibility. Claiming is a service commitment, not a way to accumulate leads.
+
+**R16. Practical content**  
+Cover:
+
+- Finding a known lead.
+- Filtering the Leads list by the dimensions actually available.
+- Useful filter recipes for new, uncontacted, buyer, seller, location, stage, and follow-up work where supported.
+- Difference between assigned leads and Pool leads.
+- Reviewing source, history, duplicate risk, previous ownership, fit, and personal capacity before claiming.
+- Pool locks/claim conflicts and what to do when another agent wins the claim.
+- Claim-on-outcome versus merely opening or dialling, using the actual product behaviour.
+- Confirming ownership after the action.
+
+**R17. Practical tool and task**  
+Provide a lead-search recipe card and claim checklist. The learner finds one buyer and one seller, filters the list, evaluates a Pool record, handles one controlled claim conflict, and confirms the final owner.
+
+#### Module 10.4 — First Phone Call & Qualification Mastery
+
+**R18. Core mindset**  
+Teach that the first call is the highest-leverage moment in AgentCRM. Its purpose is to create relevance, establish direction, capture enough truth, and secure the next meaningful commitment—usually a meeting or defined follow-up—not to complete every field.
+
+**R19. First-call workflow**  
+Teach:
+
+1. Read source, property, history, local time, and ownership before calling.
+2. Open with the specific enquiry or relationship context.
+3. Establish the client’s objective.
+4. Qualify the minimum useful commercial frame conversationally.
+5. Distinguish confirmed client facts from inferred source data.
+6. Summarise what was heard.
+7. Book the next meeting or agree the next useful action.
+8. Record outcome, qualification, note, stage, and next contact date immediately.
+
+**R20. Buyer qualification**  
+Provide a practical buyer checklist covering the confirmed essentials currently supported by the Prime Capital rubric, including purpose, budget, location, property type/bedrooms, timing, funding, ready/off-plan preference, decision stage, and decision makers. Do not duplicate full discovery training; focus on what must be captured in AgentCRM.
+
+**R21. Seller qualification**  
+Provide a separate seller checklist covering the property, location, type, bedrooms, target price, timeline, occupancy/status, ownership/authority, motivation, post-sale plan, price flexibility, and listing context where supported. Make clear which fields are essential, optional, inferred, or unavailable in the configured rubric.
+
+**R22. Practical tools and task**  
+Provide a first-call preparation card, buyer qualification card, seller qualification card, and post-call save checklist. The learner completes one buyer roleplay and one seller roleplay, then updates both records correctly.
+
+#### Module 10.5 — Lead Details, Notes, Next Contact Date & Touchpoints
+
+**R23. Core mindset**  
+Teach that every interaction should make the record more useful to the next action and the next authorised colleague. Notes are not a diary; the NCD is not a snooze button.
+
+**R24. Lead-details mastery**  
+Cover the agent-relevant sections of a lead record, including:
+
+- Identity and contact information.
+- Source and enquiry context.
+- Buyer/seller requirements.
+- Qualification state.
+- Activities and call outcomes.
+- Notes.
+- Tasks and next contact date.
+- Matches, proposals, and deals.
+- Documents where visible.
+
+**R25. Useful note standard**  
+Teach a simple note structure:
+
+- What happened.
+- What the client confirmed or changed.
+- Current intent, concern, or decision.
+- What was agreed next, by whom, and when.
+
+Do not create a decorative acronym unless it genuinely improves recall.
+
+**R26. Minimum communication touchpoints**  
+Teach the minimum sequence without inventing an unconfirmed numeric SLA:
+
+1. Make the first call as soon as the lead becomes eligible and the agent can respond properly.
+2. If unanswered, record the exact outcome and use an approved follow-up message where enabled.
+3. Set a justified NCD for the next attempt.
+4. Make the next planned attempt from Today or the relevant notification.
+5. Add a value-led follow-up tied to the enquiry, meeting, property, or proposal.
+6. Decide explicitly whether the opportunity remains active, moves to nurture, or is lost based on facts and consent.
+
+Where Prime Capital has a configured response SLA or contact-cadence policy, use that value. If no numeric standard is confirmed during build, keep the content sequence-based and flag the number for human review rather than hardcoding it.
+
+**R27. Practical tool and task**  
+Provide a note template, touchpoint cadence card, and NCD decision guide. The learner corrects weak notes/NCDs and completes a multi-touch follow-up record.
+
+#### Module 10.6 — Properties, Shortlists & Proposals
+
+**R28. Core mindset**  
+Teach that access to inventory is not advice. An agent creates value by translating confirmed requirements into a small, defensible decision set.
+
+**R29. Properties workflow**  
+Cover:
+
+- Finding and filtering properties.
+- Opening and reading property details.
+- Checking fit against the active buyer requirement.
+- Distinguishing live facts from fields that require verification.
+- Match score as a review aid, not a suitability decision.
+- Recording suggested, shared, viewed, interested, or rejected status truthfully where supported.
+- Mobile property review where practical.
+
+**R30. Proposal workflow**  
+Cover:
+
+- Selecting a small decision set.
+- Explaining fit, differences, trade-offs, and pending checks.
+- Creating and previewing a client-specific proposal.
+- Avoiding unauthorised practice sends.
+- Understanding proposal engagement and preparing the next meeting/follow-up.
+- Keeping the proposal linked to the right contact and requirement.
+
+**R31. Practical tool and task**  
+Provide a property review checklist, three-option shortlist template, and proposal quality checklist. The learner creates a draft proposal from a confirmed buyer requirement and prepares the follow-up meeting.
+
+#### Module 10.7 — The Ideal Client Journey & Pipeline
+
+**R32. Core mindset**  
+Teach that pipeline progress is the sequence of real client commitments and decisions. Stages describe evidence; they are not targets to move for appearance.
+
+**R33. Ideal journey**  
+Use this durable journey as the primary model:
+
+1. Initial call.
+2. Booked meeting.
+3. Qualification and decision frame confirmed.
+4. Property research and shortlist.
+5. Proposal prepared/shared through the authorised workflow.
+6. Follow-up meeting.
+7. Client comparison, objections, and investment decision.
+8. Explicit instruction to progress a named property.
+9. Deal creation.
+
+The content may map this journey to current pipeline labels, but must keep the evidence behind each step more important than the label.
+
+**R34. Interested versus committed**  
+Teach contrast cases such as:
+
+- “I like this one” — interested, not committed.
+- “This is our favourite; we need to discuss it” — interested, not committed.
+- “Please verify the terms and hold while we decide” — not yet committed unless the product/business process defines otherwise.
+- “Proceed with this named property; explain the next transaction step” — commitment sufficient to create a deal when other required context exists.
+
+**R35. Practical tool and task**  
+Provide a visual client-journey map, stage-evidence guide, and interested-versus-committed decision card. The learner progresses connected records through the right steps and explains every stage using evidence.
+
+#### Module 10.8 — Deals, Documents & Ongoing Relationships
+
+**R36. Core mindset**  
+Teach that the deal represents committed transaction work on a specific property. A won or lost opportunity changes the transaction; it does not erase the person or the long-term relationship.
+
+**R37. Deal workflow**  
+Cover:
+
+- The commitment gate.
+- Creating a deal from the correct client and named property.
+- Required and useful deal fields.
+- Ownership and next obligation.
+- Deal stages and evidence.
+- Key dates and financial information at the level the product supports.
+- Adding or managing associated properties where applicable.
+- Correcting a stage when evidence changes.
+- Won and lost outcomes.
+
+**R38. Documents**  
+Teach:
+
+- Where client and deal documents belong in the current product.
+- Uploading a safe dummy training document.
+- Clear naming and correct association.
+- Checking that the file is present and accessible to the right authorised users.
+- Never using real passports, Emirates IDs, bank statements, or transaction documents for practice.
+- Renaming/removing a mistaken training upload if the product supports it.
+
+**R39. Won/lost relationship model**  
+Teach all of the following:
+
+- A **won deal** begins post-transaction relationship stewardship, referrals, reviews, and future requirements where appropriate.
+- A **lost deal/opportunity** ends or changes the current transaction; it does not automatically make the person irrelevant.
+- A lost opportunity may move to an appropriate future relationship/nurture path only when there is a real reason and consent.
+- Do not keep a dead deal active merely to preserve the relationship.
+- Do-not-contact always overrides the “live prospect” mindset.
+
+**R40. Practical tool and task**  
+Provide a deal-creation checklist, document checklist, and won/lost relationship guide. The learner decides which of two records warrants a deal, creates it, uploads a dummy document, progresses the stage, and leaves an appropriate post-outcome relationship action.
+
+### C. Embedded practical tools
+
+**R41. Tool format**  
+Every module must include a clearly labelled **Agent Tool** section in plain Markdown. Tools must be concise enough to use on a phone during work and printable without special LMS infrastructure.
+
+**R42. Required tool set**  
+Deliver these tools across the modules:
+
+1. AgentCRM relationship map.
+2. Mobile quick-start checklist.
+3. Today priority guide.
+4. Speed-to-contact checklist.
+5. Lead filter recipe card.
+6. Pool claim checklist.
+7. First-call preparation card.
+8. Buyer qualification card.
+9. Seller qualification card.
+10. Post-call save checklist.
+11. Useful-note template.
+12. Minimum-touchpoint cadence card.
+13. NCD decision guide.
+14. Property review checklist.
+15. Three-property shortlist template.
+16. Proposal quality checklist.
+17. Client-journey/pipeline map.
+18. Stage-evidence guide.
+19. Interested-versus-committed decision card.
+20. Deal-creation checklist.
+21. Document checklist.
+22. Won/lost relationship guide.
+
+Tools may be combined where that improves usability. Do not inflate the content merely to preserve a count.
+
+### D. Connected workflow missions
+
+**R43. Two golden-thread journeys**  
+Replace the disconnected lab feeling with two recurring practice records:
+
+#### Buyer journey
+
+Notification/Today → find or claim → first call → buyer qualification → meeting booked → notes/NCD → property shortlist → proposal → follow-up meeting → investment decision → deal → document → post-outcome relationship.
+
+#### Seller journey
+
+Find/filter → ownership check → first call → seller qualification → notes/NCD → meeting/action plan → proposal or agreed service step where supported → follow-up decision → active/nurture/lost relationship state.
+
+**R44. Eight mission structure**  
+Rewrite the workflow lab as:
+
+- **LAB-01:** Relationship Map, Navigation & Mobile Setup
+- **LAB-02:** Today, Notification & Speed-to-Contact Sprint
+- **LAB-03:** Find, Filter & Claim the Right Lead
+- **LAB-04:** Buyer First Call and CRM Save
+- **LAB-05:** Seller First Call, Notes, NCD & Touchpoints
+- **LAB-06:** Property Shortlist and Proposal
+- **LAB-07:** Meeting-to-Decision Pipeline
+- **LAB-08:** Deal, Dummy Document and Ongoing Relationship
+
+**R45. Mission evidence**  
+Keep evidence light. Each mission must name the visible result the learner should be able to show on the practice record. Reflection may remain, but the mission's educational value comes from the resulting record and self-check, not long written evidence.
+
+### E. Focused roleplays
+
+**R46. Roleplay set**  
+Retain six roleplays, rewritten around high-value conversations:
+
+1. Buyer first contact and meeting booking.
+2. Seller first contact and qualification.
+3. Efficient qualification without interrogating.
+4. Proposal follow-up meeting and trade-off discussion.
+5. Interested versus committed decision.
+6. Won/lost opportunity and the next relationship step.
+
+No roleplay may depend on Inbox. The client prompt must create realistic pressure without scripting the answer.
+
+**R47. CRM follow-through prompt**  
+Every roleplay must finish with a short “What changes in AgentCRM?” self-check covering outcome, facts learned, stage, next action/NCD, proposal/deal decision, and relationship state as applicable.
+
+### F. Knowledge checks
+
+**R48. Quiz purpose**  
+Quizzes confirm product rules and decision understanding; they do not need to act as a complex readiness system.
+
+**R49. Quiz structure**  
+Maintain eight quizzes with five questions and an 80% pass mark for current LMS compatibility.
+
+**R50. Quiz design**  
+Questions must:
+
+- Use short realistic AgentCRM situations.
+- Use plausible near-miss alternatives.
+- Avoid obviously reckless distractors.
+- Avoid testing the same deal, DNC, or multiple-requirement rule repeatedly.
+- Test buyer and seller qualification.
+- Test Today and notifications without referring to Inbox.
+- Test interested versus committed.
+- Test deals/documents, properties/proposals, notes/NCD, Pool claiming, mobile use, and ongoing relationships.
+- Explain the operational consequence of the correct decision.
+
+### G. Simple capstone
+
+**R51. Capstone**  
+Add a concise capstone description to the competency index or workflow-lab introduction. The learner completes a 45–60 minute “run the client journey” challenge using the connected practice records.
+
+**R52. Capstone checklist**  
+The manager/coach checks only whether the learner can:
+
+1. Find and prioritise the correct lead.
+2. Act with appropriate speed and ownership.
+3. Conduct and record useful qualification.
+4. Leave a clear note and next contact date.
+5. Progress meetings, properties, and proposals truthfully.
+6. Distinguish interest from commitment.
+7. Create/manage the right deal and dummy document.
+8. Leave the correct ongoing relationship action after won/lost.
+
+Keep the checklist pass/fail and practical. Do not build a new assessment platform in this brief.
+
+### H. Fidelity, safety, and content maintenance
+
+**R53. Product baseline**  
+Verify every consequential product instruction against AgentCRM commit `58317aa0`. Current `HEAD` may be checked for awareness but must not silently replace the baseline if it differs.
+
+**R54. Today and notifications verification**  
+At the start of implementation, inspect the Today loader, next-action engine, notification bell/sheet, preferences, push/PWA surfaces, and mobile lead journey. Resolve content against learner-visible behaviour rather than comments or intended architecture alone.
+
+**R55. Buyer/seller field verification**  
+Verify the current Prime Capital qualification rubric, which buyer/seller fields are shown, which are essential, and what manual edits mark confirmed.
+
+**R56. Deal/document verification**  
+Verify current deal creation, required property association, stages, contact versus deal documents, upload/rename/delete behaviour, and agent permissions before writing steps.
+
+**R57. Feature variability**  
+Where notifications, push, mobile installation, proposals, documents, or other controls vary, state the durable workflow and the verified alternative. Do not teach unavailable controls as universal.
+
+**R58. Practice safety**  
+All examples and tasks use dummy people, properties, amounts, and files. Do not use live clients or genuine identity/financial documents.
+
+**R59. Course audit**  
+Rewrite `content/lms/10-agentcrm-mastery/AUDIT.md` as a concise claim register covering the source snapshot, product-sensitive statements, learner journeys, exclusions, and revalidation triggers. Do not retain the previous report's heavy readiness architecture as learner-facing scope.
+
+---
+
+## 6. Non-Functional Requirements
+
+### Readability and tone
+
+- Use concise UK English suitable for an international Dubai workforce.
+- Tone is direct, practical, professional, and agent-to-agent.
+- Avoid hype, slogans, patronising explanations, and academic instructional-design language.
+- Define product terms when first used; do not assume “NCD” is understood before “next contact date”.
+- Use short paragraphs, checklists, examples, and decision tables where they improve action.
+
+### Mobile and accessibility
+
+- Every Agent Tool must work as readable plain text on a mobile screen.
+- Avoid instructions that rely only on colour, precise pointer position, or one desktop layout.
+- Give controls their visible label and purpose; acknowledge mobile placement differences.
+- Scenario instructions must be understandable to a learner working in a second language.
+
+### Maintainability
+
+- Keep product-sensitive statements easy to locate in `AUDIT.md`.
+- Prefer current labels plus durable intent, not screen coordinates.
+- Record the verified product path for Today, notifications, Pool, qualification, proposals, deals, documents, and mobile.
+- Ensure course overview and module duration totals reconcile.
+
+### Data and privacy
+
+- Use only dummy or approved training records.
+- Use a harmless dummy document for upload practice.
+- Never include real contact details, passports, Emirates IDs, bank details, or transactional documents in content or scenarios.
+
+---
+
+## 7. Design and Content Requirements
+
+### Learning design
+
+- Build around **mindset → tool → worked example → contrast case → product task**.
+- Use the same buyer and seller records across modules so the learner sees cause and effect.
+- Let practical tools carry the operating standard; keep explanatory prose only where it changes judgement.
+- Teach the ideal client journey as the organising model, with product features introduced when needed.
+- Make mobile actions part of the normal workflow, not an optional appendix.
+
+### Core mindset statements
+
+The final content must express these ideas in clear learner language:
+
+1. **Speed creates opportunity.** Act quickly while still reading the context.
+2. **Claiming means ownership.** Do not claim work you cannot progress.
+3. **The record should tell the truth.** Capture what happened, not what you hoped happened.
+4. **Every touch creates a next step.** Use a meaningful NCD, not a hiding date.
+5. **Qualification guides value.** The first call should create direction and a meeting, not interrogate.
+6. **Properties require judgement.** A shortlist is more valuable than an inventory dump.
+7. **Interest is not commitment.** Create a deal only when the client decides to progress a named property.
+8. **Stages follow evidence.** Never move a stage merely to make the pipeline look healthy.
+9. **Won/lost describes the opportunity, not the human relationship.** Continue appropriate stewardship unless consent says stop.
+10. **Mobile keeps the record current.** Capture outcomes and next actions while the context is fresh.
+
+### Trust cues
+
+- Clearly distinguish current product fact, Prime Capital operating standard, and suggested best practice.
+- Mark controls that depend on notification permission, mobile installation, role, or agency configuration.
+- Do not imply that a feature has recorded an action until the learner confirms the resulting record.
+
+---
+
+## 8. Risks, Assumptions, and Open Questions
+
+### Risks
+
+1. **Today versus notification drift:** source comments and learner-visible behaviour may differ. Verify both surfaces before writing.
+2. **Seller qualification variability:** the configured Prime Capital rubric may expose more or fewer seller fields than expected.
+3. **Document ambiguity:** contact documents and deal documents may have different controls or permissions.
+4. **Mobile drift:** PWA, desktop, and mobile layouts may not expose identical actions.
+5. **Cadence ambiguity:** Prime Capital's numeric response SLA and minimum attempt count may not be formally confirmed.
+6. **Scope creep:** the work may drift back into manager training, certification systems, or product engineering.
+
+### Assumptions
+
+- Inbox remains disabled and excluded.
+- The course has not been approved for production sync, so renaming module files/slugs is acceptable when references are updated.
+- Eight modules, eight quizzes, eight workflow labs, and six roleplays remain compatible with the current LMS.
+- Existing accurate content can be reused; a full blank-page rewrite is unnecessary.
+- A manager can observe the capstone without new LMS infrastructure.
+
+### Open questions
+
+**During build — do not block initial work:**
+
+1. What numeric speed-to-contact SLA should Prime Capital publish? If not confirmed, teach immediate response and configured SLA without inventing a number.
+2. What exact minimum attempt count/timing should accompany the sequence in R26? Draft the sequence first and flag timing for human review.
+3. Which notification channels and mobile push behaviours are enabled in the Prime Capital tenant? Verify source/default behaviour and label configuration-dependent items.
+4. Which seller qualification dimensions are configured as essential?
+5. Should document practice use contact documents, deal documents, or both? Follow the learner's actual workflow and verified permissions.
+
+**Post-phase:**
+
+- Manager/team-control competency.
+- Inbox training when the feature is enabled.
+- Formal LMS readiness/certificate enforcement.
+- Automated training-tenant seeding or reset tooling.
+
+### Blockers
+
+None. The implementation agent can begin with the curriculum map, product verification, module renames, and reusable content inventory while recording the during-build questions.
+
+---
+
+## 9. Acceptance Checklist
+
+### Structure and scope
+
+- [x] Brief renamed `approved-` → `active-` before implementation begins.
+- [x] Competency overview reflects agent mastery and the ideal client journey.
+- [x] Exactly eight modules exist in the required order.
+- [x] Module files/slugs, quiz mappings, scenarios, indexes, and references are consistent.
+- [x] Inbox is absent from learner objectives, module workflows, quizzes, labs, roleplays, and capstone.
+- [x] Manager controls, dashboards, coaching, routing, and settings are removed from the competency.
+- [x] No product or Supabase mutations were performed.
+
+### Critical tools and skills
+
+- [x] Today concept and actual rules are taught accurately.
+- [x] Notifications and speed-to-contact behaviour are taught accurately.
+- [x] Finding and filtering Leads is practised.
+- [x] Pool review and claiming is practised.
+- [x] Lead Details, Notes, and NCD are practised.
+- [x] Minimum communication touchpoints are explicit.
+- [x] Buyer qualification and seller qualification are separate and practical.
+- [x] First phone call mastery is the central qualification exercise.
+- [x] Properties and proposals are practised as one advisory workflow.
+- [x] The ideal call → meeting → proposal → follow-up → decision journey is visible throughout.
+- [x] Interested versus committed is taught and tested.
+- [x] Deal creation, deal management, and dummy-document upload are practised.
+- [x] Won/lost opportunity versus ongoing relationship is taught with consent boundaries.
+- [x] Mobile use is embedded across the journey.
+
+### Learning assets
+
+- [x] Every module includes an Agent Tool section.
+- [x] The required quick-reference tool set is delivered without unnecessary duplication.
+- [x] Eight workflow missions form the connected buyer and seller journeys.
+- [x] Six roleplays match the agreed high-value conversations.
+- [x] Every roleplay ends with an AgentCRM follow-through self-check.
+- [x] Eight quizzes contain five questions each, with one defensible answer and plausible distractors.
+- [x] A simple 45–60 minute capstone and pass/fail manager checklist are included.
+
+### Fidelity and quality
+
+- [x] AgentCRM commit `58317aa0` exists and was used as the baseline.
+- [x] Today and notifications were verified against learner-visible source paths.
+- [x] Buyer/seller qualification fields and confirmation behaviour were verified.
+- [x] Pool claiming and ownership behaviour were verified.
+- [x] Properties, proposal, deal, document, and mobile behaviour were verified.
+- [x] Course `AUDIT.md` records product-sensitive claims and exclusions.
+- [x] Course headline duration equals the sum/meaning of module durations.
+- [x] Content uses clear UK English and remains usable on mobile.
+- [x] Scenario/parser validation confirms 8 modules, 40 questions, 8 labs, and 6 roleplays.
+- [x] Targeted lint/type checks run only if TypeScript changes are required; otherwise content validation is recorded.
+- [x] No LMS sync or Supabase mutation was performed without explicit confirmation of the correct project.
+
+---
+
+## 10. Handoff Notes for the Implementation Agent
+
+### Start here
+
+1. Read this brief, the original `_review-20260714_agentcrm-training-competency.md`, and `.context/agentcrm-pedagogical-review.md`.
+2. Rename this brief to `active-20260715_agentcrm-agent-mastery-rebuild.md`.
+3. Confirm AgentCRM commit `58317aa0` exists; do not silently substitute a different `HEAD`.
+4. Inspect Today, notifications, Pool, buyer/seller qualification, properties, proposals, deals, documents, and mobile source before editing claims.
+5. Produce a short old-module → new-module content map. Reuse accurate passages and remove irrelevant scope.
+6. Rename/rewrite the competency files and update linked quiz/scenario references.
+7. Rebuild the practice journeys and practical tools before polishing prose.
+8. Validate counts, mappings, durations, frontmatter, and forbidden scope.
+9. Update this checklist and add completion notes.
+10. Rename the brief to `_review-20260715_agentcrm-agent-mastery-rebuild.md` when complete.
+
+### Priorities
+
+1. Correct product behaviour and scope.
+2. Practical job tools.
+3. First-call and qualification mastery.
+4. Connected buyer/seller journeys.
+5. Properties → proposals → meetings → decisions → deals.
+6. Mobile execution.
+7. Quiz and prose refinement.
+
+### Do not overbuild
+
+- Do not build a new certification or evidence platform.
+- Do not add Inbox as a future-looking section.
+- Do not retain manager material merely because Module 10.8 already exists.
+- Do not create more scenarios than the agreed eight labs and six roleplays.
+- Do not add academic assessment terminology to learner content.
+- Do not turn the modules into exhaustive product documentation.
+- Do not hardcode an unconfirmed numeric SLA or contact cadence.
+
+### What good looks like
+
+An agent can keep the course open beside AgentCRM and use its tools immediately. The buyer and seller records progress naturally from Today/notification through first call, qualification, meetings, properties/proposal, decision, deal/documents, and the next relationship action. The learner understands not only which control to use, but the business mindset behind it.
+
+### References
+
+#### Workspace
+
+- `catalyst/briefs/_review-20260714_agentcrm-training-competency.md`
+- `.context/agentcrm-pedagogical-review.md`
+- `content/lms/10-agentcrm-mastery/`
+- `content/lms/quizzes/agentcrm-mastery-*.md`
+- `content/lms/scenarios/agentcrm-workflow-lab.md`
+- `content/lms/scenarios/agentcrm-roleplays.md`
+- `lib/lms/sync.ts`
+
+#### AgentCRM product baseline (`/Users/thg/code/agentcrm` at `58317aa0`)
+
+- `catalyst/specs/project-vision.md`
+- `catalyst/specs/project-experience.md`
+- `app/(app)/app/today/data.ts`
+- `modules/crm/lib/next-action.ts`
+- `components/shared/notifications-sheet.tsx`
+- `modules/activity/components/notification-bell.tsx`
+- `app/(app)/app/settings/notifications/page.tsx`
+- `components/shared/pwa-install-card.tsx`
+- `modules/crm/components/lead-pool-view.tsx`
+- `modules/crm/services/lead-pool-service.ts`
+- `app/api/crm/contacts/call-attempt/route.ts`
+- `app/api/crm/contacts/quick-log/route.ts`
+- `lib/qualification/`
+- `modules/crm/lib/qualification-from-requirement.ts`
+- `modules/crm/services/matching-service.ts`
+- `modules/crm/components/matches-tab.tsx`
+- `modules/crm/services/proposal-service.ts`
+- `modules/crm/services/deal-service.ts`
+- `modules/crm/components/deal-form.tsx`
+- `modules/crm/components/deal-documents.tsx`
+- `app/(app)/app/leads/[id]/_mobile/`
+- `app/api/contacts/[id]/documents/route.ts`
+
+### Known repository limitation
+
+`/Users/thg/code/launchpath-skills/public/SKILL_INDEX.md` was still missing when this brief was written. Continue with repository and Catalyst instructions unless the index becomes available.
+
+---
+
+## 11. Completion Notes
+
+**Completed by:** Codex, Tallinn workspace  
+**Completion date:** 2026-07-15
+
+### Delivered
+
+- Rebuilt the competency overview and all eight modules around one consultant working day and the connected Maya/Karim practice records.
+- Delivered 22 labelled Agent Tools, eight five-question quizzes, eight workflow missions, six focused AI roleplays, and a 45–60 minute capstone with an eight-item pass/fail checklist.
+- Rewrote the product claim audit against AgentCRM `58317aa0`, including the learner-visible Today limitation and configuration-dependent notification, qualification, document, proposal, and mobile behaviour.
+- Extended the existing scenario detail parser/UI so every roleplay's “What changes in AgentCRM?” self-check renders after practice. The existing no-AI workflow-mission reflection path was preserved.
+- Updated the scenario indexes/audit and project state. No LMS sync, Supabase access, product-repository mutation, seeding, or production-data mutation was performed.
+
+### Validation
+
+- Content/parser validation: 336 checks passed; 8 modules, 385 module minutes, 22 tools, 40 questions, 8 labs, and 6 roleplays.
+- Targeted ESLint: passed for all touched TypeScript files.
+- Vitest: 12 files and 111 tests passed.
+- `git diff --check`: passed.
+- Repo-wide `tsc --noEmit`: blocked only by pre-existing missing marketing hero images referenced by eight `(web)` pages; no error was reported in the touched scenario files.
+- Essentials generation was intentionally not run because the repository script reads and writes Supabase; this brief explicitly prohibits Supabase mutation and LMS sync.
+
+### Human review
+
+- Confirm Prime Capital's numeric response SLA and minimum-attempt timing before publishing a numeric standard.
+- Confirm enabled notification channels, browser/mobile push permissions, and any tenant event-generation limits.
+- Confirm tenant overrides to buyer/seller qualification essentials and the seller rubric.
+- Confirm the designated Maya/Karim practice records and whether LAB-08 may use contact documents, deal documents, or demonstration-only mode.
+- Sample one roleplay and the complete capstone before approving LMS sync.
+- Generate refreshed LMS essentials only as part of an explicitly authorised sync against the confirmed Supabase project.
+
+### Known product limitation
+
+At the pinned baseline, a future next contact date removes a lead from Today before message/proposal signal enrichment. The training states this learner-visible behaviour and does not claim that every live signal breaks through a future NCD.

--- a/catalyst/briefs/backlog-20260715_agentcrm-embedded-training-mode.md
+++ b/catalyst/briefs/backlog-20260715_agentcrm-embedded-training-mode.md
@@ -1,0 +1,620 @@
+<!-- CATALYST - Embedded AgentCRM training mode planning brief -->
+
+---
+title: "AgentCRM Embedded Training Mode"
+stage: mvp
+tags: [agentcrm, training, sandbox, supabase, lms]
+---
+
+# AgentCRM Embedded Training Mode
+
+> **Reference copy — not the source of truth.** This epic is implemented in the **AgentCRM product repo** (`catalyst/briefs/backlog-agentcrm-20260715-epic_embedded-training-mode.md`, on branch `docs/embedded-training-mode-briefs`), where it is decomposed into five sub-briefs and carries the live approval status. Build is underway there as of 2026-07-15. This repo only owns the downstream curriculum links/media — see [backlog-20260715_agentcrm-training-mode-lms-links.md](backlog-20260715_agentcrm-training-mode-lms-links.md). Edit the AgentCRM copy, not this one.
+>
+> **Catalyst Brief** — Read [AGENTS.md](../../AGENTS.md) and [BRIEFS.md](../../.catalyst/BRIEFS.md) before implementing.
+
+**Phase:** MVP  
+**Status:** Draft backlog — requires human approval before implementation  
+**Primary user:** Prime Capital consultant learning the core AgentCRM response loop  
+**Product baseline:** AgentCRM commit `58317aa09177e44a8e3dfa5c0d21643eb5b6c598`  
+**Implementation location:** AgentCRM product repository, with LMS links and media added here only after the embedded experience is stable  
+**Related curriculum:** [_review-20260715_agentcrm-agent-mastery-rebuild.md](_review-20260715_agentcrm-agent-mastery-rebuild.md)
+
+---
+
+## 1. Summary
+
+Add a small, durable **Training Mode inside each AgentCRM installation**. It uses the normal AgentCRM shell and selected real interaction components, but stores synthetic learner state in one isolated Supabase table rather than in operational contacts, activities, notes, requirements, or deals.
+
+The first release is deliberately limited to the four behaviours Prime Capital most needs agents to repeat correctly:
+
+1. Speed to contact.
+2. Buyer and seller qualification.
+3. Useful notes.
+4. A justified next contact date (NCD).
+
+Deliver two reusable scenario packs—one buyer and one seller—and one capstone variant assembled from the same mechanics. Do not build a general simulator, a second AgentCRM deployment, a duplicated CRM schema, automatic prose grading, or LMS-to-AgentCRM integration.
+
+The product question is:
+
+> Can a consultant respond promptly to a synthetic client signal, capture truthful qualification, leave a useful note, and set the correct next contact date in the actual AgentCRM interaction pattern without touching live client data?
+
+---
+
+## 2. Objectives and Success Criteria
+
+### Objectives
+
+1. Give every consultant a private, repeatable practice space inside the AgentCRM installation they already use.
+2. Make the four required behaviours the completion spine of every interactive scenario.
+3. Reuse the real interface and interaction language without routing any training action into operational data or outbound providers.
+4. Keep the build small enough to maintain as AgentCRM changes.
+5. Produce stable interface states that can also be used for LMS screenshots and short demonstrations.
+
+### Success criteria
+
+- A signed-in agent can enter Training Mode without a separate account, application deployment, or database.
+- Each agent sees only their own training session through Supabase row-level security.
+- Starting, saving, resetting, leaving, and restarting a scenario are reliable across browser refreshes and normal Vercel execution.
+- Both scenario packs require a speed-to-contact action, qualification changes, a new note, and a new NCD before completion.
+- Training Mode makes zero writes to operational CRM tables.
+- Training Mode invokes no phone, email, WhatsApp, SMS, proposal-send, notification-delivery, webhook, AI-outreach, or external storage provider.
+- A learner can complete either pack on desktop and a supported mobile viewport.
+- The same scenario fixtures can create approved screenshots and short interface demonstrations without real-looking personal data.
+- A single implementation team can maintain the experience without synchronising a cloned AgentCRM application or mirrored CRM schema.
+
+---
+
+## 3. Users, Roles and Permissions
+
+### Agent / consultant — in scope
+
+The learner can:
+
+- Open the Training Centre from normal agent navigation.
+- Start the buyer pack, seller pack, or capstone.
+- Work only with synthetic records.
+- Record simulated contact outcomes.
+- Update the qualification fields supplied by the scenario.
+- Save a note and NCD.
+- See objective checks and reset their own scenario.
+- Exit to normal AgentCRM deliberately.
+
+The learner cannot:
+
+- Send communications.
+- Upload documents.
+- Create real contacts, requirements, proposals, deals, tasks, notes, or activities.
+- See another learner's session.
+- alter scenario definitions or pass criteria.
+
+### Manager / coach — not a product role in this release
+
+- Manager controls, dashboards, team comparisons, overrides, routing, analytics, and scenario assignment are excluded.
+- A coach may observe the capstone directly or use the existing LMS checklist outside AgentCRM.
+- No manager read policy is required on `training_sessions` in this release.
+
+### Authentication
+
+- Use the existing AgentCRM Supabase-authenticated user.
+- Do not add training credentials, magic links, LMS tokens, or cross-application single sign-on.
+- Training Mode must not be available in unauthenticated demo auth on a production installation.
+
+---
+
+## 4. Scope Definition
+
+### In scope — must deliver
+
+1. A Training Centre entry point inside the AgentCRM agent surface.
+2. A route-bound Training Mode with a persistent synthetic-data banner and explicit Exit action.
+3. One isolated Supabase `training_sessions` table with RLS.
+4. Version-controlled TypeScript scenario definitions; no scenario-builder UI.
+5. Start, resume, complete, reset, and exit behaviours.
+6. One shared simulated contact-outcome interaction.
+7. The relevant real buyer/seller qualification controls or a thin extracted presentation layer from them.
+8. The real note and NCD interaction patterns or a thin extracted presentation layer from them.
+9. Objective completion checks for speed event, required qualification changes, note creation, and NCD validity.
+10. Buyer First Response scenario pack.
+11. Seller Response and Retry scenario pack.
+12. A capstone variant that reuses the same controls and validator with changed facts and expected answers.
+13. Desktop and supported mobile layouts.
+14. Automated isolation, RLS, service, validation, and outbound-blocking tests.
+15. A small approved visual pack captured from Training Mode for the related LMS modules.
+
+### Out of scope — must not deliver
+
+- A separate AgentCRM deployment, tenant, or database.
+- Training records in operational `contacts`, `requirements`, `activities`, `notes`, `tasks`, `properties`, `proposals`, `deals`, or document tables.
+- `is_training` columns or training filters added across operational CRM tables, RPCs, reports, cron jobs, and integrations.
+- A duplicated `training` schema mirroring the operational CRM schema.
+- A generic database provider, generic simulator SDK, visual scenario builder, or plugin system.
+- Full replicas of Today, Leads, Pool, Properties, Proposals, Pipeline, Deals, Documents, Inbox, or manager surfaces.
+- Real telephony, email, WhatsApp, SMS, push, proposal sending, webhooks, document storage, or AI outreach.
+- Inbox or manager-control training.
+- Automatic AI judgement of note quality or sales-call quality.
+- Audio call simulation, speech recognition, avatars, branching video, or generated client dialogue.
+- Cross-learner claim races or a shared synthetic world. A conflict may be a deterministic scenario event.
+- LMS progress callbacks, signed launches, iframe embedding, per-click LMS telemetry, or certificate changes.
+- A training-history dashboard or long-term evidence archive.
+- Interactive property, proposal, deal, or document workflows in this release. These remain visual/guided learning until separately justified.
+
+### Why the first release stops here
+
+The four required behaviours all share one contact-response loop and can reuse the same storage, controls, and validator. Properties, proposals, deals, documents, communications, and shared Pool races each introduce different data models or integrations. Including them now would turn this into a general AgentCRM simulator rather than a focused practice tool.
+
+---
+
+## 5. Product Journey
+
+### Entry
+
+1. The signed-in agent opens **Training Centre**.
+2. The page explains that all records are synthetic and no communication will be sent.
+3. The learner chooses Buyer, Seller, or Capstone.
+4. The learner presses **Start scenario**. The scenario clock starts only after this deliberate action.
+
+### Training workspace
+
+The learner sees:
+
+- The normal AgentCRM shell and familiar responsive styling.
+- A persistent, visually distinct **Training mode — synthetic data** banner.
+- A compact mission card with the client signal, goal, and elapsed response time.
+- A synthetic contact record using familiar AgentCRM sections.
+- Simulated contact actions, qualification, notes, and NCD controls.
+- A four-item progress summary that describes results, not arbitrary clicks.
+
+### Completion
+
+1. The learner selects a simulated contact action and records its truthful outcome.
+2. The learner confirms or corrects the required qualification facts.
+3. The learner writes and saves a decision-useful note.
+4. The learner sets the scenario's justified NCD.
+5. **Check my work** runs deterministic server-side checks.
+6. The learner sees Pass or Fix guidance for each required behaviour.
+7. The learner may reset or exit. There is no LMS callback.
+
+### Exit safety
+
+- Exit requires an explicit action and returns to normal AgentCRM.
+- The training banner and route disappear before any live page is shown.
+- Training state must never alter the provider used by ordinary AgentCRM routes.
+
+---
+
+## 6. Scenario Packs
+
+Every pack has the same mandatory completion contract:
+
+| Behaviour | Required evidence |
+|---|---|
+| Speed to contact | A simulated contact attempt is recorded after scenario start and its elapsed time is shown without inventing an unapproved operational SLA. |
+| Qualification | Required buyer/seller fields are confirmed or corrected; supplied inferred facts are not silently treated as confirmed. |
+| Useful note | A new post-contact note exists and the learner reviews it against the four-part standard. |
+| Next contact date | A new NCD is valid, future-dated where appropriate, and matches the commitment supplied by the scenario. |
+
+### Pack A — Buyer First Response
+
+**Signal:** A fresh portal buyer enquiry appears in the training mission card.  
+**Synthetic contact:** Training Buyer Maya B.  
+**Starting state:** Source range and property interest are present; commercial facts are partly inferred; no meaningful first response exists.
+
+The learner must:
+
+1. Read source, enquiry, local-time, ownership, and prior-activity context.
+2. Begin the simulated contact attempt promptly.
+3. Record the supplied connected outcome.
+4. Correct the source budget to Maya's confirmed comfortable maximum.
+5. Confirm purpose, location, property type/bedrooms, timing, funding, ready/off-plan preference, decision stage, and decision-maker context supplied by the scenario.
+6. Leave unknown facts unknown.
+7. Save a note covering context, facts/decision, action/commitment, and owner/timing.
+8. Set the proposal-review meeting as the exact NCD.
+
+**Completion-specific checks:**
+
+- Confirmed budget differs correctly from the inferred source range.
+- Required buyer facts have the expected confirmed/inferred state.
+- The outcome, note creation time, and NCD all occur in this run.
+- The NCD matches the supplied meeting time.
+
+### Pack B — Seller Response and Retry
+
+**Signal:** An assigned seller enquiry needs an immediate first attempt.  
+**Synthetic contact:** Training Seller Karim S.  
+**Starting state:** Basic property context exists; seller qualification is incomplete; the first supplied attempt is No answer.
+
+The learner must:
+
+1. Begin the first simulated attempt promptly and save **No answer** rather than Contacted.
+2. Set the supplied justified retry NCD.
+3. Trigger the scenario's connected follow-up event without waiting in real time.
+4. Record the connected outcome.
+5. Confirm property, location, type, bedrooms, target price, timing, motivation, post-sale plan, flexibility, occupancy, co-owner/authority context, and undecided listing arrangement supplied by the scenario.
+6. Leave unsupported exclusivity or authority unconfirmed.
+7. Save a four-part useful note.
+8. Replace the retry NCD with the agreed valuation meeting time.
+
+**Completion-specific checks:**
+
+- No answer and connected are two separate synthetic activities.
+- The first attempt is timestamped for the speed check.
+- Required seller facts have the expected confirmed/open state.
+- The current note and NCD describe the valuation commitment, not the earlier retry.
+
+### Capstone — Mixed Response Loop
+
+- Reuse Pack A or Pack B mechanics with different names, values, source details, response outcomes, meeting times, and qualification deltas.
+- Do not add new controls, tables, assessment types, or external integrations.
+- Hide step-level hints until **Check my work**.
+- Require all four common checks to pass.
+- The existing LMS coach checklist remains the human review mechanism for note usefulness and judgement.
+
+---
+
+## 7. Completion and Feedback Rules
+
+### Speed to contact
+
+- `started_at` is written by the server when the learner presses **Start scenario**.
+- `first_contact_attempt_at` is written only when the first simulated outcome is saved.
+- Elapsed time is computed server-side.
+- The interface shows elapsed response time and reinforces immediate action.
+- The first release does not turn an unapproved numeric SLA into a pass/fail threshold.
+- A later confirmed Prime operational target can be added to the scenario definition without changing the storage model.
+- Reset creates a fresh start timestamp.
+
+### Qualification
+
+- Each scenario definition declares the fields that matter, the supplied answers, and the expected confirmed/inferred/open state.
+- Validation checks only those declared facts.
+- Do not create a generic scoring engine for every possible rubric field.
+- Buyer and seller expectations remain separate.
+
+### Notes
+
+- Deterministic checks confirm that a new non-empty note was saved in the current run.
+- Do not use word count, keyword matching, or AI to claim that prose is good.
+- Show the four-part human standard beside self-review:
+  1. Context/interaction.
+  2. Confirmed facts and decision meaning.
+  3. Agreed action or commitment.
+  4. Owner and timing.
+- The learner explicitly confirms their review; the capstone coach can challenge quality.
+
+### Next contact date
+
+- Validation checks that the NCD was changed in the current run.
+- It must equal the scenario's supplied commitment time or fall within an explicitly declared permitted window.
+- It must obey the product's normal maximum-NCD invariant.
+- The current NCD must replace obsolete retry dates after a connected outcome.
+
+### Pass model
+
+- Each common behaviour is Pass or Fix; do not calculate a percentage score.
+- A pack completes only when all four common behaviours and its scenario-specific checks pass.
+- Completion is stored only in the learner's training session.
+- There is no certificate or LMS progress effect in this release.
+
+---
+
+## 8. Technical Architecture
+
+### Architectural boundary
+
+Do not switch the whole AgentCRM database provider globally. Add a route-scoped `TrainingScenarioService` used only under the Training Centre routes.
+
+```text
+AgentCRM app shell
+├── /app/**                 existing live services → operational tables
+└── /app/training/**        TrainingScenarioService → training_sessions only
+                                                    → no outbound providers
+```
+
+This avoids changing live service resolution and avoids pretending that the existing process-global memory adapter provides learner isolation.
+
+### Supabase storage
+
+Create one table in each AgentCRM installation's existing Supabase project:
+
+`training_sessions`
+
+| Column | Purpose |
+|---|---|
+| `id uuid` | Stable row ID. |
+| `user_id uuid` | Existing authenticated learner; RLS owner. |
+| `scenario_key text` | Buyer, seller, or capstone definition key. |
+| `scenario_version integer` | Version used to create/reset state. |
+| `run_number integer` | Increments on reset. |
+| `status text` | `not_started`, `active`, or `completed`. |
+| `state jsonb` | Synthetic contact, requirement, activities, notes, NCD, mission state, and deterministic results. |
+| `started_at timestamptz` | Server start time for the current run. |
+| `first_contact_attempt_at timestamptz` | Server timestamp for speed evidence. |
+| `completed_at timestamptz` | Current run completion time. |
+| `created_at timestamptz` | Initial row creation. |
+| `updated_at timestamptz` | Last mutation. |
+
+Use a unique constraint on `(user_id, scenario_key)` and reset/update the same row. This prevents an unbounded event archive and removes the need for a cleanup cron in the first release.
+
+### Row-level security
+
+- Enable RLS.
+- Authenticated users may select, insert, and update only rows where `user_id = auth.uid()`.
+- Delete is not required; Reset updates the existing row from the server-owned fixture.
+- No manager-wide read policy.
+- No anonymous policy.
+- Server actions must derive `user_id` from the authenticated session, never from request input.
+
+### Scenario definitions
+
+- Store versioned synthetic fixture definitions in AgentCRM TypeScript, not in Supabase tables.
+- Use synthetic names, domains, phone numbers, properties, and meeting details clearly marked for training.
+- Validate definitions and stored state with explicit schemas.
+- Reset copies the current fixture version into the learner's row and clears timing/completion fields.
+- A definition version change resets or migrates the affected session explicitly; do not silently combine versions.
+
+### UI reuse rule
+
+- Reuse the AgentCRM shell, design tokens, responsive patterns, and presentational controls.
+- Reuse existing qualification, outcome, note, and NCD components only when their data and mutation handlers can be injected safely.
+- If a component directly owns Supabase/server calls, extract the smallest presentational layer needed by both live and training routes.
+- Do not refactor unrelated CRM services into a universal repository pattern.
+- Do not recreate full live pages merely for visual similarity.
+
+### Outbound safety
+
+- Training routes expose simulated outcomes, not dial/send actions.
+- Do not mount live communications controls in Training Mode.
+- Do not call operational API routes and rely on a `training=true` parameter.
+- Add server-side tests proving that scenario actions use only `TrainingScenarioService`.
+- The persistent banner states that no communication is sent.
+
+---
+
+## 9. Supabase Migration and Rollback
+
+### Migration
+
+One idempotent migration must:
+
+1. Create `training_sessions`.
+2. Add the unique constraint and useful owner/status index.
+3. Enable RLS.
+4. Create authenticated owner-only select/insert/update policies.
+5. Add updated-at handling using the project's existing convention where available.
+6. Grant only the minimum authenticated access required.
+
+### Rollback
+
+- Disable the Training Centre feature flag/navigation entry.
+- The operational product remains unaffected because no operational schema or row is changed.
+- The isolated table may be dropped in an explicit rollback migration after confirming that training progress is not needed.
+
+### Deployment order
+
+1. Apply migration to a non-production AgentCRM Supabase project.
+2. Run RLS and isolation tests with two authenticated users.
+3. Deploy code with Training Centre disabled by default.
+4. Enable for approved internal users/installation.
+5. Validate both scenarios and reset.
+6. Enable for all Prime agents after human acceptance.
+
+Do not apply migrations or seed any Supabase project while planning this brief.
+
+---
+
+## 10. Design and Content Requirements
+
+- Training Mode must feel unmistakably like AgentCRM, not like an LMS quiz or a separate branded product.
+- A persistent amber or otherwise clearly distinct training banner must remain visible on desktop and mobile.
+- Synthetic contacts must include `Training` in the visible record label.
+- Mission instructions stay short and action-oriented; do not expose the expected answers before the learner acts.
+- Pass/Fix feedback names the missing result and how to inspect it.
+- Avoid celebratory gamification, points, badges, leaderboards, and decorative animation.
+- The normal AgentCRM shell must not expose Inbox or manager controls within Training Mode.
+- Exiting Training Mode must be obvious and deliberate.
+
+### Visual training outputs
+
+After the UI is stable, capture from the actual embedded Training Mode:
+
+- One short Buyer First Response demonstration.
+- One short Seller Response and Retry demonstration.
+- Approximately eight annotated screenshots covering signal, qualification, outcome, note, NCD, validation, reset, and mobile layout.
+- Captions/transcripts suitable for the related LMS modules.
+
+Do not create a separate animation system. Normal screen recording and static annotation are sufficient.
+
+---
+
+## 11. Non-Functional Requirements
+
+### Safety and privacy
+
+- Synthetic data only.
+- No real names, emails, phone numbers, documents, or client details.
+- No operational-table mutations.
+- No outbound provider calls.
+- RLS isolation is release-blocking.
+
+### Reliability
+
+- Refresh and resume must preserve the active run.
+- Reset must be deterministic.
+- Two simultaneous users must not see or change each other's state.
+- Vercel process restart or scale-out must not lose state.
+
+### Accessibility and responsiveness
+
+- Keyboard-operable controls and visible focus states.
+- Status feedback must not rely on colour alone.
+- Appropriate labels and live-region feedback for validation.
+- Usable at the same supported mobile widths as the core lead workflow.
+
+### Performance
+
+- Starting, saving, checking, and resetting should normally provide visible feedback within two seconds on the target deployment.
+- Keep state bounded to the scenario objects required by this brief.
+
+---
+
+## 12. Validation Plan
+
+### Database and security
+
+- Migration applies and rolls back cleanly in a disposable/non-production project.
+- RLS owner can create/read/update their row.
+- A second authenticated user cannot select or mutate the first user's row.
+- Anonymous access is denied.
+- Request-provided `user_id` cannot override session ownership.
+
+### Service tests
+
+- Start creates the correct versioned state.
+- Resume returns the same state after a new request/process.
+- Reset restores the fixture and increments `run_number`.
+- First contact time is set once per run.
+- Buyer and seller qualification transitions preserve inferred/open facts correctly.
+- Notes and NCD changes are scoped to the current run.
+- Completion passes and fails for every declared condition.
+- No operational repository or outbound adapter is called.
+
+### End-to-end tests
+
+- Buyer pack passes end to end on desktop.
+- Seller no-answer → retry → connected flow passes end to end on desktop.
+- Buyer or seller capstone passes without hints.
+- Reset removes prior answers and timing evidence.
+- Refresh/resume works.
+- Exit returns to normal AgentCRM with no training banner or state leakage.
+- Two-user browser contexts remain isolated.
+- Supported mobile viewport can complete both packs.
+
+### Human acceptance
+
+- A Prime Capital reviewer confirms the buyer and seller qualification expectations.
+- A Prime Capital reviewer confirms that elapsed response time is presented accurately and without an invented SLA.
+- A reviewer confirms the notes/NCD model matches expected agent practice.
+- A reviewer completes both packs without developer assistance.
+- Captured media contains only approved synthetic information.
+
+---
+
+## 13. Delivery Sequence and Estimate
+
+### Phase 1 — Integration audit and final component boundary
+
+**Indicative effort:** 2 days
+
+- Trace the exact live component/service calls for outcome, buyer/seller qualification, notes, and NCD at baseline `58317aa0`.
+- Identify which presentational components accept injected state/actions and which need a small extraction.
+- Confirm the final route/component map before broad edits.
+- Produce a revised estimate if the live components are more tightly coupled than expected.
+
+This is not a memory-mode pilot. It is the first implementation step for the durable Supabase design.
+
+### Phase 2 — Supabase foundation and Training Centre shell
+
+**Indicative effort:** 3–4 days
+
+- Migration, RLS, types, fixture schema, scenario service, start/resume/reset/exit.
+- Feature-gated Training Centre and persistent banner.
+- Isolation and service tests.
+
+### Phase 3 — Shared response loop and Buyer pack
+
+**Indicative effort:** 4–5 days
+
+- Simulated outcome, timing evidence, buyer qualification, note, NCD, deterministic checks.
+- Desktop/mobile completion and end-to-end tests.
+
+### Phase 4 — Seller pack and capstone variant
+
+**Indicative effort:** 4–6 days
+
+- Seller qualification and two-touch outcome state.
+- Capstone fixture variants using the same engine.
+- Full regression, isolation, reset, and mobile tests.
+
+### Phase 5 — LMS links and visual pack
+
+**Indicative effort:** 2–3 days
+
+- Capture two short demonstrations and approximately eight screenshots.
+- Add captions/transcripts and contextual links/media to the existing curriculum.
+- No LMS callback or new assessment infrastructure.
+
+### Total planning range
+
+**15–20 engineering days for one engineer**, subject to the two-day coupling audit. The first release must be stopped or re-scoped if implementing the shared controls requires a broad AgentCRM data-layer refactor.
+
+---
+
+## 14. Risks, Assumptions and Decisions
+
+### Key risks
+
+1. **Live components own their data calls.** Mitigation: extract only the necessary presentational boundary; do not generalise the whole product.
+2. **Training Mode accidentally exposes a live mutation.** Mitigation: separate route/service, no live action controls, integration tests that fail on operational calls.
+3. **The JSON state grows into a second CRM schema.** Mitigation: store only the fields needed by the two packs; reject unrelated feature requests.
+4. **Automatic checks overclaim note quality.** Mitigation: deterministic presence check plus human four-part review.
+5. **Scenario facts drift from the live rubric.** Mitigation: version fixtures and review them when qualification controls change.
+
+### Assumptions
+
+- Each AgentCRM agency continues to use a separate Supabase project/database.
+- The existing authenticated user ID is available to server actions.
+- Prime wants persistent per-agent practice rather than anonymous public demo access.
+- The first release prioritises repeated core operating discipline over breadth of CRM features.
+
+### Human decisions before approval
+
+- **Required:** Confirm the buyer and seller scenario facts and expected qualification states.
+- **Required:** Approve excluding interactive properties, proposals, deals, documents, Inbox, and manager controls from this release.
+- **Required:** Approve one isolated Supabase table and migration in each enabled AgentCRM installation.
+
+---
+
+## 15. Acceptance Checklist
+
+### Architecture and safety
+
+- [ ] Training Mode runs inside the existing AgentCRM deployment.
+- [ ] Only one isolated `training_sessions` table is added.
+- [ ] No training rows enter operational CRM tables.
+- [ ] Owner-only RLS passes two-user and anonymous tests.
+- [ ] No outbound provider or operational action route is reachable.
+- [ ] Normal AgentCRM routes retain their existing database behaviour.
+
+### Learner experience
+
+- [ ] Buyer pack requires speed, qualification, note, and NCD evidence.
+- [ ] Seller pack requires speed, qualification, note, and NCD evidence.
+- [ ] Capstone reuses the same mechanics without new infrastructure.
+- [ ] Start, resume, check, reset, and exit work on desktop and mobile.
+- [ ] Pass/Fix results are deterministic and understandable.
+- [ ] Note quality is not falsely presented as machine-assessed.
+
+### Scope control
+
+- [ ] No generic simulator or scenario-authoring platform was introduced.
+- [ ] No cloned database schema or operational training flags were introduced.
+- [ ] No LMS callback, certificate change, iframe, manager dashboard, Inbox training, or real messaging was introduced.
+- [ ] Properties, proposals, deals, and documents remain visual/guided rather than interactive in this release.
+
+### Training media
+
+- [ ] Two short demonstrations are captured from the finished Training Mode.
+- [ ] Approximately eight approved synthetic screenshots are available.
+- [ ] LMS placement includes captions/transcripts and no real data.
+
+---
+
+## 16. Handoff Notes for the Implementation Agent
+
+1. Work in the AgentCRM repository from baseline commit `58317aa0`; preserve later compatible work and do not reset unrelated changes.
+2. Begin with the live component/service coupling audit. Do not write the generic training framework until the narrowest safe reuse boundary is known.
+3. Implement the table, RLS, scenario service, and Buyer pack as one production-shaped vertical slice. Do not use process memory as an intermediate architecture.
+4. Keep scenario state deliberately incomplete. If a field or object does not support speed, qualification, note, or NCD practice, it probably does not belong in this brief.
+5. Treat outbound isolation and operational-table isolation as release blockers, not polish.
+6. Do not apply or mutate any Supabase project without explicit environment confirmation and migration authority at implementation time.
+7. Keep this brief in `backlog-` until the four required human decisions are approved. Rename it to `active-` only when implementation is authorised.

--- a/catalyst/briefs/backlog-20260715_agentcrm-embedded-training-mode.md
+++ b/catalyst/briefs/backlog-20260715_agentcrm-embedded-training-mode.md
@@ -8,7 +8,7 @@ tags: [agentcrm, training, sandbox, supabase, lms]
 
 # AgentCRM Embedded Training Mode
 
-> **Reference copy — not the source of truth.** This epic is implemented in the **AgentCRM product repo** (`catalyst/briefs/backlog-agentcrm-20260715-epic_embedded-training-mode.md`, on branch `docs/embedded-training-mode-briefs`), where it is decomposed into five sub-briefs and carries the live approval status. Build is underway there as of 2026-07-15. This repo only owns the downstream curriculum links/media — see [backlog-20260715_agentcrm-training-mode-lms-links.md](backlog-20260715_agentcrm-training-mode-lms-links.md). Edit the AgentCRM copy, not this one.
+> **Reference copy — STALE, not the source of truth.** This epic is implemented in the **AgentCRM product repo** (`catalyst/briefs/backlog-agentcrm-20260715-epic_embedded-training-mode.md`). As of 2026-07-15 the source-of-truth version has advanced well past this copy: **all five sub-briefs are in review**, the coupling-audit gate was accepted (six thin presentational seams), scope grew on approval to add **bounded synthetic buyer property selection + proposal draft/preview** (Pack A now 7 checks, Pack B 6), local RLS/isolation verification passed, and the **media pack was delivered** (2 demos + 11 screenshots). Do not treat the body below as current — read the AgentCRM copy. This repo owns only the downstream curriculum links/media — see [backlog-20260715_agentcrm-training-mode-lms-links.md](backlog-20260715_agentcrm-training-mode-lms-links.md).
 >
 > **Catalyst Brief** — Read [AGENTS.md](../../AGENTS.md) and [BRIEFS.md](../../.catalyst/BRIEFS.md) before implementing.
 

--- a/catalyst/briefs/backlog-20260715_agentcrm-training-mode-lms-links.md
+++ b/catalyst/briefs/backlog-20260715_agentcrm-training-mode-lms-links.md
@@ -1,0 +1,87 @@
+<!-- CATALYST - AgentCRM Training Mode curriculum links & media brief -->
+
+---
+title: "AgentCRM Training Mode — curriculum links & media"
+stage: mvp
+tags: [lms, agentcrm, training, media, content]
+---
+
+# AgentCRM Training Mode — Curriculum Links & Media
+
+> **Catalyst Brief** — Read [AGENTS.md](../../AGENTS.md) and [BRIEFS.md](../../.catalyst/BRIEFS.md) before implementing.
+>
+> **LMS-side companion** to the AgentCRM Embedded Training Mode epic, which is implemented in the AgentCRM product repo (`/Users/thg/code/agentcrm`, baseline `58317aa0`). See [backlog-20260715_agentcrm-embedded-training-mode.md](backlog-20260715_agentcrm-embedded-training-mode.md) for the full context. **This is the only piece of that epic that lands in this repo.**
+
+## 1. Summary
+
+Once the embedded Training Mode is stable and its visual pack is captured (AgentCRM sub-brief 5), place the demonstrations, screenshots, captions, and contextual links into the existing AgentCRM Mastery curriculum. This is a content/media placement task only — no LMS callback, no certificate change, no iframe embedding, no new assessment infrastructure.
+
+The curriculum already exists in `_review` (the AgentCRM Mastery competency: `content/lms/10-agentcrm-mastery/` modules, quizzes, and `content/lms/scenarios/agentcrm-workflow-lab.md` / `agentcrm-roleplays.md`). This brief enriches it with real captured media from Training Mode and points learners to the embedded practice experience.
+
+## 2. Scope Definition
+
+### In scope
+
+1. Add the two short demonstrations (Buyer First Response, Seller Response and Retry) and ~8 annotated screenshots into the relevant `10-agentcrm-mastery` modules.
+2. Add captions/transcripts (supplied by the AgentCRM capture brief) alongside the media.
+3. Add contextual links from the workflow labs (`agentcrm-workflow-lab.md`) pointing learners to the embedded Training Mode for hands-on practice.
+4. Validate that all new files parse against the LMS sync schema and cross-references resolve.
+
+### Out of scope
+
+- Any LMS-to-AgentCRM integration: no progress callback, signed launch, iframe, per-click telemetry, or certificate effect (epic §4 out-of-scope).
+- Changes to quizzes, pass thresholds, or certification logic.
+- Producing the media itself (owned by AgentCRM sub-brief 5).
+- Any change to the AgentCRM product repo.
+
+## 3. Dependencies
+
+- **Blocked by** AgentCRM sub-brief `feature_training-mode-visual-capture` delivering approved synthetic assets + captions.
+- Assumes the AgentCRM Mastery curriculum remains in place (currently `_review`).
+
+## 4. Approach
+
+Receive the media pack + captions from the AgentCRM team. Place assets in the LMS media location used by existing modules and reference them from the relevant `10-agentcrm-mastery` module bodies. Add short contextual links from the workflow labs to the embedded Training Mode (buyer, seller, capstone). Keep placement consistent with existing module/scenario markdown patterns. Run local content validation.
+
+## 5. Acceptance Criteria
+
+- [ ] Two demonstrations and ~8 screenshots placed in the relevant AgentCRM Mastery modules with captions/transcripts.
+- [ ] Workflow labs link learners to the embedded Training Mode for buyer, seller, and capstone practice.
+- [ ] All new/changed content parses against the LMS sync schema; cross-references resolve.
+- [ ] No LMS callback, certificate change, iframe, or new assessment infrastructure introduced.
+- [ ] Media contains only approved synthetic data.
+
+## 6. Human Review
+
+- Confirm the captured media matches the labels/feature gates of the Prime Capital production tenant.
+- Confirm the workflow-lab links point to the correct embedded Training Mode entry points.
+
+## 7. Media handoff spec (give to the AgentCRM capture team before sub-brief 5)
+
+Deriving from this repo's existing LMS media conventions so assets drop in without rework:
+
+### Screenshots (~8)
+
+- **Format:** PNG. **Destination path:** `public/images/lms/training/` (embed as `![alt](/images/lms/training/<name>.png)`).
+- **Naming:** kebab-case by state — `signal.png`, `qualification.png`, `outcome.png`, `note.png`, `ncd.png`, `validation.png`, `reset.png`, `mobile.png`.
+- **Alt text:** each asset ships with a one-line descriptive alt string (screen-reader + caption use).
+- **Viewports:** desktop states full-width; at least one capture at the supported mobile lead-workflow width (the `mobile.png` state).
+- **Content rules:** persistent "Training mode — synthetic data" banner visible in-frame; synthetic contacts show the `Training` label; no real names/emails/phones/client data.
+
+### Demonstrations (2 short recordings)
+
+- Buyer First Response and Seller Response-and-Retry, one each.
+- **DECISION (2026-07-15):** capture as **MP4, 1920×1080 landscape, H.264**, delivered as files (not a hosting link). Rationale: the module `videos:` array is empty everywhere and adding a video-embed schema to the LMS sync layer is out of scope for this release; an MP4 in `public/` embedded via a `<video>` tag (or linked) needs no schema change. Keep each demo short (target under ~90s).
+- Each demo ships with a caption/transcript.
+
+## 8. Placement map (asset → destination)
+
+The workflow lab (`content/lms/scenarios/agentcrm-workflow-lab.md`) already uses the same golden-thread records (Training Buyer Maya B., Training Seller Karim S.), so media aligns 1:1:
+
+| Asset | Destination |
+|---|---|
+| Buyer demo + signal/qualification/outcome/note/ncd stills | `10-agentcrm-mastery/10.3` (finding/claiming), `10.4` (first call & qualification), `10.5` (notes & follow-up); buyer LABs in the workflow lab |
+| Seller demo + retry/connected stills | `10.4`/`10.5` seller variants; seller LABs (Karim) in the workflow lab |
+| validation / reset stills | module completion/feedback sections; workflow-lab `Self-check` sections |
+| mobile still | `10.1` (operating model & mobile setup) and LAB-01 |
+| "Practice this in Training Mode" links (buyer / seller / capstone) | workflow-lab LAB sections (after `Safety stop` / in `Model Approach`) — point to the embedded Training Centre entry points |

--- a/catalyst/briefs/backlog-20260715_agentcrm-training-mode-lms-links.md
+++ b/catalyst/briefs/backlog-20260715_agentcrm-training-mode-lms-links.md
@@ -58,30 +58,53 @@ Receive the media pack + captions from the AgentCRM team. Place assets in the LM
 
 ## 7. Media handoff spec (give to the AgentCRM capture team before sub-brief 5)
 
-Deriving from this repo's existing LMS media conventions so assets drop in without rework:
+**DELIVERED 2026-07-15** by the AgentCRM team. Note the scope grew on approval: the buyer flow now includes bounded synthetic property selection + proposal draft/preview, so the pack is **11 screenshots** (adds 06-property, 07-proposal) + **2 MP4 demos**. Delivered dimensions are 1280×900 (desktop) and 390×844 (mobile) — not the 1920×1080 originally specced, which is fine: these embed as-is.
 
-### Screenshots (~8)
+### Destination paths in this repo
 
-- **Format:** PNG. **Destination path:** `public/images/lms/training/` (embed as `![alt](/images/lms/training/<name>.png)`).
-- **Naming:** kebab-case by state — `signal.png`, `qualification.png`, `outcome.png`, `note.png`, `ncd.png`, `validation.png`, `reset.png`, `mobile.png`.
-- **Alt text:** each asset ships with a one-line descriptive alt string (screen-reader + caption use).
-- **Viewports:** desktop states full-width; at least one capture at the supported mobile lead-workflow width (the `mobile.png` state).
-- **Content rules:** persistent "Training mode — synthetic data" banner visible in-frame; synthetic contacts show the `Training` label; no real names/emails/phones/client data.
+- **Screenshots:** `public/images/lms/training/<file>.png` → embed as `![alt](/images/lms/training/<file>.png)`.
+- **Demos:** `public/media/lms/training/<file>.mp4` → embed via a `<video controls>` tag in the module MDX/markdown (no `videos:` frontmatter schema needed).
 
-### Demonstrations (2 short recordings)
+### Delivered assets (final)
 
-- Buyer First Response and Seller Response-and-Retry, one each.
-- **DECISION (2026-07-15):** capture as **MP4, 1920×1080 landscape, H.264**, delivered as files (not a hosting link). Rationale: the module `videos:` array is empty everywhere and adding a video-embed schema to the LMS sync layer is out of scope for this release; an MP4 in `public/` embedded via a `<video>` tag (or linked) needs no schema change. Keep each demo short (target under ~90s).
-- Each demo ships with a caption/transcript.
+| File | Kind | Caption (for embed alt/figure) |
+|---|---|---|
+| `demos/buyer-first-response.mp4` | MP4 1280×900 7.72s silent | Buyer First Response loop: signal → qualification → note → NCD → property selection → proposal preview → validation. |
+| `demos/seller-follow-up.mp4` | MP4 1280×900 7.20s silent | Seller Response & Retry: preserve No-answer + 2h retry, trigger connected follow-up, then qualification → note → NCD → validation. |
+| `01-buyer-signal.png` | 1280×900 | Start from the synthetic signal: read source context and mission before acting. |
+| `02-buyer-outcome.png` | 1280×900 | Record the supplied outcome: Connected is stored as simulated evidence, never calls a provider. |
+| `03-buyer-qualification.png` | 1280×900 | Confirm, correct, and preserve unknowns: imported values are not treated as confirmed facts. |
+| `04-buyer-note.png` | 1280×900 | Four-part note: context, decision meaning, commitment, owner/timing — learner-reviewed, not AI-graded. |
+| `05-buyer-ncd.png` | 1280×900 | Set the exact next commitment: proposal review, next business day 15:00 Dubai. |
+| `06-buyer-property.png` | 1280×900 | Choose from bounded synthetic candidates: comparison never queries the live catalogue. |
+| `07-buyer-proposal.png` | 1280×900 | Review a contained proposal draft: send, share, public view, tracking do not exist. |
+| `08-buyer-validation.png` | 1280×900 | Inspect each required result: 7 deterministic checks report Pass/Fix independently, no percentage. |
+| `09-mobile-training.png` | 390×844 | Same practice loop on mobile: banner, Exit, mission, progress visible without overflow. |
+| `10-seller-retry.png` | 1280×900 | Preserve the seller retry state: No answer + retry NCD exist before the connected follow-up. |
+| `11-reset-state.png` | 1280×900 | Reset starts a clean private run: evidence, answers, note, NCD, property, proposal return to fixture. |
+
+Full SHA-256 checksums are in the handoff manifest (`.context/attachments/.../pasted_text_2026-07-15_16-25-21.txt`) — verify after copying.
 
 ## 8. Placement map (asset → destination)
 
-The workflow lab (`content/lms/scenarios/agentcrm-workflow-lab.md`) already uses the same golden-thread records (Training Buyer Maya B., Training Seller Karim S.), so media aligns 1:1:
+The workflow lab (`content/lms/scenarios/agentcrm-workflow-lab.md`) already uses the same golden-thread records (Maya B., Karim S.), so media aligns 1:1:
 
 | Asset | Destination |
 |---|---|
-| Buyer demo + signal/qualification/outcome/note/ncd stills | `10-agentcrm-mastery/10.3` (finding/claiming), `10.4` (first call & qualification), `10.5` (notes & follow-up); buyer LABs in the workflow lab |
-| Seller demo + retry/connected stills | `10.4`/`10.5` seller variants; seller LABs (Karim) in the workflow lab |
-| validation / reset stills | module completion/feedback sections; workflow-lab `Self-check` sections |
-| mobile still | `10.1` (operating model & mobile setup) and LAB-01 |
-| "Practice this in Training Mode" links (buyer / seller / capstone) | workflow-lab LAB sections (after `Safety stop` / in `Model Approach`) — point to the embedded Training Centre entry points |
+| `buyer-first-response.mp4` + `01`,`02` | `10.3` finding/filtering/claiming; workflow-lab buyer first-response LAB |
+| `03-buyer-qualification` | `10.4` first call & qualification (buyer) |
+| `04-buyer-note`, `05-buyer-ncd` | `10.5` lead details, notes & follow-up |
+| `06-buyer-property`, `07-buyer-proposal` | `10.6` properties, shortlists & proposals (matches the new buyer property/proposal scope) |
+| `08-buyer-validation`, `11-reset-state` | module `Self-check`/completion sections; workflow-lab self-check |
+| `09-mobile-training` | `10.1` operating model & mobile setup; LAB-01 |
+| `seller-follow-up.mp4` + `10-seller-retry` | `10.4`/`10.5` seller variants; workflow-lab seller (Karim) LABs |
+| "Practice in Training Mode" links (buyer / seller / capstone) | workflow-lab LAB sections (after `Safety stop` / in `Model Approach`) → embedded Training Centre entry points |
+
+## 9. Execution status
+
+- [x] Media pack delivered by AgentCRM (2026-07-15): 2 demos + 11 screenshots, captions, transcripts, checksums.
+- [ ] **BLOCKED — need the binary files.** The manifest is in hand but the 13 actual `.mp4`/`.png` files are not in this workspace or any reachable branch. Drop the delivered `demos/` + `screenshots/` directory into the workspace (e.g. `.context/`), or point to its path.
+- [ ] Copy assets to `public/images/lms/training/` and `public/media/lms/training/`; verify SHA-256.
+- [ ] Embed images + `<video>` demos + "Practice in Training Mode" links per §8.
+- [ ] `pnpm test:run` + `pnpm lint` green; visual check that images resolve.
+- [ ] Commit; PR references the AgentCRM epic completion.

--- a/catalyst/project-state.md
+++ b/catalyst/project-state.md
@@ -15,7 +15,7 @@
 
 ## Focus
 
-LMS completion and website launch readiness. Building a real estate advisory platform with RERA certification training for Prime Capital Dubai.
+AgentCRM Competency 10 has been rebuilt around the consultant's practical working day and is awaiting human review. The review should confirm tenant-specific SLA, notification, seller-rubric, and document-practice settings before any LMS sync; Inbox and manager-control training remain excluded.
 
 ## Target
 
@@ -23,7 +23,7 @@ MVP launch — complete LMS with all competencies and polished marketing website
 
 ## Goals
 
-1. Complete RERA certification training LMS with all 9 competencies
+1. Complete and review the LMS curriculum, including all 11 competencies and AgentCRM practical readiness training
 2. Launch marketing website with lead capture
 3. Enable team onboarding through the learning platform
 
@@ -33,4 +33,4 @@ None currently.
 
 ---
 
-*Last updated: 2026-01-18*
+*Last updated: 2026-07-15*

--- a/content/lms/10-agentcrm-mastery/10.1-operating-model-navigation-mobile.md
+++ b/content/lms/10-agentcrm-mastery/10.1-operating-model-navigation-mobile.md
@@ -1,0 +1,149 @@
+---
+title: "AgentCRM Operating Model, Navigation & Mobile"
+slug: "operating-model-navigation-mobile"
+moduleNumber: "10.1"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Use AgentCRM as the shared memory and next-action system for a client relationship across desktop and mobile."
+estimatedDuration: "35 minutes"
+order: 1
+status: published
+quiz: "agentcrm-mastery-1"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "workflow-coach"
+  coachingPoints:
+    - "The contact is the person; opportunities and transactions sit around that relationship"
+    - "A reliable record explains what happened and what should happen next"
+    - "Desktop and mobile expose the same relationship through different layouts"
+    - "A deal begins only after commitment to a named property"
+---
+
+<!-- CATALYST - AgentCRM operating model, navigation, and mobile training -->
+
+# AgentCRM Operating Model, Navigation & Mobile
+
+## Your outcome
+
+After this module, you can trace one client relationship from contact to requirement, property/proposal, deal, activity, and next action on desktop and mobile without editing live data.
+
+## Core mindset
+
+> AgentCRM is the team's shared memory and next-action system, not a personal address book or an administrative report.
+
+The record succeeds when the next authorised colleague can understand the person, the current opportunity, the evidence, and the next obligation.
+
+## Why this matters
+
+Client service slows down when information is split across duplicate contacts, private notes, and memory. A connected record prevents repeat questions, duplicate outreach, premature deals, and missed promises.
+
+## The relationship model
+
+| Record | What it means | Agent question |
+|---|---|---|
+| **Contact** | The person and the history of the relationship | Who is this, how may we contact them, and what context is shared? |
+| **Enquiry/lead** | The event or opportunity that brought the person to the team | Why are they here now? |
+| **Requirement** | A buyer or seller objective | What are they trying to buy or sell? |
+| **Property/match** | Inventory assessed against a requirement | Does this property fit, and what still needs checking? |
+| **Proposal** | A curated client-facing decision set | Why should these options be compared? |
+| **Deal** | Committed transaction work on a named property | Has the client explicitly instructed us to progress? |
+| **Activity/note/task** | What happened, the meaning captured, and work to do | What changed, and what work is due? |
+| **Next contact date** | The next planned client follow-up | When must this relationship return to attention? |
+
+One person can have several requirements and deals over time. A new goal does not automatically require a new contact. A lost deal does not delete the relationship.
+
+## Core agent navigation
+
+- **Today:** due work and leads that meet the current candidate rules.
+- **Notifications:** in-app alerts and deep links generated for enabled event types.
+- **Leads:** assigned work, searchable records, filters, and eligible Pool leads.
+- **Lead detail:** identity, requirement/qualification, activity, notes, next contact, properties, proposals, deals, and documents.
+- **Properties:** inventory search and property details.
+- **Proposals:** draft and sent recommendation sets.
+- **Deals:** committed work, stages, properties, dates, outcomes, and transaction documents.
+
+Your role and agency configuration determine what appears. Missing controls are not permission to use a personal workaround.
+
+## Desktop and mobile
+
+Desktop gives more space for filters, side-by-side context, and detailed editing. The mobile lead view uses compact tabs and sheets. At the verified product baseline, mobile can expose Profile, Activity, qualification, Properties, Proposals, Deals, call/note/next-date actions, and contact documents.
+
+### Mobile installation
+
+Depending on device and configuration, AgentCRM may offer a native app path or a progressive web app (PWA) prompt.
+
+- Android may offer **Install App** or browser **Add to Home Screen**.
+- iOS may show **Share → Add to Home Screen** guidance.
+- Browser notification permission is separate from installing the app.
+- A native or PWA icon does not guarantee every notification type is enabled.
+
+Use the supported path shown by AgentCRM or your agency. Never install an unofficial copy.
+
+## Worked example: Training Buyer Maya B.
+
+Maya first enquired about a two-bedroom investment. Her contact holds identity and communication history. Her buyer requirement holds confirmed budget, location, timing, and decision context. Three reviewed properties become a draft proposal. Only after Maya says, “Proceed with Unit T-1204,” does a deal belong on the record. The next contact date makes the agreed transaction call visible.
+
+The story remains connected because each object has one job.
+
+## Tempting wrong action
+
+Maya later considers a studio for a family member. Creating a second contact feels tidy, but it fragments her history. Keep one contact and create a separate requirement when the goals are genuinely different.
+
+## Agent Tool: AgentCRM relationship map
+
+Use this one-line check:
+
+> **Person → objective → evidence → option → decision → transaction → next relationship action**
+
+Before saving, ask:
+
+- Am I on the correct person?
+- Am I updating the correct buyer or seller requirement?
+- Is this still an option, or has the client committed?
+- What evidence belongs in the activity/note?
+- What should happen next, and when?
+
+## Agent Tool: mobile quick-start checklist
+
+- [ ] Open the official AgentCRM mobile/PWA experience.
+- [ ] Confirm Profile, Activity, qualification, Properties, Proposals, and Deals are reachable on the practice record.
+- [ ] Find call, note, and next contact date actions.
+- [ ] Open the notification bell and recognise unread state/deep links if enabled.
+- [ ] Confirm browser notification permission separately.
+- [ ] Identify which controls are read-only or configuration-dependent.
+- [ ] Use only the designated practice record.
+
+## Hands-on task: LAB-01 relationship trace
+
+Open Training Buyer Maya B. on desktop and mobile.
+
+1. Locate the contact identity and enquiry source.
+2. Locate the active buyer requirement and qualification state.
+3. Locate linked properties/proposals and any deals.
+4. Locate the latest activity/note and next contact date.
+5. Trace the relationship aloud using the map above.
+6. Do not edit the record.
+
+### Success criteria
+
+- You can reach each relationship area on both layouts without relying on a screen coordinate.
+- You explain the difference between a requirement, proposal, and deal.
+- You identify the current next action and where its evidence belongs.
+- No live or training data is changed.
+
+## Common mistakes and recovery
+
+- **Duplicate contact for a new goal:** stop, search by phone/email, and attach a separate requirement to the existing person.
+- **Deal created at enquiry or proposal:** remove the premature training deal if authorised and return the work to the requirement/proposal stage.
+- **Mobile control appears missing:** check the tabs, action sheet, role, and agency configuration; use desktop for an edit that is genuinely unavailable.
+- **Notification permission confused with notification settings:** check both the browser/device permission and AgentCRM preferences.
+- **Live record opened for practice:** close it without editing and return to the named training alias.
+
+## Before moving on
+
+You should be able to say:
+
+> “AgentCRM keeps one connected client relationship. Requirements describe goals, proposals support decisions, deals track explicit commitments, and every activity should improve the next action.”

--- a/content/lms/10-agentcrm-mastery/10.2-today-notifications-speed.md
+++ b/content/lms/10-agentcrm-mastery/10.2-today-notifications-speed.md
@@ -1,0 +1,177 @@
+---
+title: "Today, Notifications & Speed to Contact"
+slug: "today-notifications-speed"
+moduleNumber: "10.2"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Use Today and enabled notifications accurately, prioritise client signals, and complete a fast response loop with a truthful next state."
+estimatedDuration: "45 minutes"
+order: 2
+status: published
+quiz: "agentcrm-mastery-2"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "performance-coach"
+  coachingPoints:
+    - "Speed matters after context is read"
+    - "Today and notifications are separate surfaces with separate rules"
+    - "A future next contact date currently hides a lead from Today before signal enrichment"
+    - "A queue control is not a substitute for a real outcome"
+---
+
+<!-- CATALYST - AgentCRM Today, notifications, and speed training -->
+
+# Today, Notifications & Speed to Contact
+
+## Your outcome
+
+After this module, you can choose the first three actions from Today and enabled notifications, respond to one timed client signal, and leave the correct outcome and next contact date.
+
+## Core mindset
+
+> Speed creates opportunity. Act quickly while still reading the context.
+
+Today and notifications reduce delay. Neither surface replaces the client record, and an empty queue is not the objective. The objective is a timely, useful human response with a truthful next action.
+
+## Why this matters
+
+The first useful response often decides whether Prime Capital joins the client's decision process. Speed without context creates generic outreach. Context without speed leaves the client waiting.
+
+## What appears on Today at the pinned baseline
+
+For active leads, the learner-visible Today loader first builds a candidate set. A lead appears when at least one of these is true:
+
+- No next contact date is set.
+- The next contact date is due today or overdue.
+- An overdue task exists.
+- The lead is New and has not yet been triaged with a future next contact date.
+
+Special states:
+
+- **Do not contact:** never appears on Today.
+- **Nurture:** appears only when its next contact date is due/overdue or an overdue task exists.
+- **Future next contact date:** hides the lead from Today.
+
+### Important product limitation
+
+Today removes future-dated leads **before** it loads unread-message, engagement, and proposal-view context. The signal engine is capable of ranking those events, but it cannot rank a contact already removed from the candidate set.
+
+Therefore:
+
+> Do not assume a new reply or proposal view will return a future-dated lead to Today at this baseline.
+
+This course does not invent a workaround. Use the separate notification surface and the agreed lead-review routine your agency enables, and record the limitation for product revalidation.
+
+## Notifications are a separate surface
+
+The notification bell/sheet can show unread in-app notifications, group them by time, and deep-link to a relevant record when the event supplies a link. Event types include items such as lead assignment, message received, lead engagement, follow-up due, and deal updates.
+
+Delivery varies:
+
+- In-app availability depends on the event being generated for you.
+- Browser push depends on AgentCRM preferences **and** browser/device permission.
+- Email, WhatsApp, digest, and per-type settings are configuration-dependent.
+- The **Action Required** strip on Today is deliberately restricted; it is not a second lead queue.
+
+When a notification arrives:
+
+1. Open the deep-linked record.
+2. Confirm the contact, ownership, recent activity, and local time.
+3. Decide whether the alert still requires action.
+4. Act through an approved channel.
+5. Save the real outcome and next action.
+6. Confirm the resulting record rather than assuming the notification completed it.
+
+## Priority order
+
+When several eligible items compete, use this guide:
+
+1. Consent, complaint, or transaction risk.
+2. A person actively waiting through an enabled notification.
+3. A fresh assigned/new enquiry requiring first contact.
+4. An overdue promise or task.
+5. Time-sensitive property/proposal engagement that is actually visible.
+6. Missing next-action repair.
+7. Qualified work ready for matching/progression.
+
+Local time, contact preference, recent colleague activity, and restrictions can change the order.
+
+## What queue controls persist
+
+- **Defer** writes a next contact date. A future date removes the lead from Today; a date later today keeps it in today's horizon.
+- **Skip** moves the card to the bottom of the current desktop queue. It does not resolve the client need or change the record.
+- **Done on desktop** hides the card for the current session and increments a locally stored daily count. It does not by itself create a call outcome, note, stage change, or next date.
+- **Done on the verified mobile Today view** calls the product's mark-contacted action. Use it only when the contact state is true and still confirm the result.
+
+The safest rule is simple: complete the real action and record state first; use a queue control second.
+
+## Worked example: Maya's assignment notification
+
+At 09:04, Maya is assigned to the consultant and an enabled in-app notification deep-links to her lead. The consultant checks the portal enquiry, sees no previous contact, confirms ownership and Dubai local time, calls at 09:08, records **No answer**, adds a concise note, and sets the approved retry time.
+
+Speed is measured by useful action, not by opening or clearing a card.
+
+## Tempting wrong action
+
+Maya has a future call scheduled for Friday and views a proposal on Wednesday. It is tempting to say, “Today will bring her back.” At this baseline, the future next contact date prevents her reaching Today enrichment. Check an enabled notification and the relevant lead record; do not teach the unsupported breakthrough claim.
+
+## Agent Tool: Today priority guide
+
+For each item, read:
+
+- **Surface:** Today or notification?
+- **Signal:** What happened?
+- **Reason:** Why might it matter now?
+- **Record:** Is it still current and correctly owned?
+- **Action:** What useful human response is due?
+- **Result:** What must the record show afterwards?
+
+## Agent Tool: speed-to-contact checklist
+
+- [ ] Open the enquiry/alert immediately when able to respond properly.
+- [ ] Confirm person, source, property/message context, ownership, and local time.
+- [ ] Check recent activity to avoid duplicate outreach.
+- [ ] Make the first useful call or approved response.
+- [ ] Record the exact outcome, not merely “attempted”.
+- [ ] Save confirmed facts and a concise note.
+- [ ] Set a justified next contact date or correct terminal/parked state.
+- [ ] Confirm ownership and resulting visibility.
+
+Prime Capital's numeric response SLA and attempt timing must be supplied by the business. Do not invent them.
+
+## Hands-on task: LAB-02 speed sprint
+
+Use the timed training set containing Maya, Karim, an overdue follow-up, and one enabled notification.
+
+1. Identify whether each item came from Today or notifications.
+2. Rank the first three actions and state why.
+3. Open the notification and verify the linked record.
+4. Complete one simulated response loop on the designated practice record.
+5. Save the actual outcome and justified next contact date.
+6. Confirm whether the record remains on Today, moves to a future horizon, or is visible only through its record/notification path.
+
+### Success criteria
+
+- The first three actions reflect waiting clients, fresh work, promises, and risk.
+- You explain the future-NCD Today limitation correctly.
+- The response uses enquiry context and the exact call outcome.
+- The next contact date agrees with the note and client commitment.
+- No external communication is sent.
+
+## Common mistakes and recovery
+
+- **Assuming Today is complete:** check enabled notifications and the relevant lead-review routine; document any hidden-signal risk.
+- **Opening a notification and treating it as resolved:** verify the record, act, save, then mark/read as appropriate.
+- **Desktop Done used as evidence:** reopen the record and log the actual outcome and next step.
+- **Skip used to avoid work:** return to the card; act or set an honest future plan.
+- **Arbitrary future date:** correct it to the agreed or operationally justified time and explain the action in the note.
+- **Notification missing on mobile:** check AgentCRM preferences, browser/device permission, installation mode, and tenant event support.
+
+## Before moving on
+
+You should be able to say:
+
+> “Today shows records that pass its candidate rules. Notifications are separate and configuration-dependent. I verify the record, respond quickly, and leave a truthful next state.”

--- a/content/lms/10-agentcrm-mastery/10.3-finding-filtering-claiming.md
+++ b/content/lms/10-agentcrm-mastery/10.3-finding-filtering-claiming.md
@@ -1,0 +1,183 @@
+---
+title: "Finding, Filtering & Claiming Leads"
+slug: "finding-filtering-claiming"
+moduleNumber: "10.3"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Find the right buyer or seller, assess context and capacity, and claim eligible Pool work without creating ownership conflicts."
+estimatedDuration: "45 minutes"
+order: 3
+status: published
+quiz: "agentcrm-mastery-3"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "sales-operations-coach"
+  coachingPoints:
+    - "Find the right opportunity before taking responsibility"
+    - "Opening and dialling an unowned Pool lead do not claim it"
+    - "Connected outcomes can establish ownership; non-contact outcomes do not"
+    - "A claim conflict protects the client from duplicate outreach"
+---
+
+<!-- CATALYST - AgentCRM lead finding, filtering, and claiming training -->
+
+# Finding, Filtering & Claiming Leads
+
+## Your outcome
+
+After this module, you can find one known buyer and one seller, build useful lead filters, evaluate an eligible Pool lead, handle a controlled claim conflict, and confirm the final owner.
+
+## Core mindset
+
+> Find the right opportunity, understand its context, then take responsibility. Claiming is a service commitment, not a way to accumulate leads.
+
+## Why this matters
+
+A fast call to the wrong, duplicate, restricted, or already-owned record creates client frustration. A correct claim with no capacity creates delay. Good lead work begins with selection and ownership evidence.
+
+## Find a known lead
+
+Start broad, then narrow:
+
+1. Search by name, phone, email, or known context.
+2. Check likely duplicates before creating anything.
+3. Confirm buyer/seller requirement, source, stage/state, owner, last activity, and next contact date.
+4. Remove filters if a known record seems missing.
+5. Confirm whether you are looking at your assigned book or the shared Pool.
+
+At the pinned baseline, Leads/Pool can support combinations such as:
+
+- Stage and qualification state.
+- Source and tag/event.
+- Temperature or priority.
+- Lead age and activity/last-contact windows.
+- Budget, city/country, property type, and timeline.
+- Nurture/active and won/lost visibility.
+- Owner or last assigned agent where role and surface permit.
+
+Available labels can vary. Build the recipe from the business question, not from every filter on screen.
+
+## Assigned versus Pool
+
+### Assigned lead
+
+An assigned lead already has a responsible owner. If that is not you, do not contact, claim, or work around ownership without an authorised handover.
+
+### Pool lead
+
+The Pool contains eligible unassigned work. Product priority tiers influence its default order. Before taking responsibility, check:
+
+- Source/enquiry and time received.
+- Buyer or seller goal.
+- Phone/email validity.
+- Recent activity and previous owner.
+- Duplicate risk.
+- Do-not-contact or other restrictions.
+- Language, market fit, local time, and your capacity.
+
+## Locks, calls, and claims
+
+The verified Pool behaviour is precise:
+
+- Expanding a Pool row applies a **five-minute soft lock** so another agent does not work the same record during review.
+- Starting a call on an unowned Pool lead writes an initiated call attempt and applies a short hold. **Dialling does not claim.**
+- On the single-contact flow, saving **Spoke**, **Appointment set**, or **Callback requested** is a claiming outcome and can transfer ownership.
+- **No answer**, **Voicemail**, **Wrong number**, **Not interested**, or an attempt without connection do not claim the Pool lead.
+- A visible manual Claim action can transfer ownership when the lead remains eligible.
+- If another agent wins the race, stop. Do not create a duplicate or continue outreach.
+
+After every claim path, refresh or reopen and confirm the owner shown on the record.
+
+## Wrong number is not do-not-contact
+
+- **Wrong number:** the dialled phone does not belong to the intended contact. The product flags that phone invalid and releases the record. It does not prove that the intended person withdrew consent on every valid channel.
+- **Do not contact:** the intended person withdraws consent or must not be contacted. Stop outreach according to the contact restriction.
+
+Do not suppress the intended contact because a third party answered an invalid number, and do not redial the invalid number.
+
+## Buyer and seller filter recipes
+
+### Fresh buyer follow-up
+
+Use a combination such as buyer/property type, source or recency, New/uncontacted state, and an appropriate location/budget only when those facts exist.
+
+### Seller opportunity
+
+Search seller requirements or seller-related source/tag, then narrow by property location/type, stage, activity, or next-contact state where supported.
+
+### Due work
+
+Use owner plus overdue/missing next-contact or activity windows rather than guessing from lead age alone.
+
+Filters find candidates. The record determines whether to act.
+
+## Worked example: Maya and Karim
+
+Maya appears in Pool after a portal enquiry. The consultant filters recent buyer enquiries, opens Maya, sees the five-minute lock, checks the property reference and duplicate risk, and calls. **No answer** is saved, so Maya remains unowned; the consultant does not pretend to own her.
+
+Karim is found through a seller requirement and Dubai Marina filter. He is already assigned. The consultant does not claim or call; they return to eligible work.
+
+## Tempting wrong action
+
+Another trainee saves **Appointment set** on Maya seconds before you. Creating “Maya copy” preserves your effort but breaks the relationship and invites duplicate contact. Accept the conflict, stop, and choose another eligible lead.
+
+## Agent Tool: lead filter recipe card
+
+Build filters in four steps:
+
+1. **Work question:** new buyer, seller, due follow-up, missing qualification, proposal follow-up?
+2. **Scope:** my assigned leads or eligible Pool?
+3. **Two or three filters:** stage/state + intent/source + time/context.
+4. **Record check:** owner, source/history, duplicate, restriction, capacity.
+
+If a known lead disappears, clear filters before assuming the record is missing.
+
+## Agent Tool: Pool claim checklist
+
+- [ ] Lead is unassigned and eligible now.
+- [ ] No duplicate person or recent colleague action exists.
+- [ ] Source, history, buyer/seller intent, and local time are understood.
+- [ ] No contact restriction blocks the action.
+- [ ] I have capacity and relevant fit to respond.
+- [ ] I know whether I am using manual Claim or claim-on-outcome.
+- [ ] I understand dialling is only a soft hold.
+- [ ] I will stop if the lock/claim reports a conflict.
+- [ ] I will confirm the final owner after saving.
+
+## Hands-on task: LAB-03 find, filter, and claim
+
+Using the controlled practice set:
+
+1. Find Training Buyer Maya B. by search and one buyer filter recipe.
+2. Find Training Seller Karim S. with a seller filter recipe.
+3. Explain why Karim must not be claimed in his starting state.
+4. Open Maya's Pool row and identify the soft lock.
+5. Apply the assigned simulated outcome.
+6. If the exercise creates a claim conflict, stop and explain the correct response.
+7. Confirm Maya's final owner, phone-valid state, and next action.
+
+### Success criteria
+
+- Both records are found without creating duplicates.
+- Filters reflect a work question rather than arbitrary narrowing.
+- Claim-on-outcome is applied correctly.
+- A non-contact outcome does not silently become ownership.
+- The final owner and restriction/phone state are confirmed.
+
+## Common mistakes and recovery
+
+- **Too many filters hide the lead:** clear all, search broadly, then add one filter at a time.
+- **Dial assumed to claim:** check the saved outcome and owner; do not begin a sustained sequence until ownership is confirmed.
+- **No answer marked Spoke to gain ownership:** correct the outcome immediately and escalate the data-integrity error.
+- **Claim conflict bypassed:** stop outreach, do not duplicate, and ask for review only if there is a genuine ownership issue.
+- **Wrong number treated as intended-contact opt-out:** keep the invalid phone blocked while preserving any legitimate contact route and consent state.
+- **Claim without capacity:** release or hand over through the approved process before delay harms the client.
+
+## Before moving on
+
+You should be able to say:
+
+> “I use filters to find likely work, the record to decide, and the product's claim result to confirm responsibility.”

--- a/content/lms/10-agentcrm-mastery/10.4-first-call-qualification.md
+++ b/content/lms/10-agentcrm-mastery/10.4-first-call-qualification.md
@@ -1,0 +1,211 @@
+---
+title: "First Phone Call & Qualification Mastery"
+slug: "first-call-qualification"
+moduleNumber: "10.4"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Prepare and run buyer and seller first calls that create relevance, reliable qualification, and a specific next commitment."
+estimatedDuration: "60 minutes"
+order: 4
+status: published
+quiz: "agentcrm-mastery-4"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "qualification-coach"
+  coachingPoints:
+    - "The first call creates direction and a next commitment, not a completed form"
+    - "Confirm source data before treating it as client fact"
+    - "Buyer and seller requirements have different qualification paths"
+    - "Save the outcome, facts, note, stage, and next contact immediately"
+---
+
+<!-- CATALYST - AgentCRM first-call and qualification training -->
+
+# First Phone Call & Qualification Mastery
+
+## Your outcome
+
+After this module, you can prepare and run separate buyer and seller first calls, capture enough confirmed truth to guide the next action, and save both records correctly.
+
+## Core mindset
+
+> The first call is the highest-leverage moment. Create relevance, establish direction, and secure the next meaningful commitment—usually a meeting or defined follow-up.
+
+Qualification is not an interrogation and not a race to turn every field green.
+
+## Why this matters
+
+A good first call turns a vague enquiry into a useful client direction. A good save turns that conversation into shared context. If either half fails, the next consultant repeats questions or gives poor advice.
+
+## The first-call workflow
+
+### 1. Prepare
+
+Read the source, named property, message, local time, owner, recent activity, existing requirements, and any previous relationship.
+
+### 2. Open with relevance
+
+Reference the specific enquiry or relationship. Avoid a generic company pitch.
+
+### 3. Establish the objective
+
+Ask what the client is trying to achieve and why now.
+
+### 4. Build the minimum useful frame
+
+Confirm the commercial facts needed for the next step. Follow the conversation; do not read the rubric as a questionnaire.
+
+### 5. Separate evidence
+
+- **Confirmed:** the client said or corrected it.
+- **Inferred:** source/AI/history suggests it; still needs confirmation.
+- **Unknown:** not discussed.
+
+### 6. Summarise
+
+Reflect the objective, constraints, and open points. Invite correction.
+
+### 7. Secure the next commitment
+
+Book a meeting, promise a defined piece of research, or agree a specific follow-up.
+
+### 8. Save immediately
+
+Record outcome, requirement/qualification, concise note, evidence-based stage, and next contact date.
+
+## Buyer qualification path
+
+Prime Capital's default buyer essentials at the baseline are:
+
+- Budget.
+- Investment timeline.
+- Property type.
+- Purchase purpose.
+- Funding source.
+- Bedrooms.
+- Locations.
+- Ready/off-plan preference.
+- Motivation trigger.
+- Decision stage.
+- Decision maker.
+
+Useful optional context includes Dubai relationship, buying experience, mortgage/pre-approval, owned property, funds location, payment method, and liquidity. The visible tenant rubric and threshold remain authoritative.
+
+Do not force all dimensions into one short call. Capture what changes the next useful step and leave unknowns honest.
+
+## Seller qualification path
+
+Prime Capital's default seller essentials are:
+
+- Property/building and location.
+- Property type and bedrooms.
+- Target price.
+- Seller timeline.
+- Motivation.
+- Post-sale plan.
+- Price flexibility.
+- Listing exclusivity/context.
+
+The baseline also supports occupancy/status, furnishing, size, views, ownership status, and decision authority, but these are optional by default. They may still be operationally important. Confirm co-owner or power-of-attorney context before implying authority to list or transact.
+
+Tenant configuration can change what is active or essential. Use the visible seller rubric and mark only evidence actually confirmed.
+
+## Worked example: Maya's buyer call
+
+The portal suggests AED 2–3M. Maya confirms a comfortable maximum of AED 2.4M, cash funding, a ready two-bedroom in Business Bay or Downtown, investment with occasional personal use, a one-to-three-month timeline, and a joint decision with her partner. She agrees to a 30-minute review meeting on Thursday at 11:00 Dubai time.
+
+The portal range remains source context; the confirmed maximum becomes the qualification truth.
+
+### Seller contrast: Karim's call
+
+Karim confirms a tenanted two-bedroom apartment in Dubai Marina, a target of AED 2.7M, a one-to-three-month selling window, joint ownership, an investment-rebalancing motivation, and openness to sensible offers. He has not agreed exclusivity and wants a valuation/action-plan meeting Tuesday.
+
+Do not mark exclusivity confirmed or imply that Karim can act alone. The next commitment is the meeting.
+
+## Tempting wrong action
+
+Maya's call went well, but decision maker and funding were not discussed. Marking both confirmed makes the qualification bar look complete and damages every later match and handover. Leave them unknown and make the next conversation purposeful.
+
+## Agent Tool: first-call preparation card
+
+- Source/enquiry/property:
+- Ownership and duplicate check:
+- Local time/preferred route:
+- Last meaningful interaction:
+- Existing buyer/seller requirement:
+- Facts inferred but unconfirmed:
+- Three questions that change the next action:
+- Best realistic next commitment:
+
+## Agent Tool: buyer qualification card
+
+Capture confirmed evidence for:
+
+1. Purpose and motivation.
+2. Budget and any stretch.
+3. Location, type, bedrooms.
+4. Ready/off-plan preference.
+5. Timing.
+6. Funding/payment readiness.
+7. Decision stage and decision makers.
+8. Meeting, deliverable, or follow-up.
+
+## Agent Tool: seller qualification card
+
+Capture confirmed evidence for:
+
+1. Property/building, location, type, bedrooms.
+2. Target price and flexibility.
+3. Timeline and occupancy/status.
+4. Ownership/authority.
+5. Motivation and post-sale plan.
+6. Listing/exclusivity context.
+7. Missing facts that require verification.
+8. Meeting, valuation/action plan, or follow-up.
+
+## Agent Tool: post-call save checklist
+
+- [ ] Exact call outcome.
+- [ ] Correct buyer or seller requirement.
+- [ ] Confirmed facts marked confirmed; inference left inferred.
+- [ ] Meaningful context and concerns in the note.
+- [ ] Stage matches evidence.
+- [ ] Next action names what, who, and when.
+- [ ] Next contact date matches the agreement.
+- [ ] Owner and visible record state confirmed.
+
+## Hands-on task: LAB-04 buyer first call and CRM save
+
+1. Prepare for Maya using her enquiry and existing record.
+2. Complete CRM-01 Buyer First Contact and Meeting Booking.
+3. Summarise Maya's objective and gain a specific meeting or follow-up.
+4. Save the exact outcome, active buyer requirement, confirmed qualification, note, stage, and next contact date.
+5. Compare the saved state with the post-call checklist.
+
+Then use CRM-02 Seller First Contact and Qualification to practise Karim's different path before Module 10.5's full seller save.
+
+### Success criteria
+
+- The opening uses specific enquiry context.
+- Buyer and seller questions follow their different goals.
+- No inferred or unknown fact becomes confirmed.
+- Each conversation ends with a useful commitment.
+- The saved buyer record contains outcome, qualification, note, truthful stage, and matching next contact date.
+
+## Common mistakes and recovery
+
+- **Rubric read as a script:** return to the client's objective, ask one open question, and capture dimensions as they emerge.
+- **Source data treated as confirmed:** change it to inferred/unknown until the client validates it.
+- **Buyer fields used for a seller:** open or update the seller requirement and use the seller-side rubric.
+- **Great conversation, weak save:** complete the post-call checklist before starting the next lead.
+- **Stage advanced because the call felt positive:** restore the stage supported by observable evidence.
+- **Vague next step (“send options”):** agree the deliverable, owner, date, and review point.
+
+## Before moving on
+
+You should be able to say:
+
+> “My first call creates direction and a specific next commitment. My save separates confirmed truth from inference and makes that commitment visible.”

--- a/content/lms/10-agentcrm-mastery/10.5-lead-details-notes-follow-up.md
+++ b/content/lms/10-agentcrm-mastery/10.5-lead-details-notes-follow-up.md
@@ -1,0 +1,196 @@
+---
+title: "Lead Details, Notes, Next Contact Date & Touchpoints"
+slug: "lead-details-notes-follow-up"
+moduleNumber: "10.5"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Make every interaction improve the lead record, the next action, and the minimum communication-touchpoint sequence."
+estimatedDuration: "45 minutes"
+order: 5
+status: published
+quiz: "agentcrm-mastery-5"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "record-discipline-coach"
+  coachingPoints:
+    - "Notes should make the next action easier, not retell the day"
+    - "A next contact date represents a justified client follow-up"
+    - "Every touch needs an exact outcome and a decision about what happens next"
+    - "Active, nurture, lost, wrong-number, and do-not-contact states solve different problems"
+---
+
+<!-- CATALYST - AgentCRM lead details, notes, NCD, and touchpoint training -->
+
+# Lead Details, Notes, Next Contact Date & Touchpoints
+
+## Your outcome
+
+After this module, you can read the agent-relevant lead details, correct a weak note/next contact date, and complete a multi-touch seller follow-up record.
+
+## Core mindset
+
+> Every interaction should make the record more useful to the next action and the next authorised colleague. Notes are not a diary; the next contact date is not a snooze button.
+
+## Why this matters
+
+A vague note forces the next consultant to guess. A distant or unjustified next contact date hides work. A good record reduces repeat questions and makes promises visible.
+
+## Read the lead in this order
+
+Desktop and mobile group controls differently. Use the same reading sequence:
+
+1. **Identity and channels:** correct person, valid details, restrictions.
+2. **Source and enquiry:** why the person arrived.
+3. **Ownership and current state:** who is responsible, active/nurture/lost/DNC.
+4. **Buyer/seller requirements:** the correct current objective.
+5. **Qualification:** missing, inferred, and confirmed evidence.
+6. **Recent activity and outcomes:** what actually happened.
+7. **Notes:** intent, concerns, decisions, and commitments.
+8. **Tasks and next contact date:** visible future obligation.
+9. **Properties, proposals, and deals:** what has been considered or committed.
+10. **Documents:** what is present and where it belongs.
+
+On mobile, the verified lead view uses compact Profile, Activity, qualification, Properties, Proposals, and Deals areas plus quick-action sheets. Save while the context is fresh, then confirm the visible result.
+
+## Structured fields versus notes
+
+Use structured requirement/qualification fields for facts the system must filter, match, or assess. Use a note for meaning that changes judgement.
+
+### Useful note standard
+
+Write four short parts:
+
+- **What happened:** exact outcome and channel/meeting.
+- **What changed:** facts the client confirmed or corrected.
+- **Current decision:** intent, concern, trade-off, or status.
+- **What happens next:** action, owner, and time.
+
+Example:
+
+> Connected by phone. Karim confirmed the Marina apartment is tenanted until November and jointly owned. He wants a sale within one to three months to rebalance into two smaller units; AED 2.7M target, open to evidence-led offers. Valuation/action-plan meeting Tuesday 10:00 Dubai time; I will prepare comparable evidence beforehand.
+
+Do not write “good call”, paste a transcript, or hide confirmed criteria only in prose.
+
+## Next contact date (NCD)
+
+The next contact date is the next planned client interaction. It should match the note and any client-facing promise.
+
+Use it when:
+
+- The client agreed a call, meeting, or review.
+- A no-answer outcome requires the next approved attempt.
+- You promised to return after a verification or deliverable.
+- A legitimate nurture relationship has a justified future review.
+
+Do not use it when:
+
+- The intended person has requested no contact.
+- The phone is invalid and no valid attempt is planned on that number.
+- The opportunity is dead and there is no consented future relationship.
+- You only want the record to disappear from Today.
+
+Tasks and next contact dates are related, not interchangeable. A research task can be due before the next client call.
+
+## Minimum communication-touchpoint sequence
+
+Until Prime Capital publishes a numeric response SLA and attempt timing, use this sequence rather than inventing numbers:
+
+1. Make the first call as soon as the lead is eligible and you can respond properly.
+2. If unanswered, record the exact outcome and use an approved follow-up message where enabled.
+3. Set a justified next contact date for the next attempt.
+4. Make the planned attempt from Today or the relevant enabled notification when it becomes due.
+5. Add a value-led follow-up tied to the enquiry, meeting, property, proposal, or seller action plan.
+6. Decide explicitly whether the opportunity stays active, moves to consented nurture, or becomes lost.
+
+Every attempt needs a truthful outcome. Attempt count alone does not prove client service.
+
+## Buyer and seller differences
+
+- **Buyer:** the note should preserve the decision frame, property trade-offs, outstanding checks, meeting/proposal promise, and who decides.
+- **Seller:** the note should preserve property/occupancy facts, authority, motivation, target/flexibility, listing context, agreed valuation/service step, and post-sale intent.
+
+The record state follows evidence for either path.
+
+## Worked example: Karim's touchpoints
+
+Karim misses the first call. The consultant saves **No answer**, uses the approved follow-up route if enabled, and sets the next planned attempt. At the second call Karim connects and agrees to Tuesday's meeting. The consultant updates seller qualification, replaces the old attempt NCD with the meeting time, adds the useful note above, and creates a preparation task for comparable evidence.
+
+The record now distinguishes past attempts, future client contact, and internal preparation.
+
+## Tempting wrong action
+
+Setting Karim's next contact date three months away because he is “not ready today” clears current work but has no client agreement. Ask what needs to happen, decide active versus nurture based on facts and consent, and choose a date that the note can defend.
+
+## Agent Tool: useful-note template
+
+Copy this structure:
+
+> **Outcome:**  
+> **Confirmed/changed:**  
+> **Current intent/concern:**  
+> **Next — action / owner / when:**
+
+Keep it concise enough to read before the next call.
+
+## Agent Tool: minimum-touchpoint cadence card
+
+- First eligible response.
+- Exact unanswered/connected outcome.
+- Approved follow-up where enabled.
+- Justified next contact date.
+- Due attempt from the visible surface.
+- Value-led follow-up tied to context.
+- Explicit active/nurture/lost/DNC decision.
+
+Use Prime Capital's published timing when supplied; until then, do not add a number.
+
+## Agent Tool: next-contact-date decision guide
+
+Ask in order:
+
+1. Is contact permitted?
+2. Is there a real next client interaction?
+3. What event or promise determines the date?
+4. Is a separate internal task needed first?
+5. Does the note state action, owner, and timing?
+6. Will the resulting Today visibility be honest?
+
+If any answer is unclear, fix the decision before saving the date.
+
+## Hands-on task: LAB-05 seller first call, notes, NCD, and touchpoints
+
+Use Training Seller Karim S.
+
+1. Complete the seller first-call roleplay if not already done.
+2. Apply one controlled no-answer attempt and one connected outcome.
+3. Update only confirmed seller qualification.
+4. Write the four-part useful note.
+5. Set the meeting as the next contact date.
+6. Add a separate preparation task if the practice environment supports it.
+7. Explain whether Karim remains active and why.
+
+### Success criteria
+
+- The no-answer and connected outcomes are distinct activities.
+- Seller fields and note content have different jobs.
+- The note records property/authority context, current intent, and the exact next step.
+- The next contact date matches the agreed meeting.
+- No arbitrary numeric cadence or external send is used.
+
+## Common mistakes and recovery
+
+- **Transcript pasted as a note:** replace it with the four decision-relevant parts.
+- **Filterable fact only in prose:** add it to the correct requirement/qualification field and retain only useful nuance in the note.
+- **NCD used as an internal task deadline:** create the internal task and keep the NCD for client contact.
+- **Every attempt set to tomorrow:** apply the approved cadence and the client's actual availability.
+- **Lost used when nurture is justified—or nurture used to avoid a truthful loss:** record the evidence and choose the correct opportunity state.
+- **DNC followed by a future date:** remove outreach and apply the contact restriction immediately.
+
+## Before moving on
+
+You should be able to say:
+
+> “My note explains what changed and why. My next contact date represents a real client obligation, and my touchpoint sequence ends in an explicit state decision.”

--- a/content/lms/10-agentcrm-mastery/10.6-properties-shortlists-proposals.md
+++ b/content/lms/10-agentcrm-mastery/10.6-properties-shortlists-proposals.md
@@ -1,0 +1,201 @@
+---
+title: "Properties, Shortlists & Proposals"
+slug: "properties-shortlists-proposals"
+moduleNumber: "10.6"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Turn confirmed buyer needs into a reviewed three-option shortlist, a client-specific proposal, and a useful follow-up meeting."
+estimatedDuration: "55 minutes"
+order: 6
+status: published
+quiz: "agentcrm-mastery-6"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "property-advisory-coach"
+  coachingPoints:
+    - "Inventory access is not advice"
+    - "Match score is a review aid, not a suitability decision"
+    - "A proposal explains fit, trade-offs, and pending checks"
+    - "Proposal engagement prepares a meeting; it does not prove commitment"
+---
+
+<!-- CATALYST - AgentCRM properties, shortlists, and proposals training -->
+
+# Properties, Shortlists & Proposals
+
+## Your outcome
+
+After this module, you can review properties against Maya's confirmed buyer requirement, create a defensible three-option draft proposal, and prepare the follow-up meeting without sending externally.
+
+## Core mindset
+
+> Access to inventory is not advice. Your value is translating confirmed requirements into a small, defensible decision set.
+
+## Why this matters
+
+An unreviewed property dump transfers work and risk to the client. A curated shortlist helps the client compare the decisions that matter.
+
+## Start with the active requirement
+
+Before property search or matching, confirm:
+
+- Correct contact and active buyer requirement.
+- Budget and any genuine stretch.
+- Location, property type, bedrooms, and ready/off-plan preference.
+- Purchase purpose, timing, and funding.
+- Decision stage and decision makers.
+- Hard constraints versus preferences.
+- Facts that still require client or inventory verification.
+
+If the requirement is too vague, return to qualification rather than compensating with more listings.
+
+## Find and read properties
+
+Use Properties search/filters that express confirmed criteria. Open each property and review:
+
+1. Price, type, bedrooms, location, and status.
+2. Current availability and source freshness.
+3. Payment plan, completion, service charges, and total cost where present.
+4. Yield or return inputs—never present an unverified figure as fact.
+5. Developer, condition, tenure, view, and other decision-relevant risks.
+6. How the property fits the active requirement and what trade-off it creates.
+
+Some fields are stored facts; others can change quickly. Mark live availability, charges, terms, and financial assumptions for verification.
+
+## Match score and statuses
+
+AgentCRM can rank eligible properties and show a match score. The score is a review aid, not proof of suitability or availability.
+
+Use the supported relationship statuses truthfully:
+
+- **Suggested:** identified for consideration.
+- **Shared:** actually provided or discussed with the client.
+- **Viewed:** the client-view state recorded by the workflow—not the consultant merely opening a record.
+- **Interested:** demonstrated client interest.
+- **Rejected:** the client rejected it; record the reason when known.
+
+Do not move statuses to make the activity look stronger.
+
+## Build a three-option decision set
+
+For Maya, use three distinct roles:
+
+1. **Best fit:** strongest balance against the confirmed brief.
+2. **Return/value trade-off:** stronger commercial potential with a clear compromise.
+3. **Risk/lifestyle alternative:** a different location, developer, completion, or use trade-off that helps the client decide.
+
+Each option needs:
+
+- Why it fits two or three confirmed criteria.
+- The main trade-off.
+- One live fact or assumption to verify.
+- The decision question it helps answer.
+
+## Create and preview the proposal
+
+At the baseline, a proposal belongs to the contact, links selected property IDs, begins as Draft, and can later become Sent, Viewed, or Expired.
+
+Before authorised sending:
+
+1. Confirm the correct contact and requirement context.
+2. Select only reviewed properties.
+3. Write a client-specific title, rationale, and next step.
+4. Explain differences and pending checks.
+5. Preview the client-facing result.
+6. Check links, media, figures, recipient, and expiry if shown.
+7. Use only the authorised send workflow.
+
+For practice, stop at a draft/preview. Do not send to a real or invented external address.
+
+## Proposal engagement
+
+Proposal status and view count show engagement, not intent. A view can justify a timely follow-up where the signal is visible, but it does not mean the client accepts a property.
+
+Use the meeting to ask:
+
+- What stood out?
+- Which trade-off matters most?
+- What needs verification?
+- Is the client still comparing, or ready to instruct progress on a named property?
+
+On mobile, owned leads can expose Properties and Proposals paths; Pool proposals are read-only until ownership is established. Confirm what your configured mobile view permits.
+
+## Worked example: Maya's three options
+
+Maya's draft includes:
+
+- **Option A:** strongest ready two-bedroom fit in Business Bay, within budget; verify current service charge.
+- **Option B:** stronger projected yield in Downtown, but at the top of her budget; verify net-yield inputs and availability.
+- **Option C:** lower entry price with a weaker personal-use location fit; useful for testing how much lifestyle matters.
+
+The proposal invites Maya and her partner to compare net return, location, and risk in Thursday's meeting.
+
+## Tempting wrong action
+
+The top match scores 94%. Sending it immediately feels efficient. Availability is unverified and it misses Maya's occasional personal-use preference. Review the score's evidence, verify live facts, and retain human judgement.
+
+## Agent Tool: property review checklist
+
+- [ ] Correct contact and requirement.
+- [ ] Hard constraints pass.
+- [ ] Preference fit is understood.
+- [ ] Availability and changing facts are verified or labelled pending.
+- [ ] Financial assumptions use authoritative inputs.
+- [ ] Main risk/trade-off is stated.
+- [ ] Match status reflects actual client interaction.
+- [ ] Property adds a distinct decision role.
+
+## Agent Tool: three-option shortlist template
+
+| Option | Why it fits | Main trade-off | Verify | Decision question |
+|---|---|---|---|---|
+| Best fit |  |  |  |  |
+| Return/value |  |  |  |  |
+| Risk/lifestyle alternative |  |  |  |  |
+
+## Agent Tool: proposal quality checklist
+
+- [ ] Client and active requirement are correct.
+- [ ] Only reviewed properties are included.
+- [ ] Rationale uses confirmed client goals.
+- [ ] Differences and trade-offs are explicit.
+- [ ] Pending checks are labelled, not invented.
+- [ ] Preview is complete and accurate.
+- [ ] Next meeting/action is clear.
+- [ ] Practice proposal remains unsent.
+
+## Hands-on task: LAB-06 property shortlist and proposal
+
+1. Reopen Maya's confirmed buyer requirement.
+2. Find/filter suitable properties and open their detail.
+3. Complete the property review checklist for at least four candidates.
+4. Select three distinct options and complete the shortlist template.
+5. Create a client-specific draft proposal and preview it.
+6. Prepare the follow-up meeting agenda.
+7. Do not send externally.
+
+### Success criteria
+
+- All three options pass hard constraints or clearly disclose a deliberate exception.
+- The set exposes meaningful trade-offs.
+- Match scores and statuses are not treated as client decisions.
+- Unverified availability/figures are labelled for checking.
+- The draft is linked to Maya and supports a defined follow-up meeting.
+
+## Common mistakes and recovery
+
+- **Filters based on assumptions:** return to the requirement and remove unconfirmed criteria.
+- **Top matches sent without review:** open each property and apply the checklist.
+- **Ten similar options:** reduce to a decision set with distinct roles.
+- **Suggested marked Shared:** restore the status until the client actually receives/discusses it.
+- **View treated as commitment:** prepare a follow-up meeting; do not create a deal.
+- **Practice proposal sent externally:** stop, report immediately, and follow the agency's incident process.
+
+## Before moving on
+
+You should be able to say:
+
+> “I use confirmed requirements to review inventory, curate a decision set, and prepare a proposal that makes trade-offs and next decisions clear.”

--- a/content/lms/10-agentcrm-mastery/10.7-client-journey-pipeline.md
+++ b/content/lms/10-agentcrm-mastery/10.7-client-journey-pipeline.md
@@ -1,0 +1,174 @@
+---
+title: "The Ideal Client Journey & Pipeline"
+slug: "client-journey-pipeline"
+moduleNumber: "10.7"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Progress buyer and seller opportunities through evidence-backed meetings and decisions, and distinguish interest from commitment."
+estimatedDuration: "45 minutes"
+order: 7
+status: published
+quiz: "agentcrm-mastery-7"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "pipeline-coach"
+  coachingPoints:
+    - "Pipeline progress is a sequence of real commitments and decisions"
+    - "Stages describe evidence; they are not targets to move for appearance"
+    - "Interest in a property is not instruction to progress it"
+    - "Every stage creates an owner and next obligation"
+---
+
+<!-- CATALYST - AgentCRM ideal client journey and pipeline training -->
+
+# The Ideal Client Journey & Pipeline
+
+## Your outcome
+
+After this module, you can progress Maya and Karim through evidence-backed stages, explain every move, and decide accurately whether the buyer is interested or committed.
+
+## Core mindset
+
+> Pipeline progress is the sequence of real client commitments and decisions. Stages describe evidence; they are not targets to move for appearance.
+
+## Why this matters
+
+An inflated pipeline gives false forecasts and hides the real next action. An under-maintained pipeline makes good work invisible. The record should mirror what the client has actually decided.
+
+## The durable buyer journey
+
+Use this journey even when the configured pipeline labels differ:
+
+1. **Initial call:** meaningful contact occurs.
+2. **Booked meeting:** a specific time and purpose are agreed.
+3. **Decision frame confirmed:** qualification and decision makers are clear enough for advice.
+4. **Property research and shortlist:** reviewed options answer the active requirement.
+5. **Proposal prepared/shared:** authorised client-facing decision set exists.
+6. **Follow-up meeting:** the client compares options and trade-offs.
+7. **Investment decision:** objections and verification needs narrow the choice.
+8. **Explicit instruction:** the client tells the consultant to progress a named property.
+9. **Deal creation:** committed transaction work begins.
+
+The stage label is useful only when its evidence is true.
+
+## Seller journey
+
+The seller thread uses the same evidence discipline:
+
+1. Initial contact and ownership check.
+2. Seller property and authority frame confirmed.
+3. Valuation/action-plan meeting booked.
+4. Evidence, service scope, and listing context discussed.
+5. Agreed service step or instruction recorded.
+6. Active follow-up, consented nurture, or truthful lost decision.
+7. Future buyer/seller requirement created only when real.
+
+Do not invent a property proposal step for a seller if the configured workflow uses a valuation or listing action instead.
+
+## Stage evidence
+
+Before any move, answer:
+
+1. What client event occurred?
+2. Where is the evidence—activity, qualification, note, proposal, or explicit instruction?
+3. What obligation does the new stage create?
+4. Who owns it?
+5. When must it happen?
+
+If the evidence changes, correct the stage and leave a concise reason. A correction improves the pipeline; it does not admit failure.
+
+## Interested versus committed
+
+Use the client's words, not your optimism.
+
+| Client statement | Record decision |
+|---|---|
+| “I like this one.” | Interested. Continue comparison/follow-up; no deal. |
+| “This is our favourite; we need to discuss it.” | Interested. Identify decision maker and next meeting; no deal. |
+| “Please verify the terms and hold while we decide.” | Not yet committed unless the verified business process explicitly defines that instruction as transaction commencement. Record the check and decision point. |
+| “Proceed with Unit T-1204; explain the next transaction step.” | Explicit commitment to a named property. Create the deal when required context is present. |
+
+An **Interested** property status can be accurate before a deal exists. Proposal views, match scores, meetings, and positive language do not independently pass the commitment gate.
+
+## Worked example: Maya's decision path
+
+Maya and her partner attend the proposal meeting. They prefer Unit T-1204 but ask for verified service charges. The consultant keeps the property Interested, records the verification task, and sets a follow-up meeting.
+
+At that meeting Maya says, “Proceed with Unit T-1204, subject to the written EOI terms.” The consultant records the explicit instruction and is now ready to create the deal in Module 10.8.
+
+## Seller worked example: Karim's stage correction
+
+Karim attends the valuation meeting but will not decide on listing until his co-owner returns. “Meeting completed” is true; “instruction to list” is not. Keep the stage at the evidence-backed point, record the co-owner decision, and set the agreed follow-up. If Karim later pauses for six months with consent, use a justified nurture path rather than leaving an active listing opportunity without work.
+
+## Tempting wrong action
+
+Maya's repeated proposal views and positive meeting make a deal look likely. Creating one now improves pipeline value but misstates the relationship. Record engagement and interest; wait for explicit instruction on a named property.
+
+## Agent Tool: client journey and pipeline map
+
+> **Call → meeting → decision frame → research → proposal → follow-up meeting → comparison → explicit instruction → deal**
+
+For sellers:
+
+> **Call → seller frame → valuation/action plan → service decision → active/nurture/lost next state**
+
+At every arrow, add evidence, owner, and date.
+
+## Agent Tool: stage-evidence guide
+
+Before moving:
+
+- **Event:** what actually occurred?
+- **Evidence:** where is it recorded?
+- **Stage:** which current label describes that evidence?
+- **Obligation:** what must happen now?
+- **Owner/date:** who will do it, and when?
+
+If one line is blank, the move is probably premature.
+
+## Agent Tool: interested-versus-committed decision card
+
+Ask:
+
+1. Has the client named the property?
+2. Have they explicitly instructed progress, not merely expressed preference?
+3. Is the immediate transaction step understood?
+4. Are the correct contact, requirement, property, owner, and next obligation available?
+
+All four support deal creation. Anything less remains pre-deal work.
+
+## Hands-on task: LAB-07 meeting-to-decision pipeline
+
+1. Start from Maya's draft proposal and Karim's booked action-plan meeting.
+2. Complete CRM-04 Proposal Follow-Up Meeting and Trade-Off Discussion.
+3. Apply four buyer statements from the table and decide the state for each.
+4. Complete CRM-05 Interested Versus Committed Decision.
+5. Progress Maya only when explicit instruction exists; explain the evidence.
+6. Record Karim's meeting result and choose active, nurture, or lost based on the supplied facts and consent.
+7. Confirm both records have an owner and next obligation or a truthful terminal state.
+
+### Success criteria
+
+- Every stage/state is explained with a real client event.
+- Proposal engagement and positive language are not treated as commitment.
+- Maya becomes deal-ready only after named-property instruction.
+- Karim's stage reflects authority and the actual service decision.
+- Both records contain the next obligation or a justified non-active state.
+
+## Common mistakes and recovery
+
+- **Stage moved after activity volume alone:** return to the last supported stage and document the correction.
+- **Meeting booked without date/purpose:** confirm the commitment and set the exact next contact.
+- **Proposal Sent treated as client progress:** wait for engagement and conversation evidence.
+- **Interested treated as deal:** remove the premature training deal if authorised and restore the property/lead state.
+- **Dead opportunity kept active to preserve relationship:** close the opportunity truthfully and create an appropriate future relationship action only with reason and consent.
+- **Seller forced through buyer stages:** map the current seller event to the configured seller/service workflow.
+
+## Before moving on
+
+You should be able to say:
+
+> “I move stages when client evidence changes. Interest supports follow-up; explicit instruction on a named property starts the deal.”

--- a/content/lms/10-agentcrm-mastery/10.8-deals-documents-relationships.md
+++ b/content/lms/10-agentcrm-mastery/10.8-deals-documents-relationships.md
@@ -1,0 +1,197 @@
+---
+title: "Deals, Documents & Ongoing Relationships"
+slug: "deals-documents-relationships"
+moduleNumber: "10.8"
+competency: "agentcrm-mastery"
+competencyNumber: 10
+type: "skills"
+description: "Create and manage committed deal work, associate safe documents correctly, and preserve the right relationship after won or lost outcomes."
+estimatedDuration: "55 minutes"
+order: 8
+status: published
+quiz: "agentcrm-mastery-8"
+videos: []
+resources: []
+aiCoach:
+  enabled: true
+  personality: "deal-stewardship-coach"
+  coachingPoints:
+    - "A deal represents committed transaction work on a named property"
+    - "Deal stages require evidence, an owner, and a next obligation"
+    - "Identity documents belong to the contact; transaction documents belong to the deal"
+    - "Won or lost ends an opportunity, not automatically the human relationship"
+---
+
+<!-- CATALYST - AgentCRM deals, documents, and relationships training -->
+
+# Deals, Documents & Ongoing Relationships
+
+## Your outcome
+
+After this module, you can decide which practice record warrants a deal, create it with the correct client/property context, add a harmless dummy document, progress the stage from evidence, and leave the right post-outcome relationship action.
+
+## Core mindset
+
+> The deal represents committed transaction work on a specific property. A won or lost opportunity changes the transaction; it does not erase the person or the long-term relationship.
+
+## Why this matters
+
+Premature deals corrupt forecasts. Missing property or document context slows transactions. Keeping a dead deal active to preserve a relationship confuses opportunity state with client value.
+
+## The commitment gate
+
+Create a deal when all of these are true:
+
+- The correct contact is known.
+- The client has explicitly instructed progress.
+- A named property/unit is identified.
+- The relevant requirement/context is clear.
+- The immediate transaction step, owner, and timing are understood.
+
+Maya's explicit “Proceed with Unit T-1204” passes the gate. Karim's valuation meeting does not create a buyer property deal.
+
+## Create the deal from context
+
+At the baseline, a deal links a contact and can link a requirement and one or more properties. Create from the lead/property context where the product offers it.
+
+Check:
+
+- Correct contact and active requirement.
+- Correct named property or unit.
+- Clear deal name.
+- Owner and collaborators where applicable.
+- Open status and the correct configured starting stage.
+- Current value/amount, currency, key dates, and source only when known.
+- Immediate obligation and date.
+
+Do not fill unknown financials or dates for appearance. A client may have more than one genuine property commitment; keep distinct transactions distinct.
+
+## Manage stages and outcomes
+
+Pipeline labels are configurable. For each stage move:
+
+1. Name the transaction event.
+2. Confirm the evidence.
+3. Update the stage/status that describes it.
+4. Record the new obligation, owner, and date.
+5. Correct the stage if evidence changes.
+
+Deal status supports open, won, lost, and archived concepts at the baseline. Won and lost need the agency's actual definition and an honest reason where applicable.
+
+## Document model
+
+The verified deal panel separates:
+
+### Identity documents — contact-level
+
+Examples include passport, Emirates ID, visa, and proof of address. These belong to the person and can be shared across their deals.
+
+### Transaction documents — deal-level
+
+Examples include EOI receipt, proof of funds, MOU, NOC, SPA, and named custom deal documents. These belong to the specific transaction.
+
+The generic mobile contact document path can list and upload files for the contact. Mobile contact documents expose rename/delete controls at the baseline. The deal checklist supports upload/view for identity and transaction slots, but universal deal-document rename/delete is not guaranteed. If a mistaken deal upload cannot be safely corrected with a visible authorised control, stop and request authorised support.
+
+## Safe upload workflow
+
+For practice, use a harmless file created for training, such as `TRAINING-ONLY-deal-checklist.pdf` containing no personal or transaction data.
+
+1. Confirm the practice contact and deal.
+2. Decide whether the file is contact identity or deal transaction evidence.
+3. Use the correct visible slot/control.
+4. Check file type/size policy and name.
+5. Upload only in the designated training environment.
+6. Confirm the file appears and can be opened by the authorised practice user.
+7. If associated incorrectly, use visible rename/delete support where available or stop and escalate.
+
+Never use a real passport, Emirates ID, bank statement, proof of funds, MOU, NOC, SPA, or client transaction file for training.
+
+## Won, lost, and the ongoing relationship
+
+### Won deal
+
+Close the transaction according to the agency definition. Then create an appropriate relationship action: handover/stewardship, review request, referral conversation, property management touchpoint, or a real future requirement. Consent and timing still apply.
+
+### Lost deal or opportunity
+
+End the current transaction truthfully and record why. The person may still have value, but nurture requires a genuine future reason and consent. Do not keep the deal open merely to remember the client.
+
+### Do not contact
+
+The contact restriction overrides every “long-term relationship” instinct. Stop outreach. Do not create a nurture date, campaign path, or different-channel workaround.
+
+## Worked example: Maya's deal
+
+Maya instructs the consultant to progress Unit T-1204 subject to written EOI terms. The consultant creates the deal against Maya, her active requirement, and Unit T-1204; records the current open stage; adds the next call about verified terms; and uploads the harmless training checklist to the designated training transaction slot.
+
+When the exercise supplies a lost outcome because terms are unacceptable, the consultant marks the deal lost with the reason, closes the transaction obligation, and records a consented future property review only if Maya agrees.
+
+## Tempting wrong action: creating a deal for Karim
+
+Karim has not committed to buy or transact on a named property. Creating a deal because he may reinvest later is premature. Keep his seller opportunity in the correct state and create a future buyer requirement only when he confirms that goal.
+
+## Agent Tool: deal-creation checklist
+
+- [ ] Correct contact.
+- [ ] Explicit instruction to progress.
+- [ ] Named property/unit.
+- [ ] Correct requirement/context.
+- [ ] Clear deal name and owner.
+- [ ] Starting status/stage matches evidence.
+- [ ] Values/dates are known, not guessed.
+- [ ] Immediate obligation, owner, and date are recorded.
+
+## Agent Tool: document checklist
+
+- [ ] Training environment and harmless dummy file.
+- [ ] Correct contact and deal.
+- [ ] Identity/contact versus transaction/deal classification.
+- [ ] Clear training filename and supported format.
+- [ ] Correct slot/control.
+- [ ] Upload visibly completed.
+- [ ] File opens for the authorised practice user.
+- [ ] Mistake corrected only through supported authorised controls.
+
+## Agent Tool: won/lost relationship guide
+
+| Opportunity outcome | Transaction action | Relationship action |
+|---|---|---|
+| Won | Close by agency definition; complete transaction obligations | Begin appropriate stewardship/referral/review/future requirement with consent |
+| Lost, future reason exists | Close with truthful reason | Set consented, justified nurture/review action |
+| Lost, no future reason | Close with truthful reason | No artificial activity; retain accurate history |
+| Do not contact | Stop outreach and apply restriction | No nurture or alternate-channel contact |
+
+## Hands-on task: LAB-08 deal, dummy document, and ongoing relationship
+
+1. Compare Maya and Karim; state which record warrants a deal and why.
+2. Create/review Maya's training deal with the correct contact, requirement, and named property.
+3. Record the starting stage and immediate obligation.
+4. Upload `TRAINING-ONLY-deal-checklist.pdf` to the authorised dummy transaction slot, or demonstrate the exact steps without uploading if storage is not approved.
+5. Confirm the file association and access.
+6. Apply the supplied stage and won/lost outcome evidence.
+7. Complete CRM-06 Won/Lost Opportunity and the Next Relationship Step.
+8. Leave Maya and Karim with the correct ongoing action or contact restriction.
+
+### Success criteria
+
+- Only the explicitly committed named-property record becomes a deal.
+- Contact, requirement, property, owner, stage, and next obligation are coherent.
+- No genuine or sensitive document is used.
+- Document type and association are correct or safely demonstrated.
+- Won/lost state is truthful and does not erase or artificially preserve the relationship.
+- Do-not-contact overrides future outreach.
+
+## Common mistakes and recovery
+
+- **Deal created from interest:** remove the premature training deal if authorised and return to the proposal/decision stage.
+- **Wrong property or requirement:** stop progression and correct the association before adding transaction work.
+- **Unknown value/date invented:** remove it and leave the field unknown until verified.
+- **Identity file attached as deal evidence:** use supported correction controls or request authorised help; do not duplicate sensitive files.
+- **Lost deal kept open for relationship memory:** close it truthfully and add a separate consented future action if one exists.
+- **DNC placed into nurture:** remove the future action and apply the restriction immediately.
+
+## Before finishing
+
+You should be able to say:
+
+> “The deal starts with explicit named-property commitment. Documents go to the right person or transaction, stages follow evidence, and the relationship continues only in a truthful and consented way.”

--- a/content/lms/10-agentcrm-mastery/AUDIT.md
+++ b/content/lms/10-agentcrm-mastery/AUDIT.md
@@ -1,0 +1,87 @@
+<!-- CATALYST - AgentCRM mastery product claim register -->
+
+# AgentCRM Mastery Claim Register
+
+## Source snapshot
+
+- Product repository: `/Users/thg/code/agentcrm`
+- Baseline: `58317aa09177e44a8e3dfa5c0d21643eb5b6c598`
+- Baseline date: 9 July 2026
+- Curriculum verification: 15 July 2026
+- Product `HEAD` matched the baseline during verification.
+- No AgentCRM, LMS, or Supabase data was changed during this rebuild.
+
+## Old-to-new content map
+
+| Previous module | Rebuilt module | Reuse decision |
+|---|---|---|
+| 10.1 Operating Model & Setup | 10.1 Operating Model, Navigation & Mobile | Retained the contact-centred model; replaced setup/integration emphasis with agent navigation and mobile use. |
+| 10.2 Running Today | 10.2 Today, Notifications & Speed to Contact | Corrected future-NCD behaviour and added the separate notification path. |
+| 10.3 Lead Pool, Ownership & First Response | 10.3 Finding, Filtering & Claiming Leads | Retained Pool safety; expanded Leads filters and exact claim-on-outcome rules. |
+| 10.4 Lead Workspace & Qualification | 10.4 First Phone Call & Qualification Mastery | Reframed around first-call performance and added a separate seller path. |
+| 10.5 Communications, Inbox & AI Follow-Up | 10.5 Lead Details, Notes, NCD & Touchpoints | Removed Inbox/AI training; retained truthful outcomes, notes, and next actions. |
+| 10.6 Matching & Proposals | 10.6 Properties, Shortlists & Proposals | Retained source-grounded matching/proposal content and made the meeting hand-off explicit. |
+| 10.7 Deals & Pipeline Hygiene | 10.7 Ideal Client Journey & Pipeline | Moved deal execution to 10.8; centred stages, meetings, decisions, and commitment evidence. |
+| 10.8 Manager Control Room | 10.8 Deals, Documents & Ongoing Relationships | Removed all manager controls; replaced them with agent deal, document, and stewardship work. |
+
+## Product-sensitive claims
+
+| Topic | Learner-facing truth at baseline | Verified source path |
+|---|---|---|
+| Today candidates | Today includes active leads with no next contact date, a due/overdue next contact date, an overdue task, or an untouched New lead. Do-not-contact never appears; nurture appears only when due. A future next contact date removes the lead before message, engagement, and proposal enrichment. | `app/(app)/app/today/data.ts` (`getTodayContacts`, candidate filter before enrichment) |
+| Signal engine | The pure next-action engine can rank unread inbound, new enquiries, engagement, and proposal views above a future next contact date, but it only runs for contacts that reached it. Training follows the learner-visible Today loader, not the engine comment alone. | `modules/crm/lib/next-action.ts` |
+| Notifications | The bell/sheet shows unread in-app items and can deep-link to a record. Settings expose browser push, email, WhatsApp, digest, and per-type choices, but settings persist locally and actual delivery depends on event generation, permission, role, and tenant configuration. Today's separate Action Required strip is restricted and must not be treated as a second lead queue. | `components/shared/notifications-sheet.tsx`; `modules/activity/components/notification-bell.tsx`; `app/(app)/app/settings/notifications/page.tsx`; `app/(app)/app/today/data.ts`; `modules/activity/notification-types.ts` |
+| Mobile/PWA | Mobile supports a compact lead journey with Profile, Activity, Buyer/qualification, Properties, Proposals, Deals, quick actions, notes/NCD, calls, and documents. PWA/native installation varies by device and configuration. | `components/shared/pwa-install-card.tsx`; `app/(app)/app/leads/[id]/_mobile/` |
+| Leads and Pool filters | Leads/Pool support search and combinations including stage, source, tags, temperature, priority, age, budget, location/country, property type, timeline, qualification, activity, and ownership-related filters where role/surface permits. Pool order uses product priority tiers. | `modules/crm/components/lead-pool-view.tsx`; `leads-filter-row.tsx`; `leads-advanced-filters.tsx` |
+| Pool locks and claims | Expanding a Pool row applies a five-minute soft lock. Dialling an unowned Pool lead applies a soft hold and writes an initiated attempt; it does not claim. A single-record outcome of spoke, appointment set, or callback claims. Non-contact/dead-end outcomes do not claim. A lost race must not be bypassed. | `modules/crm/services/lead-pool-service.ts`; `app/api/crm/contacts/call-attempt/route.ts`; `app/api/crm/contacts/quick-log/route.ts` |
+| Wrong number vs DNC | Wrong number flags the phone invalid and releases the lead; it does not mean the intended contact withdrew consent. Do-not-contact is a person/contact restriction and stops outreach. | `app/api/crm/contacts/quick-log/route.ts`; lead state flow |
+| Qualification | Qualification is per requirement and separates missing, inferred, and confirmed values. Manual requirement edits route non-empty values through confirmation. Prime's buyer essentials include budget, timeline, property type, purpose, funding, bedrooms, locations, ready/off-plan, motivation, decision stage, and decision maker. Seller essentials include property identity/location/type/bedrooms/target price/timeline plus motivation, post-sale plan, price flexibility, and listing exclusivity; occupancy, ownership and authority exist but are optional by default. Tenant configuration can change active/essential fields and threshold. | `lib/qualification/rubric-defaults.ts`; `lib/qualification/types.ts`; `lib/qualification/state.ts`; `modules/crm/lib/qualification-from-requirement.ts` |
+| Matches | Match scores rank eligible properties; they do not establish suitability or live availability. Supported relationship statuses are Suggested, Shared, Viewed, Interested, and Rejected with guarded transitions. | `modules/crm/services/matching-service.ts`; `modules/crm/components/matches-tab.tsx` |
+| Proposals | A proposal belongs to one contact, contains selected property IDs, starts as Draft, and can become Sent, Viewed, or Expired. View count is engagement evidence, not commitment. Mobile can create/view proposals for owned leads; Pool access is read-only. | `modules/crm/services/proposal-service.ts`; `modules/crm/types/proposal.ts`; mobile `proposals-tab.tsx` |
+| Deals | Deals link a contact and may link a requirement and one or more properties. Status supports Open, Won, Lost, and Archived; pipeline stage labels are configurable. Training uses the business commitment gate rather than treating a proposal view as a deal. | `modules/crm/services/deal-service.ts`; `modules/crm/components/deal-form.tsx`; `modules/crm/types/deal.ts` |
+| Documents | Identity documents are contact-level and shared across deals. Transaction and custom documents are referenced in the deal. The mobile contact document route supports generic files; deal controls distinguish identity from transaction files. File policy and permissions apply. | `modules/crm/components/deal-documents.tsx`; `app/api/contacts/[id]/documents/route.ts`; mobile `profile/documents-section.tsx` |
+
+## Connected learner journeys
+
+- **Buyer:** notification/Today → find/claim → first call → qualification → meeting → note/NCD → shortlist → proposal → follow-up meeting → decision → deal → dummy document → post-outcome action.
+- **Seller:** find/filter → ownership check → first call → seller qualification → note/NCD → meeting/action plan → agreed service step → decision → active/nurture/lost state with consent respected.
+
+The eight lab missions reuse Training Buyer Maya B. and Training Seller Karim S. so the learner sees each earlier decision affect the later record.
+
+## Explicit exclusions
+
+- Inbox workflows, objectives, quiz answers, labs, roleplays, and capstone dependencies.
+- Manager dashboards, assignment policy, routing, analytics, coaching, settings, and other manager controls.
+- Numeric response-time SLAs or attempt counts not confirmed by Prime Capital.
+- Product feature changes, test-data seeding, LMS sync, Supabase access, and production mutation.
+- Certificate-platform or assessor-system redesign.
+
+## Configuration-dependent items for human confirmation
+
+- Prime Capital's published speed-to-contact target and minimum attempt timing.
+- Enabled notification delivery channels and browser/native push permissions.
+- Any tenant overrides to buyer/seller rubric essentials or qualification threshold.
+- Which designated practice records and harmless dummy file learners should use.
+- Whether the practice tenant permits contact documents, deal documents, or both for LAB-08.
+
+## Revalidation triggers
+
+Recheck the curriculum when any of these change:
+
+- Today candidate filtering or enrichment order.
+- Notification event generation, deep links, preferences, or push/PWA delivery.
+- Pool locks, claim-on-outcome, wrong-number, ownership, or release rules.
+- Buyer/seller rubric fields, essential flags, confirmation semantics, or thresholds.
+- Lead-detail mobile tabs/actions.
+- Match statuses/scoring, proposal lifecycle/views, or property availability handling.
+- Deal/contact/property associations, stage/status definitions, or won/lost behaviour.
+- Contact/deal document storage, file policy, rename/delete support, or permissions.
+
+## Local validation target
+
+- Exactly 8 modules in numeric order.
+- Exactly 8 quizzes with 5 questions each (40 total).
+- Exactly 8 workflow labs and 6 roleplays.
+- Required frontmatter and cross-references resolve.
+- Forbidden learner scope (`Inbox` workflows and manager-control training) is absent.
+- Module duration sum is 385 minutes and matches the overview headline.

--- a/content/lms/10-agentcrm-mastery/_index.md
+++ b/content/lms/10-agentcrm-mastery/_index.md
@@ -1,0 +1,133 @@
+---
+title: "AgentCRM Mastery"
+slug: "agentcrm-mastery"
+competencyNumber: 10
+description: "Run a complete AgentCRM working day: prioritise, contact, qualify, record, match, propose, progress, document, and preserve the client relationship."
+estimatedDuration: "6 hours 25 minutes"
+moduleCount: 8
+learningObjectives:
+  - "Trace a client relationship across contacts, requirements, properties, proposals, deals, activities, and next actions on desktop and mobile"
+  - "Use Today and enabled notifications to respond quickly without mistaking either surface for a complete record"
+  - "Find, filter, assess, and claim appropriate leads while respecting ownership and Pool conflicts"
+  - "Run buyer and seller first calls that create useful qualification, a meeting or next action, and a truthful record"
+  - "Write useful notes, set justified next contact dates, and apply a repeatable communication-touchpoint sequence"
+  - "Turn a confirmed buyer requirement into a reviewed shortlist and client-specific proposal"
+  - "Progress pipeline stages from evidence and distinguish interest from commitment"
+  - "Create the right deal, associate the right property, use safe documents, and continue appropriate post-outcome stewardship"
+order: 10
+status: published
+videos: []
+resources: []
+sourceSnapshot:
+  repository: "agentcrm"
+  commit: "58317aa0"
+  verifiedAt: "2026-07-15"
+aiCoach:
+  enabled: true
+  personality: "workflow-coach"
+  focus: "practical-agent-operation"
+---
+
+<!-- CATALYST - AgentCRM agent operating playbook overview -->
+
+# Competency 10: AgentCRM Mastery
+
+## The outcome
+
+By the end of this competency, you can move a real prospect from first signal to investment decision quickly, consistently, and with a clear next action.
+
+This is an agent operating playbook, not a feature tour. Keep it open beside AgentCRM while you practise. Every module follows the same pattern:
+
+**Mindset → practical tool → worked example → tempting wrong action → product task.**
+
+## The client journey
+
+Use AgentCRM to keep one connected story:
+
+1. Notice the signal in Today or an enabled notification.
+2. Find the correct person and confirm ownership.
+3. Contact quickly after reading the enquiry and history.
+4. Qualify enough to create direction and book a useful next step.
+5. Save the outcome, confirmed facts, note, stage, and next contact date.
+6. Research and shortlist properties against the active requirement.
+7. Prepare a client-specific proposal and a follow-up meeting.
+8. Record the client's comparison, objections, and decision.
+9. Create a deal only after explicit instruction to progress a named property.
+10. Add the correct transaction context and safe documents.
+11. Close the opportunity truthfully and preserve the appropriate relationship.
+
+The same discipline applies to sellers: understand the property and authority, agree the service step, record the next action, and keep the opportunity state honest.
+
+## The ten operating mindsets
+
+1. **Speed creates opportunity.** Act quickly while still reading the context.
+2. **Claiming means ownership.** Do not claim work you cannot progress.
+3. **The record should tell the truth.** Capture what happened, not what you hoped happened.
+4. **Every touch creates a next step.** Use a meaningful next contact date, not a hiding date.
+5. **Qualification guides value.** The first call should create direction and a meeting, not an interrogation.
+6. **Properties require judgement.** A shortlist is more valuable than an inventory dump.
+7. **Interest is not commitment.** Create a deal only when the client decides to progress a named property.
+8. **Stages follow evidence.** Never move a stage merely to make the pipeline look healthy.
+9. **Won or lost describes the opportunity, not the human relationship.** Continue appropriate stewardship unless consent says stop.
+10. **Mobile keeps the record current.** Capture outcomes and next actions while the context is fresh.
+
+## Modules
+
+1. **AgentCRM Operating Model, Navigation & Mobile** — Trace the relationship and prepare desktop/mobile access.
+2. **Today, Notifications & Speed to Contact** — Read each surface accurately and close a fast response loop.
+3. **Finding, Filtering & Claiming Leads** — Locate the right buyer or seller, assess context, and take responsibility safely.
+4. **First Phone Call & Qualification Mastery** — Run separate buyer and seller first-call paths and save the result.
+5. **Lead Details, Notes, Next Contact Date & Touchpoints** — Make every interaction improve the record and the next action.
+6. **Properties, Shortlists & Proposals** — Convert confirmed needs into a defensible decision set.
+7. **The Ideal Client Journey & Pipeline** — Progress stages from evidence and separate interest from commitment.
+8. **Deals, Documents & Ongoing Relationships** — Manage committed work safely and continue the right relationship after the outcome.
+
+The module estimates total **6 hours 25 minutes**, including their short knowledge checks and hands-on tasks. The final capstone takes a further **45–60 minutes**, keeping the complete experienced-broker path within one working day.
+
+## Connected practice records
+
+The eight workflow missions use two recurring dummy records:
+
+- **Training Buyer Maya B.** — a cash buyer seeking a ready two-bedroom investment up to AED 2.4M in Business Bay or Downtown, deciding with her partner.
+- **Training Seller Karim S.** — a co-owner considering the sale of a tenanted two-bedroom Dubai Marina apartment, targeting AED 2.7M within one to three months.
+
+Use only the designated training tenant or records explicitly approved for practice. Never substitute a live client.
+
+## Knowledge and practice
+
+- Eight five-question knowledge checks, one per module, with an 80% pass mark.
+- Eight connected AgentCRM Workflow Lab missions.
+- Six focused AgentCRM Roleplays, each followed by a CRM record-state self-check.
+- One practical capstone observed by a manager or coach.
+
+## Capstone: run the client journey
+
+Allow 45–60 minutes. Starting from the connected practice records, demonstrate the buyer journey and explain the seller's correct next state. Use the product where authorised; explain rather than perform any action that would send externally or affect live data.
+
+### Manager/coach pass checklist
+
+Pass only when all eight statements are true:
+
+- [ ] Finds and prioritises the correct lead.
+- [ ] Acts with appropriate speed and ownership.
+- [ ] Conducts and records useful buyer or seller qualification.
+- [ ] Leaves a clear note and justified next contact date.
+- [ ] Progresses meetings, properties, and proposals truthfully.
+- [ ] Distinguishes interest from commitment.
+- [ ] Creates or manages the right deal and harmless dummy document.
+- [ ] Leaves the correct ongoing relationship action after a won or lost outcome.
+
+If one item fails, practise that workflow again. This checklist does not replace Prime Capital's wider sales, compliance, or transaction standards.
+
+## Safety boundaries
+
+- Use only dummy or approved training records, properties, amounts, and files.
+- Never send a test message, proposal, or notification to a real client.
+- Never claim, release, reassign, change, or upload to a live record for practice.
+- Never use real passports, Emirates IDs, bank statements, proof of funds, or transaction documents.
+- Browser push, notification types, proposals, documents, and some mobile controls depend on permission and agency configuration. Confirm the visible result after every action.
+- This competency does not teach disabled communication workspaces or manager-only controls.
+
+## Product snapshot
+
+The instructions were verified against AgentCRM commit `58317aa0` on 15 July 2026. Labels and placement may move. The decision, evidence, and resulting record state are the durable standard.

--- a/content/lms/quizzes/agentcrm-mastery-1.md
+++ b/content/lms/quizzes/agentcrm-mastery-1.md
@@ -1,0 +1,72 @@
+---
+title: "AgentCRM Operating Model, Navigation & Mobile Quiz"
+slug: "agentcrm-mastery-1"
+quizNumber: 1
+competency: "agentcrm-mastery"
+relatedModule: "10.1-operating-model-navigation-mobile"
+description: "Check your understanding of the relationship model and safe desktop/mobile operation."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM operating model quiz -->
+
+# AgentCRM Operating Model, Navigation & Mobile Quiz
+
+## Question 1
+**Maya now wants an investment studio as well as the family-home goal already recorded. What is the cleanest structure?**
+
+A) Keep one contact and add a separate requirement for the studio
+B) Replace the family-home requirement with the studio criteria
+C) Add the studio criteria only to a note on the existing requirement
+D) Create a second contact so the property searches remain separate
+
+**Correct Answer:** A
+**Explanation:** The contact represents Maya; separate requirements represent genuinely different goals. This preserves one relationship history while keeping matching criteria usable.
+
+## Question 2
+**Which sequence best describes the connected AgentCRM relationship?**
+
+A) Property → contact → stage → notification → owner
+B) Contact → requirement → property/proposal → decision/deal → next action
+C) Enquiry → deal → qualification → proposal → contact
+D) Task → property → contact → requirement → activity
+
+**Correct Answer:** B
+**Explanation:** The person is central. Requirements describe goals, properties/proposals support decisions, deals track committed work, and activities/next actions keep the relationship current.
+
+## Question 3
+**You can open AgentCRM from a home-screen icon, but browser notifications never appear. What should you check?**
+
+A) Whether the contact has an open deal
+B) Whether the device has enough storage for proposals
+C) AgentCRM notification preferences, browser/device permission, and tenant event support
+D) Whether the lead has more than one requirement
+
+**Correct Answer:** C
+**Explanation:** Installation and notification delivery are separate. Preferences, operating-system/browser permission, and configured event generation must all support the alert.
+
+## Question 4
+**A mobile tab groups information differently from desktop. What is the most reliable way to work?**
+
+A) Memorise the desktop coordinate and tap the same position on mobile
+B) Learn the record purpose and confirm the resulting state after using the visible mobile control
+C) Wait until every desktop panel has an identical mobile label
+D) Copy the information to a separate personal note until desktop is available
+
+**Correct Answer:** B
+**Explanation:** Layouts move, but contact, requirement, activity, proposal, deal, and next-action purposes remain stable. Confirming the saved result protects record integrity.
+
+## Question 5
+**What makes a training orientation safe?**
+
+A) Reading a live lead without changing it, then uploading a dummy file
+B) Using any unassigned lead because it has no owner
+C) Using the designated practice record and tracing its objects without editing live data
+D) Creating a temporary duplicate and deleting it after the exercise
+
+**Correct Answer:** C
+**Explanation:** A designated practice environment prevents accidental changes to ownership, communication, documents, or client history while still proving navigation.

--- a/content/lms/quizzes/agentcrm-mastery-2.md
+++ b/content/lms/quizzes/agentcrm-mastery-2.md
@@ -1,0 +1,72 @@
+---
+title: "Today, Notifications & Speed to Contact Quiz"
+slug: "agentcrm-mastery-2"
+quizNumber: 2
+competency: "agentcrm-mastery"
+relatedModule: "10.2-today-notifications-speed"
+description: "Check your ability to interpret Today, enabled notifications, queue controls, and response priorities accurately."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM Today and notifications quiz -->
+
+# Today, Notifications & Speed to Contact Quiz
+
+## Question 1
+**Maya has a future next contact date and views her proposal again today. What should you expect from Today at the pinned baseline?**
+
+A) Today removes the future date and shows Maya as overdue
+B) Today can rank the view only after Maya passes its candidate filter, so the future date currently keeps her out
+C) Today creates a deal because the proposal was viewed again
+D) Today changes the property status to Interested and shows Maya
+
+**Correct Answer:** B
+**Explanation:** The loader excludes future-dated contacts before proposal/message enrichment. Use the separately enabled notification/lead-review path; do not assume the view returns Maya to Today.
+
+## Question 2
+**Which active lead normally qualifies for Today?**
+
+A) A lead with a future next contact date and no overdue task
+B) A do-not-contact lead with a missing date
+C) A lead whose next contact date is due today
+D) A nurture lead with neither a due date nor overdue task
+
+**Correct Answer:** C
+**Explanation:** Due/overdue next contact dates are Today candidates. Future dates hide active leads; DNC never appears; nurture wakes only when due or an overdue task exists.
+
+## Question 3
+**What does desktop Done prove by itself?**
+
+A) That the client interaction was saved with a call outcome
+B) That the stage and next contact date were updated
+C) Only that the card was hidden for the session and the local daily count increased
+D) That the notification was marked read on every device
+
+**Correct Answer:** C
+**Explanation:** Desktop Done changes queue-session state, not the underlying client evidence. Save the real outcome and next action before clearing the card.
+
+## Question 4
+**An in-app notification deep-links to a lead. What is the best next step?**
+
+A) Mark it read immediately because opening proves completion
+B) Verify contact, ownership, recent activity, and local time before acting and saving the result
+C) Set tomorrow as the next contact date before reading the record
+D) Treat the notification type as proof that the lead stage changed
+
+**Correct Answer:** B
+**Explanation:** A notification is an alert, not the completed workflow. Record verification prevents duplicate, mistimed, or outdated action.
+
+## Question 5
+**Which should normally be prioritised first?**
+
+A) A fresh assigned enquiry you can respond to properly now
+B) A qualified record with a justified follow-up next month and no new visible alert
+C) A property research task due next week
+D) A note-format correction on a closed training record
+
+**Correct Answer:** A
+**Explanation:** Fresh first-contact work is time-sensitive and client-facing. The future commitment and internal tasks remain important but do not outrank a new eligible response.

--- a/content/lms/quizzes/agentcrm-mastery-3.md
+++ b/content/lms/quizzes/agentcrm-mastery-3.md
@@ -1,0 +1,72 @@
+---
+title: "Finding, Filtering & Claiming Leads Quiz"
+slug: "agentcrm-mastery-3"
+quizNumber: 3
+competency: "agentcrm-mastery"
+relatedModule: "10.3-finding-filtering-claiming"
+description: "Check your ability to find the right lead, understand Pool locks and claim outcomes, and resolve ownership safely."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM lead finding and claiming quiz -->
+
+# Finding, Filtering & Claiming Leads Quiz
+
+## Question 1
+**A known seller disappears after you apply several filters. What should you do first?**
+
+A) Create a new seller contact from memory
+B) Clear filters, search broadly, then add one relevant filter at a time
+C) Search only the Pool because assigned leads cannot be filtered
+D) Change the seller requirement into a buyer requirement
+
+**Correct Answer:** B
+**Explanation:** Filters narrow the visible set and can hide a valid record. Broad search protects against duplicate creation and reveals the actual ownership/state.
+
+## Question 2
+**You expand an unowned Pool row to review it. What has happened?**
+
+A) The lead is permanently assigned to you
+B) A five-minute soft lock protects the review, but ownership has not transferred
+C) The first-response clock has stopped and the lead is Contacted
+D) Other agents can no longer find the contact in Leads
+
+**Correct Answer:** B
+**Explanation:** Expansion creates a temporary Pool lock. Claim ownership must still be established through the visible claim or supported outcome flow.
+
+## Question 3
+**Which saved single-record call outcome can claim an unowned Pool lead?**
+
+A) No answer
+B) Voicemail
+C) Callback requested
+D) Wrong number
+
+**Correct Answer:** C
+**Explanation:** Callback is a claiming outcome, alongside Spoke and Appointment set. Non-contact and dead-end outcomes leave the lead unowned.
+
+## Question 4
+**Another agent wins the claim while you are reviewing Maya. What is the correct response?**
+
+A) Stop and choose other eligible work, raising a review only if ownership is genuinely wrong
+B) Continue the call because your review started first
+C) Create a duplicate so both agents can preserve their notes
+D) Save Spoke to force ownership back to you
+
+**Correct Answer:** A
+**Explanation:** The conflict prevents duplicate outreach. Bypassing it corrupts ownership and client history.
+
+## Question 5
+**A third party says the number does not belong to the intended lead. What record decision is accurate?**
+
+A) Mark the intended contact DNC across every channel
+B) Save Wrong number so the phone is invalidated/released, without inventing an intended-contact opt-out
+C) Save No answer and retry the same phone later
+D) Save Callback so the record becomes yours to investigate
+
+**Correct Answer:** B
+**Explanation:** Wrong number protects the third party and invalid phone. It is distinct from the intended person's consent state.

--- a/content/lms/quizzes/agentcrm-mastery-4.md
+++ b/content/lms/quizzes/agentcrm-mastery-4.md
@@ -1,0 +1,72 @@
+---
+title: "First Phone Call & Qualification Mastery Quiz"
+slug: "agentcrm-mastery-4"
+quizNumber: 4
+competency: "agentcrm-mastery"
+relatedModule: "10.4-first-call-qualification"
+description: "Check your buyer/seller first-call preparation, evidence boundaries, qualification, and post-call save decisions."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM first-call qualification quiz -->
+
+# First Phone Call & Qualification Mastery Quiz
+
+## Question 1
+**Maya's portal filter says AED 2–3M, but she has not discussed budget. How should it appear before the call?**
+
+A) Confirmed because the source captured it
+B) Inferred context that guides a question but still needs client confirmation
+C) Unknown with the source information deleted
+D) Confirmed only if the lead score is high
+
+**Correct Answer:** B
+**Explanation:** Source data is useful preparation, not client-confirmed truth. Promoting it early can distort qualification and matching.
+
+## Question 2
+**What is the strongest purpose for a first call?**
+
+A) Complete every active qualification field before ending
+B) Establish the objective, confirm the minimum useful frame, and agree a meaningful next commitment
+C) Present three properties before asking about timing or decision makers
+D) Move the stage after any positive response
+
+**Correct Answer:** B
+**Explanation:** The first call creates direction and a next step. It should not become a form interrogation or premature recommendation.
+
+## Question 3
+**Which set belongs specifically in Karim's seller qualification?**
+
+A) Property/location, target price, timeline, motivation, post-sale plan, flexibility, and listing context
+B) Proposal view count, match score, buyer bedrooms, and funding source
+C) Only the target price and next contact date
+D) Deal probability, EOI amount, and buyer decision stage
+
+**Correct Answer:** A
+**Explanation:** Seller qualification describes the asset, timing, authority/context, motivation, and intended service decision. It is separate from buyer matching and deal fields.
+
+## Question 4
+**Karim is a co-owner, but the other owner has not joined the discussion. What should you record?**
+
+A) Sole decision authority because Karim made the enquiry
+B) Joint/co-owner context and the remaining authority question
+C) Listing exclusivity because a meeting was booked
+D) Confirmed permission to transact if the target price is known
+
+**Correct Answer:** B
+**Explanation:** Authority must follow evidence. Recording the co-owner dependency prevents later stages from assuming instruction that Karim cannot give alone.
+
+## Question 5
+**What completes a strong post-call save?**
+
+A) Qualification fields only
+B) A detailed transcript with no structured updates
+C) Exact outcome, supported qualification, concise note, evidence-backed stage, and matching next contact date
+D) A future date and later stage, with the note added when time allows
+
+**Correct Answer:** C
+**Explanation:** The combination preserves system-usable facts, relationship meaning, current state, and the next obligation.

--- a/content/lms/quizzes/agentcrm-mastery-5.md
+++ b/content/lms/quizzes/agentcrm-mastery-5.md
@@ -1,0 +1,72 @@
+---
+title: "Lead Details, Notes, Next Contact Date & Touchpoints Quiz"
+slug: "agentcrm-mastery-5"
+quizNumber: 5
+competency: "agentcrm-mastery"
+relatedModule: "10.5-lead-details-notes-follow-up"
+description: "Check your ability to write useful notes, set justified next dates, and run a truthful communication-touchpoint sequence."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM notes, NCD, and touchpoints quiz -->
+
+# Lead Details, Notes, Next Contact Date & Touchpoints Quiz
+
+## Question 1
+**Which note is most useful before Karim's next meeting?**
+
+A) “Good call. Follow up soon.”
+B) “Connected; jointly owned tenanted Marina 2BR, AED 2.7M target, open to evidence-led offers. Valuation meeting Tue 10:00; I prepare comparables.”
+C) A full word-for-word call transcript with no conclusion
+D) “Seller looks strong; move forward.”
+
+**Correct Answer:** B
+**Explanation:** It captures outcome, confirmed change, current decision context, and the owned/timed next step without burying the reader.
+
+## Question 2
+**You promised to send verified comparables Monday and speak Tuesday. How should the work be represented?**
+
+A) Use Monday as the next contact date and omit Tuesday
+B) Use Tuesday as the next client contact and a separate Monday preparation/delivery task where supported
+C) Use one note with both dates and no visible reminder
+D) Set both dates as deal stages
+
+**Correct Answer:** B
+**Explanation:** The next contact date represents client follow-up; a separate task can make the prerequisite work visible.
+
+## Question 3
+**A lead does not answer the first call. What is the next step in the sequence-based standard?**
+
+A) Record the exact outcome, use an approved follow-up where enabled, and set the justified next attempt
+B) Mark Contacted because the consultant acted quickly
+C) Move to nurture immediately so Today remains clear
+D) Add a distant date until Prime Capital confirms a numeric SLA
+
+**Correct Answer:** A
+**Explanation:** The standard preserves the real attempt and a purposeful next action without inventing timings or overstating contact.
+
+## Question 4
+**Which next contact date is defensible?**
+
+A) Three months away because the queue is busy
+B) Friday 14:00 because the client asked for a call after receiving verified terms Friday morning
+C) Tomorrow because every active lead should return daily
+D) Month-end because it aligns with reporting
+
+**Correct Answer:** B
+**Explanation:** The date follows a client agreement and preceding deliverable. It can be explained by the note and action plan.
+
+## Question 5
+**After several value-led attempts, the client says the purchase is paused for six months and agrees to reconnect then. What is the best record decision?**
+
+A) Keep the opportunity active with weekly reminders
+B) Use a justified, consented nurture/future-review state and record the reason
+C) Mark every previous call No answer
+D) Leave the current next date unchanged so Today decides
+
+**Correct Answer:** B
+**Explanation:** A real future reason and consent support nurture. Keeping dead active work distorts priority and ignores the client's stated timing.

--- a/content/lms/quizzes/agentcrm-mastery-6.md
+++ b/content/lms/quizzes/agentcrm-mastery-6.md
@@ -1,0 +1,72 @@
+---
+title: "Properties, Shortlists & Proposals Quiz"
+slug: "agentcrm-mastery-6"
+quizNumber: 6
+competency: "agentcrm-mastery"
+relatedModule: "10.6-properties-shortlists-proposals"
+description: "Check your property-review, shortlist, match-status, proposal, and engagement decisions."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM properties and proposals quiz -->
+
+# Properties, Shortlists & Proposals Quiz
+
+## Question 1
+**The active requirement records Business Bay as a confirmed preference and Downtown only in an old note. How should you filter?**
+
+A) Use both as hard constraints because either appears on the record
+B) Use confirmed Business Bay; validate Downtown before relying on it as a current alternative
+C) Ignore location and send the top matches by score
+D) Create a new requirement for every area
+
+**Correct Answer:** B
+**Explanation:** Matching criteria should follow confirmed current requirements. An old note can prompt a question but should not silently drive the shortlist.
+
+## Question 2
+**A 94% match has unverified availability and a service charge that may change the net return. What is the right decision?**
+
+A) Keep it as a candidate, verify the live facts, and state the trade-off before recommending it
+B) Mark it Shared because the score is high
+C) Remove all lower-scoring options before review
+D) Present the gross yield as net until charges are confirmed
+
+**Correct Answer:** A
+**Explanation:** The score supports ranking, not suitability or live truth. Verification protects the client's decision and the consultant's credibility.
+
+## Question 3
+**When is the Shared match status accurate?**
+
+A) When the consultant opens the property record
+B) When the system suggests the property
+C) When the property was actually provided or discussed with the client
+D) When the proposal remains a private draft
+
+**Correct Answer:** C
+**Explanation:** Status should describe client interaction. Suggested and draft work are not yet shared.
+
+## Question 4
+**What makes a three-option shortlist useful?**
+
+A) Each option has a distinct decision role, stated fit, trade-off, and pending check
+B) All three have the highest available match score
+C) Each option is from the same building to simplify comparison
+D) The proposal contains every available unit as an appendix
+
+**Correct Answer:** A
+**Explanation:** Distinct roles help the client compare value, risk, and lifestyle while keeping uncertainty visible.
+
+## Question 5
+**Maya views the proposal repeatedly. What can you conclude?**
+
+A) She is engaged, so a context-aware follow-up meeting may be timely
+B) She has selected the highest-scoring property
+C) Her partner has approved the purchase
+D) The proposal should be marked Won
+
+**Correct Answer:** A
+**Explanation:** View count is engagement evidence only. The follow-up conversation must uncover what stood out and whether any decision was made.

--- a/content/lms/quizzes/agentcrm-mastery-7.md
+++ b/content/lms/quizzes/agentcrm-mastery-7.md
@@ -1,0 +1,72 @@
+---
+title: "The Ideal Client Journey & Pipeline Quiz"
+slug: "agentcrm-mastery-7"
+quizNumber: 7
+competency: "agentcrm-mastery"
+relatedModule: "10.7-client-journey-pipeline"
+description: "Check your stage-evidence, buyer/seller journey, and interested-versus-committed decisions."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM client journey and pipeline quiz -->
+
+# The Ideal Client Journey & Pipeline Quiz
+
+## Question 1
+**Maya says, “Unit T-1204 is our favourite, but my partner and I need to discuss it.” What is the correct state?**
+
+A) Interested, with the decision meeting recorded; no deal yet
+B) Committed, because a favourite property is named
+C) Lost, because the partner has not agreed
+D) Won, subject to a future date
+
+**Correct Answer:** A
+**Explanation:** Preference is real interest, but the client has not instructed progress. The next decision point belongs on the record.
+
+## Question 2
+**Which statement is strongest evidence for deal readiness?**
+
+A) “I opened the proposal twice.”
+B) “This option seems good value.”
+C) “Proceed with Unit T-1204 and explain the next transaction step.”
+D) “Please send another comparison.”
+
+**Correct Answer:** C
+**Explanation:** It is explicit instruction to progress a named property. The other statements support engagement or further pre-deal work.
+
+## Question 3
+**What should happen before a pipeline stage move?**
+
+A) Record the client event, its evidence, the new obligation, owner, and date
+B) Check whether the new stage improves the monthly forecast
+C) Confirm that at least three activities exist
+D) Wait until every qualification field is complete, regardless of the event
+
+**Correct Answer:** A
+**Explanation:** Stage integrity comes from observable evidence and the work created by that event, not activity volume or reporting pressure.
+
+## Question 4
+**Karim attended a valuation meeting but cannot decide until his co-owner returns. What should the stage show?**
+
+A) Instruction to list, because the meeting occurred
+B) The completed meeting/evidence point with a co-owner decision follow-up
+C) Lost, because immediate authority is missing
+D) Deal created for Karim's possible reinvestment
+
+**Correct Answer:** B
+**Explanation:** The meeting is evidence; listing instruction is not. The stage and next contact should reflect the remaining decision.
+
+## Question 5
+**You discover that a stage was advanced on optimism rather than evidence. What is the best recovery?**
+
+A) Leave it because moving backwards damages performance
+B) Correct it to the supported stage and add a concise reason/next obligation
+C) Add a generic note but keep the stage
+D) Close the opportunity so the inconsistency disappears
+
+**Correct Answer:** B
+**Explanation:** A truthful correction restores pipeline reliability and makes the real next work visible.

--- a/content/lms/quizzes/agentcrm-mastery-8.md
+++ b/content/lms/quizzes/agentcrm-mastery-8.md
@@ -1,0 +1,72 @@
+---
+title: "Deals, Documents & Ongoing Relationships Quiz"
+slug: "agentcrm-mastery-8"
+quizNumber: 8
+competency: "agentcrm-mastery"
+relatedModule: "10.8-deals-documents-relationships"
+description: "Check your deal associations, document placement, stage management, and post-outcome relationship decisions."
+passingScore: 80
+questionCount: 5
+estimatedDuration: "5 minutes"
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM deals, documents, and relationships quiz -->
+
+# Deals, Documents & Ongoing Relationships Quiz
+
+## Question 1
+**Which context should Maya's new deal preserve?**
+
+A) Correct contact, active requirement, named property, owner, starting stage, and next obligation
+B) Contact and estimated value only; the property can be added after closing
+C) Property and proposal view count only; ownership follows automatically
+D) A new contact so the deal has a clean history
+
+**Correct Answer:** A
+**Explanation:** Connected context lets transaction work start safely and keeps the obligation tied to the real client decision.
+
+## Question 2
+**Where should a harmless dummy EOI receipt be associated for the practice transaction?**
+
+A) In Maya's free-text note
+B) In the deal's transaction-document area for the correct training deal
+C) In Karim's contact identity documents
+D) In an external personal drive linked from the activity
+
+**Correct Answer:** B
+**Explanation:** EOI evidence belongs to the specific transaction. Notes and contact identity slots have different purposes.
+
+## Question 3
+**Which document is contact-level and reusable across that person's deals?**
+
+A) MOU for Unit T-1204
+B) NOC for a specific resale
+C) Passport identity record
+D) EOI receipt for a named property
+
+**Correct Answer:** C
+**Explanation:** Identity documents belong to the contact. EOI, MOU, NOC, SPA, and similar evidence belong to the relevant deal.
+
+## Question 4
+**A training transaction document was attached to the wrong deal and no supported correction control is visible. What should you do?**
+
+A) Upload another copy to the correct deal and ignore the first
+B) Rename the deal so the document appears correct
+C) Stop and request authorised correction rather than duplicating or hiding the mistake
+D) Copy the file into the contact note as a backup
+
+**Correct Answer:** C
+**Explanation:** Unsupported workarounds multiply sensitive data and corrupt associations. Use visible authorised controls or escalate.
+
+## Question 5
+**A deal is lost because the terms are unsuitable, but Maya agrees to review new options next quarter. What is the right record result?**
+
+A) Keep the deal open so the relationship remains visible
+B) Mark the deal lost with the reason and create a consented, justified future relationship action
+C) Mark the deal won because the relationship continues
+D) Apply do-not-contact to prevent accidental follow-up
+
+**Correct Answer:** B
+**Explanation:** The transaction ends truthfully while the human relationship continues through a separate, consented next action.

--- a/content/lms/scenarios/AUDIT.md
+++ b/content/lms/scenarios/AUDIT.md
@@ -1,12 +1,12 @@
 # Content Audit — Scenarios Folder
 
-**Last Audited:** 2026-01-10  
-**Audited By:** GitHub Copilot Agent
+**Last Audited:** 2026-07-15
+**Audited By:** Catalyst Agent
 
 ## Summary
 
-- Files audited: 6
-- Issues fixed: 6 (added frontmatter to all files)
+- Files audited: 11
+- Scenario bank total: 113
 - Status: ✅ PASS
 
 ## Scenario Mapping
@@ -19,6 +19,11 @@
 | objections | objection-navigation, market-intelligence | ✅ |
 | closing | transaction-management, objection-navigation, relationship-stewardship | ✅ |
 | difficult-situations | relationship-stewardship, transaction-management | ✅ |
+| ai-skills | ai-empowered-agent | ✅ |
+| aml-onboarding | aml-compliance | ✅ |
+| aml-red-flags | aml-compliance | ✅ |
+| agentcrm-workflow-lab | agentcrm-mastery | ✅ |
+| agentcrm-roleplays | agentcrm-mastery | ✅ |
 
 ## Fixes Applied
 
@@ -77,8 +82,11 @@ Added YAML frontmatter with required schema fields:
 - The audit brief referenced different filenames than what exists in the repository. The actual files are category-based scenario collections rather than individual scenario files.
 - Each file contains multiple individual scenarios with their own difficulty ratings (⭐, ⭐⭐, ⭐⭐⭐)
 - Competency slugs validated against existing competency folder names in `content/lms/`
-- The `_index.md` file serves as the scenario bank overview and was not modified (it doesn't require frontmatter changes)
-- Total scenario count across all files: **75 scenarios**
+- The `_index.md` file serves as the learner-facing scenario bank overview and contains the current category mapping.
+- AgentCRM Workflow Lab deliberately has no AI persona prompts; its missions are marked complete through the existing self-reflection flow.
+- The AgentCRM lab contains eight connected buyer/seller missions, and each mission names a visible practice-record result plus a short self-check.
+- The six AgentCRM roleplays each end with a `What changes in AgentCRM?` record-state check and stay within agent permissions.
+- Total scenario count across all files: **113 scenarios**
 
 ## Valid Competency Slugs
 
@@ -90,3 +98,6 @@ The following competency slugs are used and validated:
 - `transaction-management`
 - `objection-navigation`
 - `relationship-stewardship`
+- `ai-empowered-agent`
+- `aml-compliance`
+- `agentcrm-mastery`

--- a/content/lms/scenarios/_index.md
+++ b/content/lms/scenarios/_index.md
@@ -1,15 +1,15 @@
 # Scenario Bank
-## Prime Capital — AI Roleplay Training Scenarios
+## Prime Capital — Practice & Simulation Bank
 
-**Version:** 1.1  
-**Date:** January 2026  
-**Total Scenarios:** 83
+**Version:** 1.2
+**Date:** July 2026
+**Total Scenarios:** 113
 
 ---
 
 ## Purpose
 
-This Scenario Bank provides structured practice situations for Prime Capital consultants to develop client-facing skills through AI-powered roleplay. Each scenario simulates real-world interactions consultants will encounter, allowing safe practice before live client contact.
+This Scenario Bank provides structured practice situations for Prime Capital consultants through AI-powered roleplay and hands-on workflow labs. Each scenario allows safe practice before live client or production-system work.
 
 ---
 
@@ -22,7 +22,7 @@ This Scenario Bank provides structured practice situations for Prime Capital con
 3. **Note the key challenges** you'll need to navigate
 4. **Review common mistakes** to avoid known pitfalls
 5. **Study the model approach** before beginning practice
-6. **Use the AI simulation prompt** to begin your roleplay session
+6. **Use the AI simulation prompt** for roleplays, or complete the named training-tenant evidence for hands-on labs
 7. **Practice until confident** — aim for natural, brand-aligned responses
 
 ### For Managers
@@ -45,6 +45,10 @@ This Scenario Bank provides structured practice situations for Prime Capital con
 | [Closing](closing.md) | 10 | EOI commitment, overcoming hesitation, assumptive techniques |
 | [Difficult Situations](difficult-situations.md) | 10 | Ghosted clients, lost deals, angry clients, developer delays |
 | [AI Skills Practice](ai-skills.md) | 8 | Hands-on Gemini exercises — research, communication, productivity |
+| [AML Onboarding](aml-onboarding.md) | 8 | Customer risk, identity checks, beneficial ownership, and escalation |
+| [AML Red Flags](aml-red-flags.md) | 8 | Suspicious behaviour, sanctions, source of funds, and reporting decisions |
+| [AgentCRM Workflow Lab](agentcrm-workflow-lab.md) | 8 | Connected buyer/seller missions from first signal to deal and ongoing relationship |
+| [AgentCRM Roleplays](agentcrm-roleplays.md) | 6 | High-value agent conversations followed by exact CRM record-state decisions |
 
 ---
 
@@ -75,14 +79,14 @@ Typical errors consultants make — what to avoid.
 ### Model Approach
 A recommended framework for handling the scenario — how to approach it successfully.
 
-### AI Simulation Prompt
-The exact prompt to use with an AI assistant to begin the roleplay.
+### AI Simulation Prompt or Evidence Task
+Roleplays provide the exact prompt used to begin an AI conversation. Hands-on labs instead name the safe in-product task and evidence required.
 
 ---
 
 ## Competency Mapping
 
-Scenarios connect to the six Prime Capital competencies:
+Scenarios connect to Prime Capital competencies:
 
 | Competency | Related Scenarios |
 |------------|-------------------|
@@ -92,6 +96,8 @@ Scenarios connect to the six Prime Capital competencies:
 | Transaction Management | Closing 1-10, Difficult Situations 1-4 |
 | Objection Navigation | Objections 1-20 |
 | Relationship Stewardship | Difficult Situations 1-10, Closing 6-10 |
+| AML & Compliance | AML Onboarding 1-8, AML Red Flags 1-8 |
+| AgentCRM Mastery | AgentCRM Workflow Lab 1-8, AgentCRM Roleplays 1-6 |
 
 ---
 

--- a/content/lms/scenarios/agentcrm-roleplays.md
+++ b/content/lms/scenarios/agentcrm-roleplays.md
@@ -1,0 +1,314 @@
+---
+title: "AgentCRM Roleplays"
+slug: "agentcrm-roleplays"
+type: "scenario"
+description: "Six focused client conversations followed by the exact AgentCRM record-state decisions they require."
+competencies: ["agentcrm-mastery"]
+difficulty: "progressive"
+estimatedDuration: "2 hours"
+objectives:
+  - "Practise high-value buyer and seller conversations without depending on a messaging surface"
+  - "Turn each conversation into a truthful AgentCRM outcome, qualification, stage, NCD, and relationship state"
+scenarioCount: 6
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM focused conversation roleplays -->
+
+# AgentCRM Roleplays
+
+## How to use these roleplays
+
+Use each conversation to practise the human judgement that must precede a CRM update. Do not use real client information. After the conversation, complete **What changes in AgentCRM?** before marking the practice complete.
+
+The AI persona should create realistic pressure without supplying the correct process. If AI practice is unavailable, a colleague or coach can play the client from the same prompt.
+
+---
+
+## CRM-01: Buyer First Contact and Meeting Booking ⭐
+
+### Situation
+You are calling Maya within the approved practice window after her portal enquiry about a ready two-bedroom investment. The source range is AED 2–3M but is not confirmed.
+
+### Client Persona
+**Name:** Maya Bennett  
+**Style:** Busy, cautious, expects a generic listing pitch  
+**Starting truth:** Comfortable maximum AED 2.4M; cash; Business Bay or Downtown; joint decision with partner
+
+### Consultant Objective
+Create relevance, establish the buyer's direction, and book a specific review meeting without interrogating or promising property facts.
+
+### Key Challenges
+- Maya is speaking with another agency
+- Source data may be mistaken for confirmed fact
+- The consultant has only a short first-call window
+
+### Common Mistakes
+- Opening with a company pitch
+- Treating AED 2–3M as confirmed
+- Sending listings before understanding the decision frame
+- Ending with an undefined promise
+
+### Model Approach
+1. Reference the exact enquiry.
+2. Ask what Maya wants the investment to achieve.
+3. Confirm the minimum commercial frame naturally.
+4. Summarise what changed from source data.
+5. Agree a specific proposal-review meeting.
+
+### What changes in AgentCRM?
+- **Outcome:** What exact call result occurred?
+- **Facts:** Which buyer dimensions became confirmed; which remain inferred/unknown?
+- **Stage:** What evidence supports the current stage?
+- **Next action/NCD:** What meeting or deliverable, owned by whom, and when?
+- **Proposal/deal:** Is research/proposal preparation justified? Is a deal justified? Why?
+- **Relationship state:** Active, nurture, lost, or restricted?
+
+### AI Simulation Prompt
+```
+You are Maya Bennett, a busy buyer who submitted a portal enquiry for a ready two-bedroom investment in Dubai. The portal filter says AED 2–3M, but your comfortable maximum is AED 2.4M cash. You are considering Business Bay or Downtown, want net return plus occasional personal use, and decide with your partner.
+
+You expect a generic listing pitch and are speaking with another agency. Start reserved. Reveal useful facts when the consultant references your actual enquiry, asks focused questions, and avoids pressure. Correct them if they present the portal budget as confirmed. Agree to a Thursday 11:00 Dubai-time review meeting only if they summarise your needs and state what they will prepare.
+```
+
+---
+
+## CRM-02: Seller First Contact and Qualification ⭐⭐
+
+### Situation
+Karim enquired about selling a two-bedroom apartment in Dubai Marina. You need enough seller context to book a useful valuation/action-plan meeting.
+
+### Client Persona
+**Name:** Karim Saleh  
+**Style:** Direct, commercially experienced, protective of privacy  
+**Starting truth:** Tenanted; joint ownership; AED 2.7M target; one-to-three-month timing; investment rebalance; exclusivity undecided
+
+### Consultant Objective
+Understand the property, timing, motivation, authority, pricing context, and next service step without assuming instruction to list.
+
+### Key Challenges
+- Karim asks for a valuation before sharing much context
+- His co-owner must agree
+- He is comparing brokerage approaches
+
+### Common Mistakes
+- Treating target price as verified market value
+- Ignoring tenancy or co-owner authority
+- Marking listing exclusivity after a meeting booking
+- Using buyer qualification questions
+
+### Model Approach
+1. Confirm the property and reason for the enquiry.
+2. Explore timeline, occupancy, motivation, target/flexibility, and post-sale plan.
+3. Clarify ownership/decision authority and listing context.
+4. Explain what evidence the action-plan meeting will cover.
+5. Book the exact meeting and preparation step.
+
+### What changes in AgentCRM?
+- **Outcome:** Was contact made and what was agreed?
+- **Facts:** Which seller fields are confirmed, optional, or still open?
+- **Stage:** What does the meeting booking prove—and not prove?
+- **Next action/NCD:** What preparation and client meeting are due?
+- **Proposal/deal:** Is any buyer proposal or property deal justified?
+- **Relationship state:** Why does the seller opportunity remain active, nurture, lost, or restricted?
+
+### AI Simulation Prompt
+```
+You are Karim Saleh, co-owner of a tenanted two-bedroom Dubai Marina apartment. You may sell within one to three months to rebalance into smaller investments. Your target is AED 2.7M, but you are open to evidence-led discussion. Your co-owner must agree and you have not chosen an exclusive brokerage.
+
+Start direct: ask for an immediate valuation and avoid volunteering sensitive details. Share context when the consultant explains why it matters and asks seller-specific questions. Push back if they imply the target is verified value or that a meeting means you have instructed them to list. Agree to a Tuesday 10:00 action-plan meeting if the preparation sounds useful and precise.
+```
+
+---
+
+## CRM-03: Efficient Qualification Without Interrogating ⭐⭐
+
+### Situation
+A returning buyer record contains nine-month-old preferences. The client wants an efficient conversation and does not want to repeat irrelevant history.
+
+### Client Persona
+**Name:** Aisha Rahman  
+**Style:** Time-poor and analytical  
+**Starting truth:** Previous investment goal changed to a ready primary residence; AED 3.5M cash; four-month timeline; joint decision
+
+### Consultant Objective
+Validate old context, uncover the current decision frame conversationally, and secure one precise next action.
+
+### Key Challenges
+- Old structured facts look complete
+- The current goal is materially different
+- Not every qualification dimension must be asked in one call
+
+### Common Mistakes
+- Reading every field as a questionnaire
+- Assuming the old requirement remains active
+- Marking unasked fields confirmed
+- Failing to separate the new goal from the historical one
+
+### Model Approach
+1. Acknowledge the previous context and ask what changed.
+2. Follow the current goal with a few decision-changing questions.
+3. Confirm funding, timing, property frame, and decision makers.
+4. Summarise and invite correction.
+5. Agree a specific shortlist review.
+
+### What changes in AgentCRM?
+- **Outcome:** What conversation and commitment occurred?
+- **Facts:** Which old facts were corrected, retained, or left unconfirmed?
+- **Stage:** What evidence supports the current state?
+- **Next action/NCD:** What shortlist/review is due and when?
+- **Proposal/deal:** Should the old requirement close and a new one open? Is any deal justified?
+- **Relationship state:** Is the relationship active under the new goal?
+
+### AI Simulation Prompt
+```
+You are Aisha Rahman, returning after nine months. Your old record says Dubai Marina, two-bedroom investment. Your situation changed: you are relocating, want a ready primary residence in Dubai Hills or Downtown, have AED 3.5M cash, plan to act within four months, and decide with your partner.
+
+You dislike repetitive questionnaires. Respond well when the consultant acknowledges the old context and asks what changed. Correct assumptions. Share the current frame gradually and agree to a shortlist review next Tuesday only if the consultant summarises accurately and avoids trying to complete every possible field.
+```
+
+---
+
+## CRM-04: Proposal Follow-Up Meeting and Trade-Off Discussion ⭐⭐
+
+### Situation
+Maya and her partner reviewed three options. Option B has the strongest projected return but an unverified service charge and a developer-risk concern.
+
+### Client Persona
+**Name:** Maya Bennett  
+**Style:** Evidence-led and collaborative  
+**Starting truth:** Engaged with the proposal; not yet committed
+
+### Consultant Objective
+Discover what stood out, compare the trade-offs honestly, define verification work, and agree the next decision meeting.
+
+### Key Challenges
+- Engagement can be mistaken for buying intent
+- Net-return inputs are incomplete
+- Maya and her partner weigh risk differently
+
+### Common Mistakes
+- Announcing tracked view counts
+- Defending every option equally
+- Guessing the service charge or return
+- Pressing for a deal before the decision is ready
+
+### Model Approach
+1. Ask what stood out after review.
+2. Explore Maya's and her partner's different trade-offs.
+3. Separate verified facts from pending checks.
+4. Agree the comparison/verification work.
+5. Book the decision meeting.
+
+### What changes in AgentCRM?
+- **Outcome:** What did the meeting decide?
+- **Facts:** Which preference, concern, or decision-maker context changed?
+- **Stage:** What evidence supports the proposal/follow-up stage?
+- **Next action/NCD:** What verification and meeting are due?
+- **Proposal/deal:** Which property statuses change? Is a deal justified yet?
+- **Relationship state:** Why does the opportunity remain active?
+
+### AI Simulation Prompt
+```
+You are Maya Bennett in a proposal follow-up meeting with your partner. You both like Option B's projected return, but the service charge is unverified and your partner worries about developer delivery history. You reviewed the proposal carefully but have not chosen to proceed.
+
+Challenge unsupported reassurance. If the consultant asks what matters, compares risk and return honestly, and labels pending checks, agree to a short decision meeting after the evidence arrives. Pull back if they treat proposal engagement as commitment or mention tracking your exact number of views.
+```
+
+---
+
+## CRM-05: Interested Versus Committed Decision ⭐⭐⭐
+
+### Situation
+After a viewing, Maya says Unit T-1204 is the favourite. You must establish whether that is preference, a request to verify, or explicit instruction to progress.
+
+### Client Persona
+**Name:** Maya Bennett  
+**Style:** Decisive once the process is clear  
+**Starting truth:** Interested; needs written EOI-term explanation before instruction
+
+### Consultant Objective
+Clarify intent, explain the verified next step without guarantees, and obtain a precise decision that either does or does not pass the deal gate.
+
+### Key Challenges
+- “Favourite” sounds stronger than it is
+- The client needs process clarity
+- Pressure can turn genuine interest into withdrawal
+
+### Common Mistakes
+- Creating the deal before explicit instruction
+- Promising the unit is held
+- Treating a verification request as commitment
+- Ending without owner and timing
+
+### Model Approach
+1. Confirm why the property leads the comparison.
+2. Ask whether Maya wants to keep comparing, verify terms, or instruct progress.
+3. Explain the next verified step and what it does not guarantee.
+4. Record the exact instruction or lack of it.
+5. Agree responsibility and timing.
+
+### What changes in AgentCRM?
+- **Outcome:** What exact decision statement occurred?
+- **Facts:** What transaction/process concern was learned?
+- **Stage:** Interested or committed—what evidence decides?
+- **Next action/NCD:** Who verifies/explains what, and when is the next contact?
+- **Proposal/deal:** Does Unit T-1204 become a deal now? Why or why not?
+- **Relationship state:** What active opportunity remains?
+
+### AI Simulation Prompt
+```
+You are Maya Bennett after viewing Unit T-1204. Say, “This is definitely our favourite.” You are not yet instructing progress because you and your partner need the written EOI and refund terms explained.
+
+If the consultant assumes commitment or guarantees a hold, slow down and challenge them. If they clarify your intent, explain only verified next steps, and give you space to decide, ask the remaining questions. After a clear explanation, choose one of two variants: explicitly instruct them to proceed with Unit T-1204 subject to written terms, or ask for one more comparison. Do not reveal the variant early.
+```
+
+---
+
+## CRM-06: Won/Lost Opportunity and the Next Relationship Step ⭐⭐⭐
+
+### Situation
+Maya's named-property opportunity has reached an outcome. The variant is either Won, Lost because the terms fail her brief, or Lost with no current buying plan.
+
+### Client Persona
+**Name:** Maya Bennett  
+**Style:** Appreciates clarity; dislikes automatic follow-up assumptions  
+**Starting truth:** The current transaction is ending; future consent depends on the variant
+
+### Consultant Objective
+Close the opportunity truthfully, acknowledge the client decision, and agree an appropriate ongoing relationship action without keeping the transaction artificially active.
+
+### Key Challenges
+- A positive relationship can tempt the consultant to leave a dead deal open
+- A lost deal does not always mean a lost person
+- Future nurture requires a real reason and consent
+- A contact restriction overrides stewardship
+
+### Common Mistakes
+- Marking Won because the relationship stayed positive
+- Keeping Lost work open to remember the client
+- Scheduling nurture without asking
+- Treating a won transaction as the end of service
+
+### Model Approach
+1. Confirm the transaction outcome and reason.
+2. Explain the immediate close/handover step.
+3. Ask whether a specific future relationship action is useful.
+4. Agree timing and channel only when consent exists.
+5. Respect a request for no further contact immediately.
+
+### What changes in AgentCRM?
+- **Outcome:** Won, Lost, or contact restriction—what evidence supports it?
+- **Facts:** What reason, future goal, or consent decision was learned?
+- **Stage:** What deal/opportunity status must close?
+- **Next action/NCD:** Stewardship, consented nurture, no action, or DNC?
+- **Proposal/deal:** What closes and what remains historical?
+- **Relationship state:** How does the person continue—or not continue—beyond this opportunity?
+
+### AI Simulation Prompt
+```
+You are Maya Bennett at the end of the Unit T-1204 opportunity. Privately choose one variant: (1) the purchase completed and you want post-transaction help; (2) the terms failed your brief but you want to review new options next quarter; or (3) you are stopping the Dubai search and do not want follow-up.
+
+State the current outcome clearly but do not volunteer the future preference until asked respectfully. Push back if the consultant keeps the transaction open, assumes nurture, or treats a positive relationship as consent. Respond well to a truthful close and a specific, optional next relationship step.
+```

--- a/content/lms/scenarios/agentcrm-workflow-lab.md
+++ b/content/lms/scenarios/agentcrm-workflow-lab.md
@@ -1,0 +1,406 @@
+---
+title: "AgentCRM Workflow Lab"
+slug: "agentcrm-workflow-lab"
+type: "scenario"
+description: "Eight connected hands-on missions that move a buyer and seller through an AgentCRM working day."
+competencies: ["agentcrm-mastery"]
+difficulty: "progressive"
+estimatedDuration: "4 hours embedded across the modules"
+objectives:
+  - "Run connected buyer and seller journeys using only approved practice records"
+  - "Use Today, notifications, Leads, Pool, qualification, notes, NCD, properties, proposals, deals, documents, and mobile safely"
+  - "Leave visible, truthful record states after every action"
+scenarioCount: 8
+practiceType: "hands-on"
+aiRoleplayDisabled: true
+createdAt: "2026-07-14"
+updatedAt: "2026-07-15"
+---
+
+<!-- CATALYST - AgentCRM connected workflow lab -->
+
+# AgentCRM Workflow Lab
+
+## How to use this lab
+
+Complete each mission in the designated training tenant or by demonstrating the exact steps on supplied read-only records. Never use live clients, send externally, change production ownership, or upload genuine identity/transaction files.
+
+These missions are embedded in Modules 10.1–10.8 rather than extra study time. Each mission produces a visible record result. Keep evidence light: show the practice record and answer the self-check. Reflection may record what you would improve, but it does not replace the product result.
+
+### Golden-thread records
+
+- **Training Buyer Maya B.** — cash buyer; ready two-bedroom investment; up to AED 2.4M; Business Bay or Downtown; one-to-three-month timeline; joint decision with partner.
+- **Training Seller Karim S.** — co-owner; tenanted two-bedroom Dubai Marina apartment; AED 2.7M target; one-to-three-month sale window; investment rebalance; open to evidence-led offers.
+
+### Safety stop
+
+If the record, role, feature, notification permission, storage, or practice action does not match the mission, stop and explain the intended workflow. Do not improvise against live data.
+
+---
+
+## LAB-01: Relationship Map, Navigation & Mobile Setup ⭐
+
+### Situation
+It is your first AgentCRM practice session. Maya's connected practice record is available on desktop and mobile/PWA.
+
+### Client Persona
+**Record:** Training Buyer Maya B.  
+**Starting state:** Contact, buyer requirement, sample activity, and read-only linked objects available  
+**Environment:** Designated practice tenant or supplied read-only record
+
+### Consultant Objective
+Trace person → requirement → property/proposal → deal → activity/next action across desktop and mobile without editing.
+
+### Key Challenges
+- Mobile groups controls into compact tabs and sheets
+- Installation and browser notification permission are separate
+- A missing control may be role/configuration-dependent
+
+### Common Mistakes
+- Treating a new goal as a new contact
+- Testing setup on a live lead
+- Assuming a home-screen icon means notifications are enabled
+- Memorising coordinates instead of the record model
+
+### Model Approach
+1. Open the official AgentCRM desktop and supported mobile/PWA experience.
+2. Locate Today, notifications, Leads, Properties, Proposals, and Deals.
+3. Open Maya and find identity, active requirement, qualification, Activity, Properties, Proposals, Deals, and next contact date.
+4. Identify call, note, NCD, and document paths on mobile.
+5. Check notification preference and browser permission state without changing production configuration.
+6. Explain the relationship map aloud.
+
+### Visible Result
+Maya's record is unchanged. The learner can show each object area on both layouts and state the current next action.
+
+### Self-check
+- Which object represents Maya, and which represents her current goal?
+- Where would a reviewed shortlist and committed transaction belong?
+- What mobile control/location differed without changing its purpose?
+- Was any data changed? The required answer is no.
+
+---
+
+## LAB-02: Today, Notification & Speed-to-Contact Sprint ⭐
+
+### Situation
+The practice set contains Maya as a fresh eligible lead, a due follow-up, an overdue task, a future-dated lead, and one enabled in-app notification.
+
+### Client Persona
+**Primary record:** Training Buyer Maya B.  
+**Timebox:** 12 minutes  
+**Starting state:** No meaningful first response recorded
+
+### Consultant Objective
+Rank the first three actions, open the notification path, and complete one fast response loop with a truthful outcome and next contact date.
+
+### Key Challenges
+- Today and notifications use different rules
+- A future NCD hides a lead from Today before signal enrichment at the baseline
+- Desktop Done does not create underlying client evidence
+
+### Common Mistakes
+- Treating Today as a complete event list
+- Assuming a proposal view breaks through a future NCD on Today
+- Clearing a card before recording the action
+- Inventing a response-time number
+
+### Model Approach
+1. Label each item as Today, notification, or record-review work.
+2. Rank waiting/risk, fresh response, and overdue promise using context.
+3. Open the notification and verify its contact, owner, recent activity, and local time.
+4. Complete Maya's assigned simulated call outcome.
+5. Save the exact outcome, note, and justified next contact date.
+6. Confirm the resulting Today/notification/record visibility.
+
+### Visible Result
+Maya shows one exact response outcome and a matching next contact date; the learner can explain why each of the first three actions ranked where it did.
+
+### Self-check
+- Which surface produced the signal?
+- What did the record show before action?
+- What outcome and next date were saved?
+- Would a future NCD allow later engagement to re-enter Today at this baseline?
+
+---
+
+## LAB-03: Find, Filter & Claim the Right Lead ⭐⭐
+
+### Situation
+Maya is available in the controlled Pool. Karim is discoverable through seller filters but already assigned. Another trainee may win Maya's claim.
+
+### Client Persona
+**Buyer:** Training Buyer Maya B.  
+**Seller:** Training Seller Karim S.  
+**Starting state:** Maya unassigned/eligible; Karim owned
+
+### Consultant Objective
+Find both records, build useful buyer/seller filters, evaluate Maya, apply the controlled outcome, and confirm final ownership.
+
+### Key Challenges
+- Filters can hide a known record
+- Opening creates only a five-minute soft lock
+- Dialling creates a hold/attempt, not a claim
+- Only supported connected outcomes claim on the single-record flow
+
+### Common Mistakes
+- Claiming Karim despite an existing owner
+- Treating No answer as ownership
+- Creating a duplicate after a race
+- Treating a wrong number as intended-contact DNC
+
+### Model Approach
+1. Find Maya by search plus a recent buyer/source filter.
+2. Find Karim using seller/property-location context.
+3. Check duplicate risk, restrictions, history, fit, and capacity.
+4. Open Maya and identify the soft lock.
+5. Apply the supplied outcome: No answer, Callback, or controlled conflict.
+6. Confirm the final owner and phone/contact state.
+7. Stop if another trainee owns the claim.
+
+### Visible Result
+Both original records remain unique. Maya's owner/state matches the saved outcome, and Karim remains with the correct owner.
+
+### Self-check
+- Which filters answered the work question?
+- Did the outcome claim Maya? Why or why not?
+- Did a conflict occur, and how was it handled?
+- What owner and next action are visible now?
+
+---
+
+## LAB-04: Buyer First Call and CRM Save ⭐⭐
+
+### Situation
+Maya's portal range is AED 2–3M, but her actual comfortable maximum and decision context are not confirmed.
+
+### Client Persona
+**Record:** Training Buyer Maya B.  
+**Goal:** Ready two-bedroom investment with occasional personal use  
+**Starting state:** Source context present; qualification partly inferred
+
+### Consultant Objective
+Run a relevant first call, confirm the minimum useful buyer frame, book a review meeting, and save the complete post-call state.
+
+### Key Challenges
+- Source budget differs from confirmed budget
+- The first call must not become an eleven-question form
+- Maya's partner shares the decision
+
+### Common Mistakes
+- Marking portal values confirmed
+- Sending options before understanding the goal
+- Ending with “I'll send something”
+- Updating fields without outcome/note/NCD
+
+### Model Approach
+1. Prepare from source, property, history, local time, and owner.
+2. Reference the exact enquiry.
+3. Confirm purpose, AED 2.4M maximum, locations, type/bedrooms, ready preference, timing, cash funding, decision stage, and partner role naturally.
+4. Summarise the frame and book Thursday's proposal-review meeting.
+5. Save call outcome, active requirement, supported confirmations, concise note, truthful stage, and exact next contact date.
+
+### Visible Result
+Maya's buyer requirement separates confirmed from inferred facts and the record shows the meeting purpose/time, note, outcome, stage, and NCD.
+
+### Self-check
+- Which source value was corrected?
+- Which facts remain unknown or inferred?
+- What evidence supports the stage?
+- Does the note and NCD match the meeting agreement?
+
+---
+
+## LAB-05: Seller First Call, Notes, NCD & Touchpoints ⭐⭐
+
+### Situation
+Karim misses the first call and later connects. He wants an evidence-led valuation/action plan but cannot decide alone.
+
+### Client Persona
+**Record:** Training Seller Karim S.  
+**Property:** Tenanted two-bedroom Dubai Marina apartment  
+**Starting state:** Assigned; seller requirement incomplete
+
+### Consultant Objective
+Run the no-answer and connected touchpoints, complete seller qualification, write a useful note, and set the exact next contact.
+
+### Key Challenges
+- No answer and connected are separate outcomes
+- Seller essentials differ from buyer fields
+- Co-owner authority and listing exclusivity remain open
+- Internal preparation and client NCD have different purposes
+
+### Common Mistakes
+- Marking the missed call as Contacted
+- Recording target price but not authority/motivation
+- Marking exclusivity before agreement
+- Using the NCD as the comparable-research deadline
+
+### Model Approach
+1. Save the exact no-answer outcome and approved next attempt.
+2. On connection, confirm property/location/type/bedrooms, AED 2.7M target, one-to-three-month timing, motivation, post-sale plan, flexibility, occupancy, co-owner context, and undecided listing arrangement.
+3. Book Tuesday's valuation/action-plan meeting.
+4. Write the four-part useful note.
+5. Set Tuesday as the NCD and a separate comparables task if supported.
+6. Keep the opportunity active with a clear next obligation.
+
+### Visible Result
+Karim shows distinct activities, supported seller qualification, a concise decision-relevant note, and the agreed meeting NCD.
+
+### Self-check
+- What changed between the two touchpoints?
+- Which seller fields are confirmed and which remain open?
+- What evidence supports the current stage/state?
+- What internal task precedes the next client contact?
+
+---
+
+## LAB-06: Property Shortlist and Proposal ⭐⭐
+
+### Situation
+Maya is ready for a decision set. Several properties fit broadly; one high-scoring option has unverified availability and service charges.
+
+### Client Persona
+**Record:** Training Buyer Maya B.  
+**Hard constraints:** Ready 2BR, up to AED 2.4M  
+**Decision frame:** Business Bay or Downtown; net return plus occasional personal use
+
+### Consultant Objective
+Review candidates, curate three distinct options, create a client-specific draft proposal, and prepare the follow-up meeting.
+
+### Key Challenges
+- Match score is not suitability proof
+- Live facts require verification
+- Three options must support different decisions
+- Practice must stop before external send
+
+### Common Mistakes
+- Sending the top matches without review
+- Marking Suggested as Shared
+- Quoting unverified net yield or availability
+- Treating a proposal view as commitment
+
+### Model Approach
+1. Confirm Maya's active requirement.
+2. Review at least four property records against hard constraints and preferences.
+3. Select best-fit, return/value, and risk/lifestyle options.
+4. Record fit, trade-off, verification need, and decision question for each.
+5. Create and preview the draft proposal linked to Maya.
+6. Prepare the review-meeting agenda; do not send externally.
+
+### Visible Result
+Maya has a three-option draft proposal/preview with distinct rationales and labelled pending checks; match statuses remain truthful.
+
+### Self-check
+- Why is each property in the set?
+- Which live fact must be verified?
+- Which statuses changed, and what client evidence supports them?
+- What is the next meeting decision?
+
+---
+
+## LAB-07: Meeting-to-Decision Pipeline ⭐⭐⭐
+
+### Situation
+Maya and her partner compare the proposal. Karim completes his valuation meeting but still needs co-owner agreement.
+
+### Client Persona
+**Buyer:** Maya prefers Unit T-1204 but initially needs discussion and verified terms  
+**Seller:** Karim wants to review the action plan with his co-owner  
+**Starting state:** Both have completed meetings; neither begins the mission committed
+
+### Consultant Objective
+Progress both records only from evidence and distinguish Maya's interest from explicit named-property instruction.
+
+### Key Challenges
+- Positive language can sound like commitment
+- Proposal views do not prove a decision
+- Buyer and seller journeys use different evidence
+- Stage corrections must remain truthful
+
+### Common Mistakes
+- Creating a deal from “favourite”
+- Moving Karim to instructed/listed after a meeting alone
+- Leaving no owner/date after the decision
+- Refusing to correct an optimistic stage
+
+### Model Approach
+1. Record Maya's proposal-meeting trade-offs and pending checks.
+2. Keep Unit T-1204 Interested until explicit instruction exists.
+3. When the supplied variant says “Proceed with Unit T-1204,” record the instruction and next transaction step.
+4. Record Karim's meeting outcome and co-owner decision point.
+5. Choose active, consented nurture, or lost only from the variant facts.
+6. Explain each stage/state with event, evidence, obligation, owner, and date.
+
+### Visible Result
+Maya is either correctly pre-deal or ready for deal creation based on the variant. Karim's opportunity and next action reflect authority and the real service decision.
+
+### Self-check
+- What words showed interest, and what words showed commitment?
+- What evidence supports each stage/state?
+- What next obligation did each meeting create?
+- Is either record artificially advanced or left active without work?
+
+---
+
+## LAB-08: Deal, Dummy Document and Ongoing Relationship ⭐⭐⭐
+
+### Situation
+The committed variant gives Maya explicit instruction to progress Unit T-1204. Karim has no named-property buyer commitment. A later outcome card supplies Won, Lost-with-future-interest, or Do-not-contact.
+
+### Client Persona
+**Buyer:** Training Buyer Maya B.  
+**Seller:** Training Seller Karim S.  
+**Dummy file:** `TRAINING-ONLY-deal-checklist.pdf`
+
+### Consultant Objective
+Create/manage only the warranted deal, associate the correct practice document, progress the transaction truthfully, and leave both human relationships in the correct state.
+
+### Key Challenges
+- Contact, requirement, property, owner, and stage must agree
+- Identity and transaction documents have different homes
+- Won/lost opportunity and ongoing relationship are different decisions
+- DNC overrides future stewardship
+
+### Common Mistakes
+- Creating a deal for Karim's possible future reinvestment
+- Uploading a genuine client file
+- Attaching the dummy transaction file to contact identity
+- Keeping a lost deal open to remember the client
+
+### Model Approach
+1. Explain why Maya passes the commitment gate and Karim does not.
+2. Create/review Maya's deal with correct contact, requirement, Unit T-1204, owner, starting stage, and next obligation.
+3. Upload the harmless file to the authorised training transaction slot, or demonstrate without upload if storage is not approved.
+4. Confirm file name, association, visibility, and access.
+5. Apply the supplied stage/outcome evidence.
+6. For Won, begin appropriate stewardship; for Lost, close truthfully and add only a consented future action; for DNC, stop outreach.
+7. Confirm Karim's seller opportunity remains truthful and separate.
+
+### Visible Result
+Only Maya has the warranted named-property deal. The dummy file is correctly associated or safely demonstrated. Both records show a truthful opportunity outcome and ongoing relationship action.
+
+### Self-check
+- Why did the deal exist, and what property/requirement does it link?
+- Was the file contact identity or deal transaction evidence?
+- What event supports the current deal stage/status?
+- What next relationship action remains, and does consent permit it?
+
+---
+
+## Capstone: Run the Client Journey
+
+Allow 45–60 minutes. Start from the supplied Maya and Karim variants and demonstrate the eight visible outcomes without guidance.
+
+The manager/coach checks pass/fail only:
+
+- [ ] Correct lead found and prioritised.
+- [ ] Speed and ownership are appropriate.
+- [ ] Buyer/seller qualification is useful and truthful.
+- [ ] Note and next contact date are clear.
+- [ ] Meetings, properties, and proposal reflect evidence.
+- [ ] Interest and commitment are distinguished.
+- [ ] Correct deal and dummy-document decision is made.
+- [ ] Won/lost/DNC leaves the correct ongoing relationship state.
+
+If any item fails, repeat the relevant mission before unsupervised use.

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -184,10 +184,12 @@ export const config = {
       "client-discovery",
       "sales-mastery",
       "property-matching",
+      "aml-compliance",
       "transaction-management",
       "objection-navigation",
       "relationship-stewardship",
       "rera-exam-prep",
+      "agentcrm-mastery",
     ],
   },
 } as const


### PR DESCRIPTION
## What this is

Lands the rebuilt **AgentCRM Mastery (Competency 10)** curriculum and the planning package for the embedded Training Mode. Previously all working-tree only; now committed and pushed.

### Curriculum (commit `dae5e30`)
- Overview + 8 modules rebuilt around the consultant working day and the Maya B. / Karim S. golden-thread records.
- 22 labelled Agent Tools, 8 five-question quizzes, 8 workflow missions, 6 AI roleplays, pass/fail capstone.
- Scenario detail parser/UI extended so each roleplay's "What changes in AgentCRM?" self-check renders after practice.
- Registers `agentcrm-mastery` in `lib/config.ts`; updates scenario indexes/audit and project state.
- Supersedes the module structure in the 20260714 competency brief (retained for research rationale).

### Planning briefs (commit `4bd121b`)
- Reference copy of the Embedded Training Mode epic (source of truth is in the AgentCRM product repo).
- LMS-side links/media companion brief with the media capture spec + asset→module placement map.

## Validation
- `pnpm test:run` — 111 tests pass (12 files).
- `pnpm lint app/learn/scenarios` — clean.
- No LMS sync, Supabase, or product-repo mutation performed.

## Open human-review items — confirm BEFORE merge / LMS sync
- [ ] Prime Capital numeric response SLA + minimum-attempt timing.
- [ ] Enabled notification channels, push permissions, tenant event-generation limits.
- [ ] Tenant overrides to buyer/seller qualification essentials + seller rubric.
- [ ] Designated Maya/Karim practice records; whether LAB-08 may use real documents or demo-only.
- [ ] Sample one roleplay + the full capstone.

## Not in this PR
- Training Mode media (screenshots/demos) — blocked on the AgentCRM visual-capture sub-brief.
- LMS essentials generation — intentionally not run (requires authorised Supabase sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)