### PR TITLE
feat(properties): deploy signed-link detail access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,12 +172,13 @@ NEXT_PUBLIC_AHMED_STRATEGY_KIT_URL=
 # (API fetches) and client-side (iframe origin + postMessage validation).
 NEXT_PUBLIC_CRM_BASE_URL=https://crm.primecapitaldubai.com
 
-# Stable agency slug for the public property API.
-# Use "prime-capital" or "steven-leckie".
+# Legacy agency slug. No longer used for property API requests (they now key
+# off the agency UUID below), but kept for reference / any slug-based tooling.
 NEXT_PUBLIC_CRM_AGENCY_SLUG=prime-capital
 
-# Stable agency UUID for prime-capital. Tim provides.
-# Required by the widget iframe URL.
+# Stable agency UUID for prime-capital. REQUIRED — used by both the public
+# property API requests (?agency=<uuid>) and the widget iframe URL.
+# Prime value: f78d13a4-c23e-47ce-81f6-b36284891eca
 NEXT_PUBLIC_CRM_AGENCY_UUID=
 
 # AgentCRM public enquiry endpoint (server-side POST).

--- a/app/(web)/properties/[slug]/page.tsx
+++ b/app/(web)/properties/[slug]/page.tsx
@@ -19,10 +19,14 @@ import {
   formatCrmBedrooms,
   formatCrmPriceRange,
   getStatusBadge,
+  isBasicTier,
   isDevelopmentListing,
+  lockedSectionLabel,
 } from "@/lib/crm"
+import { paramReaderFromRecord, selectShareToken } from "@/lib/crm/share-token"
 import { PropertyEnquiryWidget } from "@/components/shared/property-enquiry-widget"
 import { PropertyProse } from "@/components/shared/property-enquiry-widget/property-prose"
