### PR TITLE
feat(properties): group off-plan unit types

### DIFF
--- a/app/(web)/properties/[slug]/page.tsx
+++ b/app/(web)/properties/[slug]/page.tsx
@@ -16,6 +16,7 @@ import { JsonLd, propertyJsonLd, breadcrumbJsonLd } from "@/lib/json-ld"
 
 import { getCrmPropertyBySlug } from "@/lib/crm/client"
 import {
+  type CrmUnitGroup,
   formatCrmBedrooms,
   formatCrmPriceRange,
   getStatusBadge,
@@ -82,6 +83,24 @@ function formatNoteDate(date: string): string {
   return d.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
 }
 
+function formatUnitSizeRange(
+  unit: Pick<CrmUnitGroup, "size_min_sqft" | "size_max_sqft">,
+): string {
+  const min = unit.size_min_sqft != null && unit.size_min_sqft > 0
+    ? unit.size_min_sqft
+    : null
+  const max = unit.size_max_sqft != null && unit.size_max_sqft > 0
+    ? unit.size_max_sqft
+    : null
+
+  if (min != null && max != null && min !== max) {
+    return `${min.toLocaleString("en-AE")}–${max.toLocaleString("en-AE")} sqft`
+  }
+
+  const size = min ?? max
+  return size != null ? `${size.toLocaleString("en-AE")} sqft` : "—"
+}
+
 export async function generateMetadata({ params, searchParams }: PageProps) {
   const { slug } = await params
   const token = selectShareToken(paramReaderFromRecord(await searchParams))
@@ -130,10 +149,7 @@ export default async function PropertyDetailPage({ params, searchParams }: PageP
   const statusBadge = getStatusBadge(property.status)
   const isDevelopment = isDevelopmentListing(property)
   const isBasic = isBasicTier(property)
-  // Off-plan pricing reads "Starting from". In the gated basic view the
-  // unit-mix is withheld (so isDevelopment is false), but a gated response is
-  // always an off-plan listing — key off the tier too.
-  const showStartingFrom = isDevelopment || isBasic
+  const showStartingFrom = isDevelopment
   const propertyUrl = `${SITE_URL}/properties/${property.slug}`
   const listingHeroImage = property.images[0]
   const heroImage = getPropertyCoverImage(property.images)
@@ -146,6 +162,7 @@ export default async function PropertyDetailPage({ params, searchParams }: PageP
   const hasBathroomMetric = property.bathrooms != null && property.bathrooms > 0
   const hasSizeMetric = property.sqft != null && property.sqft > 0
   const hasCompletionMetric = Boolean(property.completionDate)
+  const hasUnitAvailability = property.unitGroups?.some((unit) => unit.total_units > 0) ?? false
   const keyMetricCount =
     (hasBedroomMetric ? 1 : 0) +
     (hasBathroomMetric ? 1 : 0) +
@@ -400,46 +417,48 @@ export default async function PropertyDetailPage({ params, searchParams }: PageP
                 </SectionCard>
               )}
 
-              {isDevelopment && property.unitTypes && property.unitTypes.length > 0 && (
+              {isDevelopment && property.unitGroups && property.unitGroups.length > 0 && (
                 <SectionCard title="Available Unit Types" icon={HomeIcon}>
                   <div className="overflow-hidden border border-[var(--web-serenity)]/25 rounded-[2px]">
                     <table className="w-full text-[13px]">
                       <thead className="bg-[var(--web-serenity)]/10">
                         <tr>
                           <th className="text-left px-4 py-3 font-medium text-[var(--web-ash)]">Type</th>
-                          <th className="text-left px-4 py-3 font-medium text-[var(--web-ash)]">Beds</th>
+                          <th className="text-left px-4 py-3 font-medium text-[var(--web-ash)]">Layouts</th>
                           <th className="text-left px-4 py-3 font-medium text-[var(--web-ash)]">Size</th>
                           <th className="text-left px-4 py-3 font-medium text-[var(--web-ash)]">From</th>
-                          <th className="text-left px-4 py-3 font-medium text-[var(--web-ash)]">
-                            Available
-                          </th>
+                          {hasUnitAvailability && (
+                            <th className="text-left px-4 py-3 font-medium text-[var(--web-ash)]">
+                              Available
+                            </th>
+                          )}
                         </tr>
                       </thead>
                       <tbody>
-                        {property.unitTypes.map((unit) => (
+                        {property.unitGroups.map((unit) => (
                           <tr
-                            key={unit.name}
+                            key={`${unit.bedrooms ?? "unspecified"}-${unit.label}`}
                             className="border-t border-[var(--web-serenity)]/20 text-[var(--web-spruce)]"
                           >
-                            <td className="px-4 py-3 font-medium text-[var(--web-ash)]">{unit.name}</td>
-                            <td className="px-4 py-3">{unit.bedrooms ?? "—"}</td>
-                            <td className="px-4 py-3">
-                              {unit.size_sqft != null && unit.size_sqft > 0
-                                ? `${unit.size_sqft.toLocaleString("en-AE")} sqft`
-                                : "—"}
-                            </td>
+                            <td className="px-4 py-3 font-medium text-[var(--web-ash)]">{unit.label}</td>
+                            <td className="px-4 py-3">{unit.layouts.toLocaleString("en-AE")}</td>
+                            <td className="px-4 py-3">{formatUnitSizeRange(unit)}</td>
                             <td className="px-4 py-3">
                               {unit.price_from != null
                                 ? formatCrmPriceRange({
                                     price: unit.price_from,
                                     priceFrom: unit.price_from,
-                                    priceTo: unit.price_to,
+                                    priceTo: null,
                                   })
                                 : "—"}
                             </td>
-                            <td className="px-4 py-3">
-                              {unit.available_units} / {unit.total_units}
-                            </td>
+                            {hasUnitAvailability && (
+                              <td className="px-4 py-3">
+                                {unit.total_units > 0
+                                  ? `${unit.available_units} / ${unit.total_units}`
+                                  : "—"}
+                              </td>
+                            )}
                           </tr>
                         ))}
                       </tbody>

--- a/lib/crm/client.ts
+++ b/lib/crm/client.ts
@@ -221,7 +221,7 @@ function mapDetail(row: CrmPropertyDetail): CrmPropertyFull {
     features: row.features ?? [],
 
     paymentPlan: row.payment_plan,
-    unitTypes: row.unit_types,
+    unitGroups: row.unit_groups ?? null,
 
     media: row.media,
     masterPlanUrl: row.master_plan_url,

--- a/lib/crm/types.ts
+++ b/lib/crm/types.ts
@@ -75,6 +75,18 @@ export interface CrmUnitType {
   total_units: number
 }
 
+/** Bedroom-level summary returned in detail `unit_groups`. */
+export interface CrmUnitGroup {
+  bedrooms: number | null
+  label: string
+  layouts: number
+  size_min_sqft: number | null
+  size_max_sqft: number | null
+  price_from: number | null
+  available_units: number
+  total_units: number
+}
+
 export interface CrmMedia {
   brochure_url: string | null
   video_url: string | null
@@ -159,6 +171,8 @@ export interface CrmPropertyDetail extends CrmPropertyListItem {
   payment_plan: CrmPaymentPlan | null
 
   unit_types: CrmUnitType[] | null
+  /** Absent on API builds from before the additive unit-group rollout. */
+  unit_groups?: CrmUnitGroup[] | null
 
   media: CrmMedia | null
   master_plan_url: string | null
@@ -263,7 +277,7 @@ export interface CrmPropertyFull extends CrmProperty {
   features: string[]
 
   paymentPlan: CrmPaymentPlan | null
-  unitTypes: CrmUnitType[] | null
+  unitGroups: CrmUnitGroup[] | null
 
   media: CrmMedia | null
   masterPlanUrl: string | null
@@ -397,16 +411,30 @@ export function getStatusBadge(status: CrmPropertyStatus): string | null {
 }
 
 /**
- * Whether the PDP should render the off-plan layout (unit mix, payment plan).
+ * Whether the PDP should render the off-plan presentation. Access metadata is
+ * the stable signal for gated responses; unit groups and list-shape fields
+ * keep full/legacy responses correctly classified when access is absent.
  */
-export function isDevelopmentListing(property: CrmPropertyFull): boolean {
-  return Array.isArray(property.unitTypes) && property.unitTypes.length > 0
+export function isDevelopmentListing(
+  property: Pick<
+    CrmPropertyFull,
+    | "access"
+    | "unitGroups"
+    | "constructionProgress"
+    | "completionDate"
+    | "bedroomsMin"
+    | "bedroomsMax"
+  >,
+): boolean {
+  if (property.access?.gated) return true
+  if (Array.isArray(property.unitGroups) && property.unitGroups.length > 0) return true
+  return isOffPlanListing(property)
 }
 
 /**
  * Heuristic for the listing card: off-plan if construction is incomplete or
  * the completion date sits in the future. Used where we only have list-shape
- * data (no unit_types).
+ * data (no unit_groups).
  */
 export function isOffPlanListing(
   property: Pick<CrmProperty, "constructionProgress" | "completionDate" | "bedroomsMin" | "bedroomsMax">

--- a/tests/crm/access-helpers.test.ts
+++ b/tests/crm/access-helpers.test.ts
@@ -3,7 +3,13 @@
  */
 import { describe, it, expect } from "vitest"
 
-import { isBasicTier, lockedSectionLabel, type CrmProperty } from "@/lib/crm"
+import {
+  isBasicTier,
+  isDevelopmentListing,
+  lockedSectionLabel,
+  type CrmProperty,
+  type CrmPropertyFull,
+} from "@/lib/crm"
 
 function withAccess(access: CrmProperty["access"]): Pick<CrmProperty, "access"> {
   return { access }
@@ -31,5 +37,68 @@ describe("lockedSectionLabel", () => {
 
   it("title-cases unknown keys", () => {
     expect(lockedSectionLabel("some_new_section")).toBe("Some New Section")
+  })
+})
+
+type DevelopmentSignals = Pick<
+  CrmPropertyFull,
+  | "access"
+  | "unitGroups"
+  | "constructionProgress"
+  | "completionDate"
+  | "bedroomsMin"
+  | "bedroomsMax"
+>
+
+function developmentSignals(overrides: Partial<DevelopmentSignals> = {}): DevelopmentSignals {
+  return {
+    access: null,
+    unitGroups: null,
+    constructionProgress: null,
+    completionDate: null,
+    bedroomsMin: null,
+    bedroomsMax: null,
+    ...overrides,
+  }
+}
+
+describe("isDevelopmentListing", () => {
+  it("keeps a gated basic listing off-plan when unit groups are withheld", () => {
+    expect(
+      isDevelopmentListing(
+        developmentSignals({
+          access: { tier: "basic", gated: true, lockedSections: ["unit_types"], reason: null },
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("classifies a full legacy response from grouped units", () => {
+    expect(
+      isDevelopmentListing(
+        developmentSignals({
+          unitGroups: [
+            {
+              bedrooms: 0,
+              label: "Studio",
+              layouts: 30,
+              size_min_sqft: 393,
+              size_max_sqft: 450,
+              price_from: 748_000,
+              total_units: 0,
+              available_units: 0,
+            },
+          ],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps a completed listing without off-plan signals ready", () => {
+    expect(
+      isDevelopmentListing(
+        developmentSignals({ constructionProgress: 100, completionDate: "2020-01-01" }),
+      ),
+    ).toBe(false)
   })
 })

--- a/tests/crm/client.test.ts
+++ b/tests/crm/client.test.ts
@@ -170,4 +170,52 @@ describe("mapping", () => {
     const noAccess = await getCrmPropertyBySlug("marina-tower")
     expect(noAccess?.access).toBeNull()
   })
+
+  it("maps the additive unit_groups contract independently of raw unit_types", async () => {
+    const unitGroups = [
+      {
+        bedrooms: 0,
+        label: "Studio",
+        layouts: 30,
+        size_min_sqft: 393,
+        size_max_sqft: 450,
+        price_from: 748_000,
+        total_units: 0,
+        available_units: 0,
+      },
+      {
+        bedrooms: 1,
+        label: "1 Bedroom",
+        layouts: 45,
+        size_min_sqft: 650,
+        size_max_sqft: 820,
+        price_from: 1_100_000,
+        total_units: 12,
+        available_units: 3,
+      },
+    ]
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        data: listRow({
+          unit_types: [
+            {
+              name: "Studio Type A",
+              bedrooms: 0,
+              bathrooms: 1,
+              size_sqft: 393,
+              price_from: 748_000,
+              price_to: 765_000,
+              total_units: 0,
+              available_units: 0,
+            },
+          ],
+          unit_groups: unitGroups,
+        }),
+      }),
+    )
+
+    const property = await getCrmPropertyBySlug("marina-tower")
+
+    expect(property?.unitGroups).toEqual(unitGroups)
+  })
 })


### PR DESCRIPTION
## Summary
- consume additive unit_groups summaries while preserving raw unit_types API typing
- render one PDP row per bedroom group with size ranges and conditional availability
- classify gated off-plan listings independently of unit-group presence

## Validation
- pnpm test:run (152 tests)
- pnpm typecheck
- pnpm lint
- git diff --check