+import { StripShareToken } from "./strip-share-token"
 
 import {
   ArrowLeftIcon,
@@ -42,12 +46,17 @@ import {
   LayersIcon,
   UtensilsIcon,
   SofaIcon,
+  LockIcon,
 } from "lucide-react"
 
-export const revalidate = 300 // Match the CRM Cache-Control max-age
+// The CRM serves property detail as Cache-Control: no-store for both anonymous
+// and token-bearing responses, so this route must never be cached. Fully dynamic
+// (it also reads searchParams for the share token).
+export const dynamic = "force-dynamic"
 
 interface PageProps {
   params: Promise<{ slug: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
 const SITE_URL = "https://primecapitaldubai.com"
@@ -68,8 +77,12 @@ function formatNoteDate(date: string): string {
   return d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
 }
 
-export async function generateMetadata({ params }: PageProps) {
+export async function generateMetadata({ params, searchParams }: PageProps) {
   const { slug } = await params
+  const token = selectShareToken(paramReaderFromRecord(await searchParams))
+  // Metadata (title/OG) only needs the public basic view; never fetch the full
+  // projection here. A token-bearing page must not be indexed or leak the token
+  // via the referrer.
   const property = await getCrmPropertyBySlug(slug)
 
   if (!property) {
@@ -79,7 +92,12 @@ export async function generateMetadata({ params }: PageProps) {
   const heroImage = property.images[0]
   const description = (property.overview ?? property.description)?.slice(0, 160) ?? ""
 
+  const tokenMeta = token.present
+    ? { robots: { index: false, follow: false }, referrer: "no-referrer" as const }
+    : {}
+
   return {
+    ...tokenMeta,
     title: property.title,
     description,
     alternates: { canonical: `/properties/${property.slug}` },
@@ -97,20 +115,27 @@ export async function generateMetadata({ params }: PageProps) {
   }
 }
 
-export default async function PropertyDetailPage({ params }: PageProps) {
+export default async function PropertyDetailPage({ params, searchParams }: PageProps) {
   const { slug } = await params
-  const property = await getCrmPropertyBySlug(slug)
+  const token = selectShareToken(paramReaderFromRecord(await searchParams))
+  const property = await getCrmPropertyBySlug(slug, { shareToken: token })
 
   if (!property) notFound()
 
   const statusBadge = getStatusBadge(property.status)
   const isDevelopment = isDevelopmentListing(property)
+  const isBasic = isBasicTier(property)
+  // Off-plan pricing reads "Starting from". In the gated basic view the
+  // unit-mix is withheld (so isDevelopment is false), but a gated response is
+  // always an off-plan listing — key off the tier too.
+  const showStartingFrom = isDevelopment || isBasic
   const propertyUrl = `${SITE_URL}/properties/${property.slug}`
   const heroImage = property.images[0]
   const galleryImages = property.images.slice(1)
 
   return (
     <div className="web-property-detail">
+      {token.present && <StripShareToken />}
       <JsonLd
         data={propertyJsonLd({
           title: property.title,
@@ -200,7 +225,7 @@ export default async function PropertyDetailPage({ params }: PageProps) {
 
             <Stack gap="sm" align="end">
               <div className="text-white/70 text-[13px]">
-                {isDevelopment ? "Starting from" : "Price"}
+                {showStartingFrom ? "Starting from" : "Price"}
               </div>
               <div className="font-headline text-[var(--web-off-white)] text-[clamp(28px,4vw,40px)]">
                 {formatCrmPriceRange(property)}
@@ -265,6 +290,8 @@ export default async function PropertyDetailPage({ params }: PageProps) {
           <Grid cols={1} className="lg:grid-cols-[2fr_1fr] gap-12">
             {/* Main content */}
             <Stack gap="xl">
+              {isBasic && <LockedDetailsCard lockedSections={property.access?.lockedSections ?? []} />}
+
               {property.notes.length > 0 && (
                 <SectionCard title="Latest Updates" icon={BellIcon}>
                   <Stack gap="sm">
@@ -578,17 +605,67 @@ export default async function PropertyDetailPage({ params }: PageProps) {
                 </Stack>
               </SectionCard>
 
-              <div className="lg:sticky lg:top-24">
+              <div id="enquiry" className="lg:sticky lg:top-24 scroll-mt-24">
                 <PropertyEnquiryWidget
                   slug={property.slug}
                   propertyName={property.title}
                   propertyUrl={propertyUrl}
+                  shareRef={token.present ? { present: true, value: token.value } : undefined}
                 />
               </div>
             </Stack>
           </Grid>
         </Container>
       </section>
+    </div>
+  )
+}
+
+/**
+ * Basic-view teaser. Renders once, at the top of the detail column, with a
+ * single primary CTA (per the CRM handoff: no repeated unlock buttons, no
+ * forced modal). The enquiry widget in the sidebar is the CTA target.
+ */
+function LockedDetailsCard({ lockedSections }: { lockedSections: string[] }) {
+  return (
+    <div className="bg-white rounded-[2px] border border-[var(--web-serenity)]/30 shadow-sm">
+      <div className="flex items-center gap-2.5 px-6 py-4 border-b border-[var(--web-serenity)]/25">
+        <LockIcon className="h-4 w-4 text-[var(--web-spruce)]" />
+        <Title
+          as="h2"
+          className="font-headline text-[var(--web-ash)] text-[15px] font-normal uppercase tracking-[0.15em] leading-none"
+        >
+          Full details on request
+        </Title>
+      </div>
+      <div className="px-6 py-6">
+        <Stack gap="md">
+          <Text className="text-[var(--web-ash)] text-[15px] font-light leading-relaxed">
+            The complete profile for this residence — pricing, plans and developer
+            information — is shared privately with qualified buyers.
+          </Text>
+
+          {lockedSections.length > 0 && (
+            <Grid cols={2} className="gap-3">
+              {lockedSections.map((section) => (
+                <div key={section} className="flex items-center gap-2">
+                  <LockIcon className="h-3.5 w-3.5 text-[var(--web-spruce)] shrink-0" />
+                  <Text className="text-[var(--web-spruce)] text-[14px] font-light">
+                    {lockedSectionLabel(section)}
+                  </Text>
+                </div>
+              ))}
+            </Grid>
+          )}
+
+          <a
+            href="#enquiry"
+            className="inline-flex items-center justify-center self-start px-6 py-3 rounded-[2px] text-[11px] uppercase tracking-[0.2em] bg-[var(--web-spruce)] text-[var(--web-off-white)] hover:bg-[var(--web-ash)] transition-colors"
+          >
+            Request full details
+          </a>
+        </Stack>
+      </div>
     </div>
   )
 }

--- a/app/(web)/properties/[slug]/strip-share-token.tsx
+++ b/app/(web)/properties/[slug]/strip-share-token.tsx
@@ -1,0 +1,36 @@
+/**
+ * CATALYST - Strip Share Token From URL
+ *
+ * After the server has rendered the (full) detail using the token, remove the
+ * `ref`/`share` param from the visible address bar so it isn't shared onward,
+ * bookmarked, or copied. The token has already been passed into the enquiry
+ * widget as a prop, so scrubbing the URL cannot break attribution.
+ *
+ * UTM params are intentionally left intact.
+ */
+
+"use client"
+
+import { useEffect } from "react"
+
+export function StripShareToken() {
+  useEffect(() => {
+    const url = new URL(window.location.href)
+    let changed = false
+    for (const key of ["ref", "share"]) {
+      if (url.searchParams.has(key)) {
+        url.searchParams.delete(key)
+        changed = true
+      }
+    }
+    if (changed) {
+      window.history.replaceState(
+        window.history.state,
+        "",
+        url.pathname + url.search + url.hash,
+      )
+    }
+  }, [])
+
+  return null
+}

--- a/app/(web)/properties/page.tsx
+++ b/app/(web)/properties/page.tsx
@@ -28,7 +28,9 @@ import { PropertiesGrid } from "./_components/properties-filter"
 import { PropertiesFilterBar } from "./_components/properties-filter-bar"
 import propertiesImage from "@/public/images/hero/properties.jpg"
 
-export const revalidate = 300 // Match CRM Cache-Control max-age
+// The CRM property list is Cache-Control: no-store; do not hold a website ISR
+// cache of anonymous property data. This page is dynamic (also reads filters).
+export const dynamic = "force-dynamic"
 
 export const metadata = {
   title: "Properties",

--- a/catalyst/briefs/_review-20260715_offplan-signed-link-gating.md
+++ b/catalyst/briefs/_review-20260715_offplan-signed-link-gating.md
@@ -1,0 +1,248 @@
+# Brief: Gated Off-Plan Listings + Signed-Link Unlock
+
+**ID:** WEB-110
+**Status:** In Review (website side implemented; release gated on live CRM API)
+**Priority:** P1
+**Surface:** Web + AgentCRM (cross-system)
+**Estimate:** ~1 day website / ~3-5 days AgentCRM
+**Tags:** properties, crm, security, lead-gen
+
+---
+
+## Implementation status (website side — 2026-07-17)
+
+Website changes implemented and verified locally (typecheck via build, 140 tests pass, lint clean, production build clean). **Do NOT deploy until the new AgentCRM sharing API is live on `crm.primecapitaldubai.com` and the live-contract checks pass** (per CRM handoff v3).
+
+Changed / added:
+- `lib/config` env — property requests now key off `config.crm.agencyUuid` (`.env.local` already set to `f78d13a4-…`; `.env.example` updated).
+- `lib/crm/client.ts` — `agency=<uuid>`; `getCrmPropertyBySlug(slug, { shareToken })` forwards the token under its landing key and forces `no-store`; error logs scrub `ref`/`share`; `access` mapped to camelCase (absent = full).
+- `lib/crm/facets.ts` — agency UUID.
+- `lib/crm/types.ts` — `CrmAccess`/`CrmPropertyAccess`, `isBasicTier`, `lockedSectionLabel`.
+- `lib/crm/share-token.ts` (new) — `selectShareToken` (ref-wins-even-if-blank) + `paramReaderFromRecord`.
+- `app/(web)/properties/[slug]/page.tsx` — resolves token from `searchParams`; fetches full when present; `access.tier` branch; basic-view `LockedDetailsCard` with one `#enquiry` CTA; `noindex` + `referrer: no-referrer` when tokened; passes `shareRef` prop to the widget; renders `StripShareToken`. Route is now `ƒ` dynamic (token responses never cached).
+- `app/(web)/properties/[slug]/strip-share-token.tsx` (new) — `history.replaceState` strips `ref`/`share` after render.
+- `property-enquiry-widget.tsx` — `shareRef` prop is the sole token source (no URL read); `pageUrl` sanitised so the token can't leak into the lead record.
+- Tests: `tests/crm/{share-token,client,property-enquiry-widget,pdp-enquiry-channel,access-helpers}.test.ts(x)` — token precedence, agency UUID, no-store, log scrubbing, null-slug fallback, forbidden fields, access mapping, prop-sourced attribution, single-channel guard.
+
+Deferred to live verification (can't be exercised under jsdom / stale API): end-to-end basic↔full render against real gated payloads, CRM-minted basic/full/revoked tokens, and attribution landing on the correct CRM contact.
+
+### Review round 1 — items closed (2026-07-17)
+
+1. **Removed the anonymous 300s property cache.** `crmFetch` is now always `cache: "no-store"` (no ISR opt-in); the CRM contract is `no-store` for anonymous AND token responses, so a website TTL could keep a full response public after the default flips to basic. Removed `export const revalidate = 300` from `/properties` and `/properties/[slug]` (now `force-dynamic`). **Consequence:** any page embedding property data is now dynamic — `/`, `/contact`, `/properties`, `/properties/[slug]` render as `ƒ`. CRM request load increases (as the CRM team noted). Added `unstable_rethrow` in `crmFetch` so Next's `DYNAMIC_SERVER_USAGE` bailout isn't swallowed/logged as an upstream failure.
+2. **Hard token response headers.** `proxy.ts` (edge middleware — the repo uses `proxy.ts`, not `middleware.ts`) stamps `Cache-Control: private, no-store` + `Referrer-Policy: no-referrer` on token-bearing `/properties*` responses, via the pure `shareTokenResponseHeaders` helper (`lib/crm/token-response-headers.ts`). Unit-tested. Live header inspection remains part of the CRM-deploy gate (acceptance #12).
+3. **Full `tsc --noEmit` green.** Root cause of the earlier JPG errors was a pre-build stale state (missing `.next/types` broke `next-env.d.ts`'s image-types reference); with generated types present it is 0 errors, stable with or without `.next/types`. Added a canonical `typecheck` script (`tsc --noEmit`). Verified: `typecheck` = 0 errors, 145 tests pass, repo lint clean, production build compiles.
+
+---
+
+## Objective
+
+Off-plan properties from AgentCRM show a **basic public listing** by default on `primecapitaldubai.com`. When an agent shares a **signed link** (direct link, proposal, or campaign) from AgentCRM, the recipient / holder of that link sees the **full listing**. Secondary/ready listings are unaffected (always full).
+
+**Basic listing includes:** Name, Location + Address, Price From (not range), Bedrooms, Unit Sizes (From), About This Property, Location & Views.
+
+---
+
+## Background
+
+The website is a thin consumer of the AgentCRM public API (`crm.primecapitaldubai.com/api/public/properties`, agency `prime-capital`). All property data is fetched live per request via `lib/crm/client.ts` with Next ISR (300s) as the only cache. Today the PDP (`app/(web)/properties/[slug]/page.tsx`) pulls the full `CrmPropertyFull` for every off-plan property and renders each section conditionally.
+
+There is currently **no** share-link, proposal, or token mechanism in this repo. AgentCRM previously had `contact_share_tokens` + `campaigns` tables (dropped in `supabase/migrations/20260324999999_cleanup_crm_tables.sql`). The enquiry widget already forwards a `ref` attribution param (`lib/crm/widget.ts`) — the intended hook for share tokens.
+
+---
+
+## Core Decision: Gate at the CRM, not the website
+
+There are two ways to gate, and only one is acceptable:
+
+- **Website-side hiding (REJECT):** CRM keeps returning full data; the website hides fields unless a token is present. Fake security — every gated field still sits in the JSON payload, visible in the Network tab / view-source. Defeats the purpose.
+- **CRM-side projection (REQUIRED):** The CRM's public detail endpoint returns a **basic projection** for off-plan by default, and the **full projection** only when a valid signed token is presented. Gated data never leaves the CRM without authorization.
+
+Consequence: ~80% of the work is on AgentCRM. The website change is small — thread a token through, and render locked sections as lead-gen teasers.
+
+---
+
+## Field Split (whitelist owned by AgentCRM)
+
+| Section / field | Basic (default) | Full (unlocked) |
+|---|---|---|
+| Name / title | yes | yes |
+| Location (area) + Address | yes | yes |
+| Price From (`priceFrom` only, no `priceTo`) | yes | full range |
+| Bedrooms | yes | yes |
+| Unit size From (`sqft` / size min only) | yes | full range |
+| About This Property (`overview` / `description`) | yes | yes |
+| Location & Views (`locationAndViews`) | yes | yes |
+| Hero image | yes (1) | yes |
+| Payment Plan, DLD waiver, post-handover | — | yes |
+| Available Unit Types table (`unitTypes[]`) | — | yes |
+| Developer details, completion date, construction % | — | yes |
+| Finishing, Kitchen, Furnishings, Reasons to Invest | — | yes |
+| Documents (brochure, factsheet, master plan, video, 3D) | — | yes |
+| Notes / Latest Updates | — | yes |
+| Full gallery, Amenities, Key Features | OPEN QUESTION (§Open) | yes |
+
+The CRM detail response also returns access metadata so the website can render locked affordances rather than silently omitting:
+
+```jsonc
+"access": {
+  "tier": "basic" | "full",
+  "gated": true,
+  "lockedSections": ["payment_plan", "unit_types", "developer", "documents"]
+}
+```
+
+`lockedSections` lets the PDP show a blurred teaser + "Request full details" CTA — turning the gate into a lead funnel rather than a dead end.
+
+---
+
+## Signed-Link Mechanism
+
+**Token: opaque, DB-backed (recommended over stateless JWT).** Direct links, proposals, and campaigns all want per-recipient tracking, revocation, and expiry, which stateless JWTs can't give cleanly. One row per share link:
+
+```
+property_share_links(
+  token          text primary key,   -- >=128-bit random, URL-safe
+  property_id    uuid,
+  agent_id       uuid,               -- sharing agent (attribution)
+  contact_id     uuid null,          -- recipient, if known (proposal)
+  channel        enum('direct','proposal','campaign'),
+  scope          text default 'full',
+  expires_at     timestamptz null,   -- per-channel policy
+  revoked_at     timestamptz null,
+  max_uses       int null,
+  use_count      int default 0,
+  created_at     timestamptz
+)
+```
+
+(Stateless alternative: HMAC/JWT `{propertyId, scope, exp, jti}` signed with a CRM secret, `jti` checked against a revocation table. DB-opaque is simpler and matches the tracking Prime will want.)
+
+**Link shape:** `https://primecapitaldubai.com/properties/{slug}?share={token}`
+
+**Channels / lifecycle:**
+- **Direct link** — agent clicks "Copy full link" on a property; long-lived, revocable.
+- **Proposal** — bound to a `contact_id`; typically 30-90 day expiry.
+- **Campaign** — issued per campaign; expiry tied to campaign window; may set `max_uses`.
+
+**Attribution bonus:** the token also identifies the sharing agent + recipient. Pass it through as the widget `ref` param → any enquiry the recipient submits is auto-attributed to the sharing agent and linked to the proposal/campaign. One token does gating and attribution.
+
+---
+
+## Request Flow
+
+**Default (no token):** `/properties/{slug}` → website fetch (no auth) → CRM returns basic projection → cacheable (ISR 300), indexable.
+
+**Unlocked (`?share=token`):** `/properties/{slug}?share=T` → website forwards token to CRM (`Authorization: Bearer T` or `?share=T`) with `cache: 'no-store'` → CRM validates (lookup + not expired + not revoked + under max_uses), logs an open event, returns full projection → website renders full, sets `noindex`.
+
+**Invalid/expired token:** CRM returns basic + `access.tier:"basic"` with a reason → website shows basic view plus a subtle "This link has expired — request a new one" notice.
+
+---
+
+## AgentCRM Tasks (the bulk of the work)
+
+1. **Projection layer** on `GET /api/public/properties/{slug}` (+ list + facets): off-plan default = basic whitelist; valid token = full. Secondary listings unchanged. The whitelist is defined server-side (single source of truth).
+2. **`access` metadata + `lockedSections`** in the detail response.
+3. **Token issuance** — `property_share_links` table + agent UI ("Copy public link" / "Copy full link", "Generate proposal link", campaign link generation).
+4. **Token validation** — accept via header or `?share=`, verify lookup + expiry + revocation + max_uses, increment `use_count`, log an open event (recipient analytics).
+5. **Attribution** — when a token is present on a downstream enquiry (`ref`), tie the lead to the token's agent / contact / campaign.
+6. **Ops** — rate-limit the token path to deter enumeration; keep default responses `max-age=300` but mark token responses `no-store`.
+
+---
+
+## Contract locked by AgentCRM (2026-07-17)
+
+The CRM team returned the finalized contract — see `.context/agentcrm-signed-link-gating-brief.md` (their handoff). CRM-side design is settled; the website tasks below are updated to match it. Key deltas from the original draft:
+
+- **Agency param is a UUID**, not the `prime-capital` slug: `agency=f78d13a4-c23e-47ce-81f6-b36284891eca`. Confirmed the **same** UUID the widget already uses — set `NEXT_PUBLIC_CRM_AGENCY_UUID=f78d13a4-c23e-47ce-81f6-b36284891eca` and switch the property-request `agency` param from `config.crm.agencySlug` to `config.crm.agencyUuid`.
+- **Enquiry channel resolved: the PDP iframe widget is the single owner.** Do NOT add a second submission via `app/api/leads/route.ts` for a PDP enquiry. The widget posts internally to `/api/public/property-chat/lead` on the CRM origin, canonicalises `ref`, and resolves attribution server-side — no Bearer key touches the browser. Its response is `{success, contactId, enquiryId, created, readiness}` with **no `attributed` flag**; verify attribution on the resulting CRM contact/enquiry. The server-side Bearer route (`/api/public/enquiry`) stays authoritative only for native non-widget forms.
+- **Dual token param**: accept both `?ref=` and `?share=`; **`ref` wins even when blank**. Canonicalise to `ref` when building the widget URL. Do NOT map it to UTM or ManyChat fields.
+- **`Referrer-Policy: no-referrer`** on token-bearing pages (stricter than the site global).
+- **Scrub the token from the visible URL** with `history.replaceState` after the server fetch; retain it only in page state for enquiry submission.
+- **No page/RSC caching** for token requests (not just `no-store` on the fetch). Never log the token to Sentry/analytics. Expect `Cache-Control: private, no-store` from the API.
+- **Secondary listings** are full-access but unit identity is never public — see the Secondary-property rule below.
+- Detail links must use **`slug ?? id`** (secondary listings can have `slug: null`).
+
+## Website (jakarta) Tasks
+
+1. `lib/crm/client.ts` —
+   - Switch the `agency` query param from `config.crm.agencySlug` to `config.crm.agencyUuid`. Set `NEXT_PUBLIC_CRM_AGENCY_UUID=f78d13a4-c23e-47ce-81f6-b36284891eca` in the source `.env.local` (root project dir — do not edit the workspace copy) and `.env.example`.
+   - `getCrmPropertyBySlug(slugOrId, { shareToken })` and the list fetch: when a token is present, append it to the CRM request and use `cache: 'no-store'`.
+   - In the error/`trackError` path, scrub the token from any URL sent to Sentry.
+2. `lib/crm/types.ts` — add the `access` block (`tier`, `gated`, `locked_sections`, `reason`) to the list item AND detail types; treat missing `access` as full/legacy (backward compatible).
+3. `lib/crm/browse-filters.ts` (or a small shared parser) — read the share token: `ref` first (wins even when blank), else `share`.
+4. `app/(web)/properties/[slug]/page.tsx` —
+   - Read the token from `searchParams`; pass to the fetch.
+   - Branch on `access.tier`: `full` renders all returned sections; `basic` renders teaser fields + `locked_sections` unlock/contact UI. Never render null gated values as `0` / "unknown" / empty rows.
+   - When a token is present: force dynamic rendering (opt out of `revalidate = 300`), set `robots: { index: false }` and `Referrer-Policy: no-referrer`.
+5. Token lifecycle on the client — pass the token from the server render into page state as a **prop**, `history.replaceState` to strip `ref`/`share` from the URL. **Gotcha:** `PropertyEnquiryWidget` currently reads `ref` from `window.location.search` (`property-enquiry-widget.tsx:112`). Once the URL is scrubbed that read returns nothing, so the token must be threaded to the widget as a prop, not re-read from the URL — and the widget must also fall back to `share` when `ref` is absent.
+6. Enquiry (PDP) — keep the iframe widget as the sole path; do not also POST via `/api/leads`. Append the canonical token to the widget URL as `ref` (prefer `property.embedUrl` + set `ref`, per the CRM sample; our `buildWidgetUrl` already maps `ref` and uses `agencyUuid`, which is equivalent once the env UUID is set). Verify attribution on the CRM contact — the widget response has no `attributed` flag.
+7. Detail-link builders — use `property.slug ?? property.id`:
+   - `app/(web)/properties/_components/properties-filter.tsx:148`
+   - `app/sitemap.ts:44` (or filter null-slug rows from the sitemap)
+8. Browse cards — off-plan cards show "Price from" (drop `priceTo`); handle `access.tier: "basic"` list items.
+
+## Secondary-property rule (new)
+
+Secondary/ready listings are full-access, but **unit identity is never public**. The website must tolerate and never re-introduce it:
+
+- No `unit_number` / `unitNumber` — the PDP sidebar already guards `{property.unitNumber && …}`; keep it. Never source a unit number from CMS, URL, analytics, or cache.
+- Redacted unit-identifying prose and media URLs (accept as-is).
+- `slug: null` → route via UUID (the `slug ?? id` fix above).
+
+---
+
+## Build Sequencing: AgentCRM first or website first?
+
+**Recommendation: AgentCRM first — specifically the projection (the gate) — then website + CRM token work in parallel against a frozen contract.**
+
+The dependency is directional (website consumes what the CRM produces), and the gate is security-critical, so it cannot ship from the website alone. Never ship website-side hiding as a stopgap — it leaks the full payload.
+
+Key insight: **the CRM projection alone delivers the gate with zero website deploy.** Because the PDP already renders sections conditionally, the moment the CRM starts returning basic-only for off-plan, those sections simply disappear on the live site. No leak, graceful degradation.
+
+**Phase 0 — Contract lock (both, day 1).** Agree and write down the JSON shape: `access` block, `lockedSections` keys, token param name, header-vs-query, error semantics. This unblocks parallel work — the website builds against a fixture of the agreed contract immediately.
+
+**Phase 1 — CRM: the gate (Tasks 1-2).** Ship basic projection as the off-plan default. Gating is now LIVE, safely, with no website change.
+
+**Phase 2 — parallel.**
+- CRM: token issuance (3) + validation → full (4).
+- Website: all website tasks against the frozen contract, testable against CRM staging as soon as Task 4 exists. Merge is safe because with no token nothing changes.
+
+**Phase 3 — integrate.** End-to-end unlock flow on staging; attribution (5); verify `no-store` + `noindex`; verify cache isolation (a token response must never land on a cache key a tokenless visitor can read).
+
+**Compatibility guarantees that make either deploy order safe:**
+- Website treats missing `access` as full/legacy → a website deploy before the CRM changes breaks nothing.
+- CRM flipping the default to basic before the website ships → PDP degrades gracefully (sections vanish), still no leak.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Off-plan PDP with no token renders only the 7 basic sections; gated fields are absent from the JSON payload (verify in Network tab)
+- [ ] Off-plan PDP with a valid `?share` token renders the full listing
+- [ ] Expired / revoked / invalid token falls back to basic view with a notice
+- [ ] Token responses are `no-store` on both sides and never served from cache to a tokenless visitor
+- [ ] Token URLs return `noindex` and never appear in the sitemap
+- [ ] Secondary/ready listings are unchanged (always full)
+- [ ] An enquiry from a tokenised link is attributed to the sharing agent / campaign
+- [ ] Off-plan browse cards show "Price from" (no range)
+- [ ] Missing `access` metadata is treated as full (no regression on legacy responses)
+
+---
+
+## Open Questions (post-handover)
+
+Resolved by the CRM handoff (v2, 2026-07-17): field split, `access` shape, token degradation, issuance, agency UUID (same as the widget's, env `NEXT_PUBLIC_CRM_AGENCY_UUID`), and enquiry channel (iframe widget is the sole PDP owner) are all settled. Remaining:
+
+1. **CTA prominence** — should the basic view push "Request full details" hard (lead-gen), or stay a clean minimal listing? (Product/design call for Prime.)
+
+---
+
+## Release blocker (2026-07-17)
+
+The new AgentCRM sharing API build is **not yet deployed** to `https://crm.primecapitaldubai.com` — the DB migration is live, but the CRM domain was still serving the previous API build during the 2026-07-17 smoke test. We can build the website changes now, but **cannot verify or release** end-to-end until CRM redeploys. Do not flip the `agency` param to the UUID in production until the new build is confirmed serving. Get a redeploy ETA from the CRM team.
+
+## Risks
+
+- **Cache correctness is the top risk.** A token response written to a shared cache key leaks full data to the public. Enforce `no-store` on the fetch AND opt the page out of ISR/RSC caching for token requests.
+- **Referer leakage** — a query-param token can leak via the `Referer` header to third-party assets. Keep `Referrer-Policy: strict-origin-when-cross-origin` (already set in `next.config.ts`) and avoid third-party requests on the PDP that carry the full URL.
+- **Cross-team coordination** — the CRM is a separate system/team. The Phase 0 contract lock is the critical unblocker; slippage there blocks both sides.

--- a/components/shared/property-enquiry-widget/property-enquiry-widget.tsx
+++ b/components/shared/property-enquiry-widget/property-enquiry-widget.tsx
@@ -44,6 +44,14 @@ interface PropertyEnquiryWidgetProps {
   propertyName?: string
   /** Canonical PDP URL — sent with the lead. */
   propertyUrl?: string
+  /**
+   * Server-resolved share token (canonical `ref`). Passed as a prop — NOT read
+   * from the URL — because the PDP scrubs `ref`/`share` from the address bar via
+   * history.replaceState, which can run before this widget mounts. Reading the
+   * URL here would silently drop attribution. `present` with a blank value means
+   * an explicit blank `ref` (no token); we forward nothing in that case.
+   */
+  shareRef?: { present: boolean; value: string }
   /** Optional pre-fill for known visitors. */
   prefill?: { name?: string; email?: string; phone?: string }
   /** Title attribute for accessibility. */
@@ -97,9 +105,26 @@ declare global {
   }
 }
 
-function readAttributionParams(): Pick<
+/**
+ * Current page URL with the share token stripped. Sent to the CRM as the lead's
+ * page_url, so it must not carry `ref`/`share` — otherwise the token leaks into
+ * the lead record even though we scrub the address bar.
+ */
+function cleanPageUrl(fallback?: string): string | undefined {
+  if (typeof window === "undefined") return fallback
+  const url = new URL(window.location.href)
+  url.searchParams.delete("ref")
+  url.searchParams.delete("share")
+  return url.toString()
+}
+
+/**
+ * Read UTM params from the URL. The share token (`ref`) is deliberately NOT
+ * read here — it arrives as a prop and the URL is scrubbed of it on mount.
+ */
+function readUtmParams(): Pick<
   WidgetUrlParams,
-  "utmSource" | "utmMedium" | "utmCampaign" | "utmContent" | "utmTerm" | "ref"
+  "utmSource" | "utmMedium" | "utmCampaign" | "utmContent" | "utmTerm"
 > {
   if (typeof window === "undefined") return {}
   const search = new URLSearchParams(window.location.search)
@@ -109,7 +134,6 @@ function readAttributionParams(): Pick<
     utmCampaign: search.get("utm_campaign") ?? undefined,
     utmContent: search.get("utm_content") ?? undefined,
     utmTerm: search.get("utm_term") ?? undefined,
-    ref: search.get("ref") ?? undefined,
   }
 }
 
@@ -132,6 +156,7 @@ export function PropertyEnquiryWidget({
   slug,
   propertyName,
   propertyUrl,
+  shareRef,
   prefill,
   title = "Enquire about this property",
 }: PropertyEnquiryWidgetProps) {
@@ -141,18 +166,22 @@ export function PropertyEnquiryWidget({
 
   // Build the iframe URL on mount so we can fold in UTM params from
   // window.location.search before the iframe loads (single load, no flash).
+  // The share token comes from the `shareRef` prop, never the URL — a
+  // present-but-blank ref forwards nothing (buildWidgetUrl drops empty values).
+  const shareRefValue = shareRef?.present ? shareRef.value : undefined
   useEffect(() => {
     const params: WidgetUrlParams = {
       property: slug,
       propertyName,
       propertyUrl,
-      pageUrl: typeof window !== "undefined" ? window.location.href : propertyUrl,
-      ...readAttributionParams(),
+      pageUrl: cleanPageUrl(propertyUrl),
+      ...readUtmParams(),
+      ref: shareRefValue || undefined,
       ...(prefill ?? {}),
     }
     // eslint-disable-next-line react-hooks/set-state-in-effect -- defer-mount: read window once on the client.
     setSrc(buildWidgetUrl(params))
-  }, [slug, propertyName, propertyUrl, prefill])
+  }, [slug, propertyName, propertyUrl, shareRefValue, prefill])
 
   // postMessage bridge: ready + resize + analytics. Always validate origin.
   // Height write is imperative via ref so React reconciliation can't stutter

--- a/lib/crm/client.ts
+++ b/lib/crm/client.ts
@@ -16,36 +16,54 @@
 
 import "server-only"
 
+import { unstable_rethrow } from "next/navigation"
+
 import { config } from "@/lib/config"
 import { trackError } from "@/lib/error-tracking"
 import type {
+  CrmAccess,
   CrmListFilters,
   CrmListResponse,
   CrmProperty,
+  CrmPropertyAccess,
   CrmPropertyDetail,
   CrmPropertyFull,
   CrmPropertyListItem,
 } from "./types"
+import type { SelectedShareToken } from "./share-token"
 
-const REVALIDATE_SECONDS = 300 // CRM advertises Cache-Control max-age=300
 const CRM_PARAM_MAX_LENGTH = 200
 
-interface FetchOptions {
-  /** Skip the in-memory ISR cache for this request (e.g., previews). */
-  noCache?: boolean
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- reserved for future per-request options.
+interface FetchOptions {}
 
 function isCrmConfigured(): boolean {
   return Boolean(
     config.crm.baseUrl &&
-      config.crm.agencySlug &&
-      config.crm.agencySlug.length <= CRM_PARAM_MAX_LENGTH,
+      config.crm.agencyUuid &&
+      config.crm.agencyUuid.length <= CRM_PARAM_MAX_LENGTH,
   )
+}
+
+/**
+ * Redact share tokens before a URL reaches error reporting. Token-bearing
+ * detail URLs must never appear in Sentry breadcrumbs.
+ */
+function scrubUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    for (const key of ["ref", "share"]) {
+      if (url.searchParams.has(key)) url.searchParams.set(key, "REDACTED")
+    }
+    return url.toString()
+  } catch {
+    return rawUrl
+  }
 }
 
 function buildListUrl(filters: CrmListFilters | undefined): string {
   const url = new URL("/api/public/properties", config.crm.baseUrl)
-  url.searchParams.set("agency", config.crm.agencySlug)
+  url.searchParams.set("agency", config.crm.agencyUuid)
 
   if (filters?.q) url.searchParams.set("q", filters.q)
   if (filters?.listingType) url.searchParams.set("listing_type", filters.listingType)
@@ -74,23 +92,37 @@ function buildListUrl(filters: CrmListFilters | undefined): string {
   return url.toString()
 }
 
-function buildDetailUrl(slugOrId: string): string {
+function buildDetailUrl(slugOrId: string, shareToken?: SelectedShareToken): string {
   const url = new URL(`/api/public/properties/${encodeURIComponent(slugOrId)}`, config.crm.baseUrl)
-  url.searchParams.set("agency", config.crm.agencySlug)
+  url.searchParams.set("agency", config.crm.agencyUuid)
+  // Forward the token under the key the visitor landed with. A present-but-blank
+  // value is preserved so the CRM can distinguish "no token" from "blank ref".
+  if (shareToken?.present) url.searchParams.set(shareToken.key, shareToken.value)
   return url.toString()
 }
 
-async function crmFetch<T>(url: string, opts: FetchOptions = {}): Promise<T | null> {
-  const init: RequestInit & { next?: { revalidate?: number; tags?: string[] } } = {
+async function crmFetch<T>(url: string): Promise<T | null> {
+  // Always no-store. The CRM property list/detail contract is
+  // `Cache-Control: no-store` for BOTH anonymous and token-bearing responses —
+  // a website ISR/TTL cache could keep a full anonymous response public after
+  // the agency flips its default to basic. Do not reintroduce a revalidate cache
+  // until AgentCRM ships a safe anonymous-cache + invalidation contract.
+  const init: RequestInit = {
     headers: { Accept: "application/json" },
-    ...(opts.noCache ? { cache: "no-store" } : { next: { revalidate: REVALIDATE_SECONDS } }),
+    cache: "no-store",
   }
+
+  const safeUrl = scrubUrl(url)
 
   let res: Response
   try {
     res = await fetch(url, init)
   } catch (error) {
-    trackError(error, { context: "crm", url, action: "fetch" })
+    // A no-store fetch during static generation makes the route dynamic; Next
+    // signals that by throwing. Re-throw its control-flow errors (also
+    // notFound/redirect) instead of swallowing them as upstream failures.
+    unstable_rethrow(error)
+    trackError(error, { context: "crm", url: safeUrl, action: "fetch" })
     return null
   }
 
@@ -98,21 +130,36 @@ async function crmFetch<T>(url: string, opts: FetchOptions = {}): Promise<T | nu
   if (res.status === 429) {
     trackError(new Error(`CRM rate limited (${res.status})`), {
       context: "crm",
-      url,
+      url: safeUrl,
       retryAfter: res.headers.get("Retry-After"),
     })
     return null
   }
   if (!res.ok) {
-    trackError(new Error(`CRM responded ${res.status}`), { context: "crm", url, status: res.status })
+    trackError(new Error(`CRM responded ${res.status}`), {
+      context: "crm",
+      url: safeUrl,
+      status: res.status,
+    })
     return null
   }
 
   try {
     return (await res.json()) as T
   } catch (error) {
-    trackError(error, { context: "crm", url, action: "parse" })
+    trackError(error, { context: "crm", url: safeUrl, action: "parse" })
     return null
+  }
+}
+
+/** Map the CRM access block to camelCase. Absent access = full (legacy). */
+function mapAccess(access: CrmAccess | null | undefined): CrmPropertyAccess | null {
+  if (!access) return null
+  return {
+    tier: access.tier,
+    gated: Boolean(access.gated),
+    lockedSections: access.locked_sections ?? [],
+    reason: access.reason ?? null,
   }
 }
 
@@ -161,6 +208,8 @@ function mapListItem(row: CrmPropertyListItem): CrmProperty {
 
     embedUrl: row.embed_url,
     embedHtml: row.embed_html,
+
+    access: mapAccess(row.access),
   }
 }
 
@@ -219,11 +268,10 @@ const EMPTY_RESULT: GetCrmPropertiesResult = {
  */
 export async function getCrmProperties(
   filters?: CrmListFilters,
-  opts?: FetchOptions
 ): Promise<GetCrmPropertiesResult> {
   if (!isCrmConfigured()) return EMPTY_RESULT
 
-  const data = await crmFetch<CrmListResponse>(buildListUrl(filters), opts)
+  const data = await crmFetch<CrmListResponse>(buildListUrl(filters))
   if (!data) return EMPTY_RESULT
 
   return {
@@ -255,10 +303,7 @@ export async function getAllCrmProperties(
   const all: CrmProperty[] = []
   let cursor = filters?.cursor
   for (let page = 0; page < maxPages; page++) {
-    const data = await crmFetch<CrmListResponse>(
-      buildListUrl({ ...filters, cursor, limit: 50 }),
-      opts,
-    )
+    const data = await crmFetch<CrmListResponse>(buildListUrl({ ...filters, cursor, limit: 50 }))
     if (!data) break
     all.push(...data.data.map(mapListItem))
     if (!data.pagination.has_more || !data.pagination.next_cursor) break
@@ -278,12 +323,14 @@ export async function getAllCrmProperties(
  */
 export async function getCrmPropertyBySlug(
   slugOrId: string,
-  opts?: FetchOptions
+  opts?: FetchOptions & { shareToken?: SelectedShareToken }
 ): Promise<CrmPropertyFull | null> {
   if (!isCrmConfigured()) return null
   if (!slugOrId || slugOrId.length > CRM_PARAM_MAX_LENGTH) return null
 
-  const response = await crmFetch<CrmDetailResponse>(buildDetailUrl(slugOrId), opts)
+  // All CRM fetches are no-store (see crmFetch), so anonymous and token-bearing
+  // detail responses are equally uncached — the token just unlocks more fields.
+  const response = await crmFetch<CrmDetailResponse>(buildDetailUrl(slugOrId, opts?.shareToken))
   if (!response) return null
   const row = "data" in response ? response.data : response
   if (!row) return null

--- a/lib/crm/facets.ts
+++ b/lib/crm/facets.ts
@@ -42,7 +42,7 @@ const EMPTY_FACETS: PublicPropertyFacets = {
 }
 
 function isCrmConfigured(): boolean {
-  return Boolean(config.crm.baseUrl && config.crm.agencySlug)
+  return Boolean(config.crm.baseUrl && config.crm.agencyUuid)
 }
 
 function sortFacetOptions(options: PublicPropertyFacetOption[]): PublicPropertyFacetOption[] {
@@ -108,7 +108,7 @@ export async function fetchPropertyFacets(
   if (!isCrmConfigured()) return EMPTY_FACETS
 
   const url = new URL("/api/public/properties/facets", config.crm.baseUrl)
-  url.searchParams.set("agency", config.crm.agencySlug)
+  url.searchParams.set("agency", config.crm.agencyUuid)
   appendFilterParams(url, filters)
 
   let res: Response

--- a/lib/crm/share-token.ts
+++ b/lib/crm/share-token.ts
@@ -1,0 +1,54 @@
+/**
+ * CATALYST - Share-Token Resolution (Client-safe)
+ *
+ * A signed share link minted by AgentCRM unlocks the full off-plan detail for
+ * the holder. It lands on the PDP as either `?ref=<token>` or `?share=<token>`.
+ *
+ * Precedence rule (from the CRM handoff): if both keys are present, `ref` wins
+ * — even when it is present-but-blank. A blank `ref` must NOT fall back to
+ * `share`; it means "explicitly no attribution token". We preserve the key the
+ * visitor landed with when forwarding to the CRM detail request, and
+ * canonicalise to `ref` only when building the enquiry-widget iframe URL.
+ *
+ * No server-only imports here — safe for both the server page and the client
+ * widget.
+ */
+
+/** A minimal read surface satisfied by URLSearchParams. */
+interface ParamReader {
+  has(key: string): boolean
+  get(key: string): string | null
+}
+
+export type SelectedShareToken =
+  | { present: true; key: "ref" | "share"; value: string }
+  | { present: false }
+
+/**
+ * Resolve the share token from URL params with ref-wins-even-if-blank
+ * precedence. Returns which key won so the caller can forward it unchanged.
+ */
+export function selectShareToken(params: ParamReader): SelectedShareToken {
+  if (params.has("ref")) {
+    return { present: true, key: "ref", value: params.get("ref") ?? "" }
+  }
+  if (params.has("share")) {
+    return { present: true, key: "share", value: params.get("share") ?? "" }
+  }
+  return { present: false }
+}
+
+/**
+ * Build a param reader from a Next.js `searchParams` record. Only the first
+ * value of a repeated key is considered (matching URLSearchParams.get).
+ */
+export function paramReaderFromRecord(
+  record: Record<string, string | string[] | undefined>,
+): ParamReader {
+  const usp = new URLSearchParams()
+  for (const [key, value] of Object.entries(record)) {
+    if (typeof value === "string") usp.set(key, value)
+    else if (Array.isArray(value) && value.length > 0) usp.set(key, value[0])
+  }
+  return usp
+}

--- a/lib/crm/token-response-headers.ts
+++ b/lib/crm/token-response-headers.ts
@@ -1,0 +1,25 @@
+/**
+ * CATALYST - Share-token response headers (edge-safe, no imports)
+ *
+ * Token-bearing property pages must carry hard HTTP response headers — not just
+ * force-dynamic rendering and a <meta name="referrer"> tag:
+ *   - Cache-Control: private, no-store  → the unlocked full detail is never
+ *     cached by any shared/CDN/browser layer.
+ *   - Referrer-Policy: no-referrer       → the token in the URL never leaks via
+ *     the Referer header.
+ *
+ * Applied in proxy.ts (edge middleware). Returns null for anonymous requests so
+ * the caller leaves their headers untouched.
+ */
+
+export function shareTokenResponseHeaders(
+  searchParams: URLSearchParams,
+): Record<string, string> | null {
+  if (searchParams.has("ref") || searchParams.has("share")) {
+    return {
+      "Cache-Control": "private, no-store",
+      "Referrer-Policy": "no-referrer",
+    }
+  }
+  return null
+}

--- a/lib/crm/types.ts
+++ b/lib/crm/types.ts
@@ -88,6 +88,22 @@ export interface CrmNote {
   date: string
 }
 
+export type CrmAccessTier = "basic" | "full"
+
+/**
+ * Per-response access decision from the CRM. Off-plan listings return
+ * `tier: "basic"` unless the request carries a valid `full` share token; the
+ * gated fields are then simply absent from the payload. `locked_sections`
+ * enumerates what the full view would add so the UI can render a teaser.
+ * Missing on legacy responses — treat absent `access` as full (see mapper).
+ */
+export interface CrmAccess {
+  tier: CrmAccessTier
+  gated: boolean
+  locked_sections: string[]
+  reason: string | null
+}
+
 /** List endpoint property — every documented field. */
 export interface CrmPropertyListItem {
   id: string
@@ -129,6 +145,9 @@ export interface CrmPropertyListItem {
 
   embed_url: string
   embed_html: string
+
+  /** Access decision for this response. Absent on legacy API builds. */
+  access?: CrmAccess | null
 }
 
 /** Detail endpoint extends list shape with rich fields + markdown blocks. */
@@ -184,6 +203,14 @@ export interface CrmListResponse {
 // APP-SHAPED TYPES (camelCase, used by pages/components)
 // =============================================================================
 
+/** Mapped (camelCase) access decision — see CrmAccess. */
+export interface CrmPropertyAccess {
+  tier: CrmAccessTier
+  gated: boolean
+  lockedSections: string[]
+  reason: string | null
+}
+
 export interface CrmProperty {
   id: string
   title: string
@@ -191,6 +218,9 @@ export interface CrmProperty {
   slug: string
   reference: string | null
   description: string | null
+
+  /** Access decision for this response; null when the API omits it (legacy = full). */
+  access: CrmPropertyAccess | null
 
   area: string
   buildingName: string | null
@@ -315,6 +345,37 @@ export interface PublicPropertyFacets {
 // =============================================================================
 // HELPERS
 // =============================================================================
+
+/**
+ * Whether this response is the gated basic tier. Absent `access` (legacy API
+ * builds) is treated as full — never gate a response the CRM didn't gate.
+ */
+export function isBasicTier(property: Pick<CrmProperty, "access">): boolean {
+  return property.access?.tier === "basic"
+}
+
+/**
+ * Human labels for the CRM's `locked_sections` keys, used by the basic-view
+ * teaser. Unknown keys fall back to a title-cased version of the key.
+ */
+const LOCKED_SECTION_LABELS: Record<string, string> = {
+  payment_plan: "Payment plan",
+  unit_types: "Unit types & pricing",
+  developer: "Developer details",
+  documents: "Brochures, floor plans & documents",
+  media: "Media & 3D tours",
+  amenities: "Amenities",
+  reasons_to_invest: "Investment highlights",
+  finishing: "Finishing & materials",
+  notes: "Latest updates",
+}
+
+export function lockedSectionLabel(key: string): string {
+  return (
+    LOCKED_SECTION_LABELS[key] ??
+    key.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+  )
+}
 
 /**
  * True when the property should display a non-available badge on the PDP.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "node scripts/next-build.mjs",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/proxy.ts
+++ b/proxy.ts
@@ -15,6 +15,7 @@ import type { NextRequest } from "next/server"
 import { createServerClient } from "@supabase/ssr"
 import type { CookieOptions } from "@supabase/ssr"
 import { getBrand, DEFAULT_BRAND_ID } from "@/lib/brand"
+import { shareTokenResponseHeaders } from "@/lib/crm/token-response-headers"
 
 // -----------------------------------------------------------------------------
 // Environment Configuration
@@ -130,6 +131,17 @@ export async function proxy(request: NextRequest) {
   // Attach brand context to all downstream responses
   response.headers.set("x-brand", brand.id)
   response.cookies.set("brand", brand.id, brandCookieOptions)
+
+  // Token-bearing property pages: stamp hard no-store + no-referrer response
+  // headers (defence beyond force-dynamic + <meta name="referrer">).
+  if (pathname.startsWith("/properties")) {
+    const tokenHeaders = shareTokenResponseHeaders(request.nextUrl.searchParams)
+    if (tokenHeaders) {
+      for (const [key, value] of Object.entries(tokenHeaders)) {
+        response.headers.set(key, value)
+      }
+    }
+  }
 
   // ---------------------------------------------------------------------------
   // Auth: Route Protection

--- a/tests/crm/access-helpers.test.ts
+++ b/tests/crm/access-helpers.test.ts
@@ -1,0 +1,35 @@
+/**
+ * CATALYST - Access-tier helper tests
+ */
+import { describe, it, expect } from "vitest"
+
+import { isBasicTier, lockedSectionLabel, type CrmProperty } from "@/lib/crm"
+
+function withAccess(access: CrmProperty["access"]): Pick<CrmProperty, "access"> {
+  return { access }
+}
+
+describe("isBasicTier", () => {
+  it("is true for a basic-tier response", () => {
+    expect(isBasicTier(withAccess({ tier: "basic", gated: true, lockedSections: [], reason: null }))).toBe(true)
+  })
+
+  it("is false for a full-tier response", () => {
+    expect(isBasicTier(withAccess({ tier: "full", gated: false, lockedSections: [], reason: null }))).toBe(false)
+  })
+
+  it("treats absent access as full (legacy responses are never gated)", () => {
+    expect(isBasicTier(withAccess(null))).toBe(false)
+  })
+})
+
+describe("lockedSectionLabel", () => {
+  it("maps known keys to friendly labels", () => {
+    expect(lockedSectionLabel("payment_plan")).toBe("Payment plan")
+    expect(lockedSectionLabel("unit_types")).toBe("Unit types & pricing")
+  })
+
+  it("title-cases unknown keys", () => {
+    expect(lockedSectionLabel("some_new_section")).toBe("Some New Section")
+  })
+})

--- a/tests/crm/client.test.ts
+++ b/tests/crm/client.test.ts
@@ -1,0 +1,173 @@
+/**
+ * CATALYST - AgentCRM client tests
+ *
+ * Covers the sharing/gating contract: agency UUID requests, token forwarding
+ * with no-store, token scrubbing in error logs, null-slug UUID fallback,
+ * access mapping, and that internal fields never survive mapping.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest"
+
+const AGENCY_UUID = "f78d13a4-c23e-47ce-81f6-b36284891eca"
+
+vi.mock("server-only", () => ({}))
+// NB: factory is hoisted above imports — inline the literal, no outer refs.
+vi.mock("@/lib/config", () => ({
+  config: {
+    crm: {
+      baseUrl: "https://crm.example.com",
+      agencyUuid: "f78d13a4-c23e-47ce-81f6-b36284891eca",
+      agencySlug: "prime-capital",
+    },
+  },
+}))
+vi.mock("@/lib/error-tracking", () => ({ trackError: vi.fn() }))
+
+import { getCrmProperties, getCrmPropertyBySlug } from "@/lib/crm/client"
+import { trackError } from "@/lib/error-tracking"
+
+function jsonResponse(data: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => data,
+  } as unknown as Response
+}
+
+function listRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "uuid-1",
+    title: "Marina Tower",
+    slug: "marina-tower",
+    area: "Dubai Marina",
+    price: 1_000_000,
+    price_from: 1_000_000,
+    images: [],
+    ...overrides,
+  }
+}
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.stubGlobal("fetch", mockFetch)
+})
+
+describe("agency requests", () => {
+  it("queries the property list with the agency UUID", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: [listRow()], pagination: { next_cursor: null, has_more: false, total: 1 } }),
+    )
+    await getCrmProperties()
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain(`agency=${AGENCY_UUID}`)
+  })
+
+  it("queries the detail endpoint with the agency UUID and never caches (no-store)", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: listRow() }))
+    await getCrmPropertyBySlug("marina-tower")
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toContain(`agency=${AGENCY_UUID}`)
+    // Anonymous property fetches must be no-store too — no website ISR/TTL.
+    expect(init.cache).toBe("no-store")
+    expect(init.next).toBeUndefined()
+  })
+
+  it("uses no-store for the anonymous list fetch (no ISR revalidate)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({ data: [listRow()], pagination: { next_cursor: null, has_more: false, total: 1 } }),
+    )
+    await getCrmProperties()
+    const init = mockFetch.mock.calls[0][1]
+    expect(init.cache).toBe("no-store")
+    expect(init.next).toBeUndefined()
+  })
+})
+
+describe("share token forwarding", () => {
+  it("forwards the token under the landing key and disables caching", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: listRow() }))
+    await getCrmPropertyBySlug("marina-tower", {
+      shareToken: { present: true, key: "ref", value: "tok-123" },
+    })
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toContain("ref=tok-123")
+    expect(init.cache).toBe("no-store")
+    expect(init.next).toBeUndefined()
+  })
+
+  it("preserves a share-key landing token", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: listRow() }))
+    await getCrmPropertyBySlug("marina-tower", {
+      shareToken: { present: true, key: "share", value: "tok-9" },
+    })
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toContain("share=tok-9")
+    expect(url).not.toContain("ref=")
+  })
+
+  it("scrubs the token from error-tracking on fetch failure", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network down"))
+    await getCrmPropertyBySlug("marina-tower", {
+      shareToken: { present: true, key: "ref", value: "super-secret-token" },
+    })
+    expect(trackError).toHaveBeenCalledTimes(1)
+    const meta = (trackError as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1]
+    expect(meta.url).not.toContain("super-secret-token")
+    expect(meta.url).toContain("ref=REDACTED")
+  })
+})
+
+describe("mapping", () => {
+  it("falls back to the UUID when the slug is null (secondary privacy)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: [listRow({ id: "uuid-secondary", slug: null })],
+        pagination: { next_cursor: null, has_more: false, total: 1 },
+      }),
+    )
+    const { properties } = await getCrmProperties()
+    expect(properties[0].slug).toBe("uuid-secondary")
+  })
+
+  it("never exposes commission_rate or raw unit_number", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: listRow({ commission_rate: 2.5, unit_number: "APT-1203" }),
+      }),
+    )
+    const property = await getCrmPropertyBySlug("marina-tower")
+    expect(property).not.toBeNull()
+    expect("commission_rate" in (property as object)).toBe(false)
+    // unit_number (snake) is never mapped; only the camel unitNumber exists and
+    // is null unless the API supplies it under the mapped field.
+    expect("unit_number" in (property as object)).toBe(false)
+  })
+
+  it("maps the access block to camelCase, null when absent", async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: listRow({
+          access: {
+            tier: "basic",
+            gated: true,
+            locked_sections: ["payment_plan", "unit_types"],
+            reason: null,
+          },
+        }),
+      }),
+    )
+    const withAccess = await getCrmPropertyBySlug("marina-tower")
+    expect(withAccess?.access).toEqual({
+      tier: "basic",
+      gated: true,
+      lockedSections: ["payment_plan", "unit_types"],
+      reason: null,
+    })
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ data: listRow() }))
+    const noAccess = await getCrmPropertyBySlug("marina-tower")
+    expect(noAccess?.access).toBeNull()
+  })
+})

--- a/tests/crm/pdp-enquiry-channel.test.ts
+++ b/tests/crm/pdp-enquiry-channel.test.ts
@@ -1,0 +1,35 @@
+/**
+ * CATALYST - PDP enquiry-channel guard
+ *
+ * The property detail page must keep the CRM iframe widget as the single owner
+ * of PDP enquiries. It must NOT also submit through the server /api/leads route
+ * (that route is for native, non-widget forms only). This is a structural guard
+ * — the async server component can't be imported under jsdom because it pulls in
+ * server-only modules.
+ */
+import { describe, it, expect } from "vitest"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+
+const pageSource = readFileSync(
+  path.join(process.cwd(), "app/(web)/properties/[slug]/page.tsx"),
+  "utf8",
+)
+
+describe("PDP enquiry channel", () => {
+  it("renders the iframe enquiry widget", () => {
+    expect(pageSource).toContain("PropertyEnquiryWidget")
+  })
+
+  it("does not submit through /api/leads", () => {
+    expect(pageSource).not.toContain("/api/leads")
+  })
+
+  it("exposes an #enquiry anchor as the CTA target", () => {
+    expect(pageSource).toContain('id="enquiry"')
+  })
+
+  it("scrubs the share token from the URL when present", () => {
+    expect(pageSource).toContain("StripShareToken")
+  })
+})

--- a/tests/crm/property-enquiry-widget.test.tsx
+++ b/tests/crm/property-enquiry-widget.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * CATALYST - PropertyEnquiryWidget attribution tests
+ *
+ * The share token must reach the iframe from the `shareRef` prop, never from
+ * window.location.search — the PDP scrubs ref/share from the URL on mount.
+ */
+import { describe, it, expect, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+import { PropertyEnquiryWidget } from "@/components/shared/property-enquiry-widget/property-enquiry-widget"
+
+const TITLE = "Enquire about this property"
+
+beforeEach(() => {
+  window.history.replaceState({}, "", "/")
+})
+
+describe("PropertyEnquiryWidget attribution", () => {
+  it("forwards the shareRef prop as the iframe's canonical ref", async () => {
+    render(<PropertyEnquiryWidget slug="marina-tower" shareRef={{ present: true, value: "tok-abc" }} />)
+    const iframe = await screen.findByTitle(TITLE)
+    expect(iframe.getAttribute("src")).toContain("ref=tok-abc")
+  })
+
+  it("survives URL scrubbing — token comes from the prop, not the address bar", async () => {
+    // URL has no token (already scrubbed) but the prop carries it.
+    render(<PropertyEnquiryWidget slug="marina-tower" shareRef={{ present: true, value: "tok-xyz" }} />)
+    const iframe = await screen.findByTitle(TITLE)
+    expect(iframe.getAttribute("src")).toContain("ref=tok-xyz")
+  })
+
+  it("does NOT read a ref token from window.location.search", async () => {
+    window.history.replaceState({}, "", "/?ref=url-token&utm_source=email")
+    render(<PropertyEnquiryWidget slug="marina-tower" />)
+    const iframe = await screen.findByTitle(TITLE)
+    const src = iframe.getAttribute("src") ?? ""
+    expect(src).not.toContain("url-token")
+    // UTM is still read from the URL — only the ref token is prop-sourced.
+    expect(src).toContain("utm_source=email")
+  })
+
+  it("forwards nothing for a present-but-blank ref", async () => {
+    render(<PropertyEnquiryWidget slug="marina-tower" shareRef={{ present: true, value: "" }} />)
+    const iframe = await screen.findByTitle(TITLE)
+    const src = iframe.getAttribute("src") ?? ""
+    expect(src).not.toMatch(/[?&]ref=/)
+  })
+})

--- a/tests/crm/share-token.test.ts
+++ b/tests/crm/share-token.test.ts
@@ -1,0 +1,72 @@
+/**
+ * CATALYST - Share-token resolution tests
+ */
+import { describe, it, expect } from "vitest"
+
+import {
+  selectShareToken,
+  paramReaderFromRecord,
+} from "@/lib/crm/share-token"
+
+function sp(query: string) {
+  return new URLSearchParams(query)
+}
+
+describe("selectShareToken", () => {
+  it("selects ref when only ref is present", () => {
+    expect(selectShareToken(sp("ref=abc"))).toEqual({
+      present: true,
+      key: "ref",
+      value: "abc",
+    })
+  })
+
+  it("canonicalises a share-only landing (share wins when ref absent)", () => {
+    expect(selectShareToken(sp("share=xyz"))).toEqual({
+      present: true,
+      key: "share",
+      value: "xyz",
+    })
+  })
+
+  it("prefers ref over share when both are present", () => {
+    expect(selectShareToken(sp("ref=abc&share=xyz"))).toEqual({
+      present: true,
+      key: "ref",
+      value: "abc",
+    })
+  })
+
+  it("lets a present-but-blank ref win and does NOT fall back to share", () => {
+    expect(selectShareToken(sp("ref=&share=xyz"))).toEqual({
+      present: true,
+      key: "ref",
+      value: "",
+    })
+  })
+
+  it("reports absence when neither key is present", () => {
+    expect(selectShareToken(sp("utm_source=email"))).toEqual({ present: false })
+  })
+})
+
+describe("paramReaderFromRecord", () => {
+  it("reads string values and preserves present-but-blank", () => {
+    const reader = paramReaderFromRecord({ ref: "", utm_source: "email" })
+    expect(reader.has("ref")).toBe(true)
+    expect(reader.get("ref")).toBe("")
+    expect(reader.has("share")).toBe(false)
+  })
+
+  it("takes the first value of a repeated key", () => {
+    const reader = paramReaderFromRecord({ ref: ["a", "b"] })
+    expect(reader.get("ref")).toBe("a")
+  })
+
+  it("resolves ref-wins precedence end to end from a Next record", () => {
+    const token = selectShareToken(
+      paramReaderFromRecord({ ref: "", share: "xyz" }),
+    )
+    expect(token).toEqual({ present: true, key: "ref", value: "" })
+  })
+})

--- a/tests/crm/token-response-headers.test.ts
+++ b/tests/crm/token-response-headers.test.ts
@@ -1,0 +1,36 @@
+/**
+ * CATALYST - Token response-header tests
+ *
+ * The pure header decision used by proxy.ts (edge middleware) to stamp
+ * token-bearing property responses. Anonymous requests must be left untouched.
+ */
+import { describe, it, expect } from "vitest"
+
+import { shareTokenResponseHeaders } from "@/lib/crm/token-response-headers"
+
+function sp(query: string) {
+  return new URLSearchParams(query)
+}
+
+describe("shareTokenResponseHeaders", () => {
+  it("returns private/no-store + no-referrer for a ref token", () => {
+    expect(shareTokenResponseHeaders(sp("ref=tok"))).toEqual({
+      "Cache-Control": "private, no-store",
+      "Referrer-Policy": "no-referrer",
+    })
+  })
+
+  it("returns the headers for a share token too", () => {
+    expect(shareTokenResponseHeaders(sp("share=tok"))?.["Cache-Control"]).toBe(
+      "private, no-store",
+    )
+  })
+
+  it("stamps even a present-but-blank ref (still a token landing)", () => {
+    expect(shareTokenResponseHeaders(sp("ref="))?.["Referrer-Policy"]).toBe("no-referrer")
+  })
+
+  it("returns null for anonymous requests (headers untouched)", () => {
+    expect(shareTokenResponseHeaders(sp("utm_source=email"))).toBeNull()
+  })
+})

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -15,6 +15,9 @@ vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(),
   usePathname: () => '/',
   redirect: vi.fn(),
+  // No-op like the real thing for non-framework errors (it only re-throws
+  // Next's internal control-flow errors).
+  unstable_rethrow: vi.fn(),
 }))
 
 // Mock next/cache


### PR DESCRIPTION
## Summary
- consume Prime's basic/full AgentCRM access contract
- forward ref/share tokens without caching or logging them
- keep the iframe as the sole PDP enquiry channel and preserve attribution after URL scrubbing
- use the agency UUID and support null-slug secondary listings
- enforce token response headers and a single locked-details CTA

## Verification
- typecheck passes
- 145/145 tests pass
- lint passes
- production build passes
