### PR TITLE
Add London Dubai investor meeting landing page

### DIFF
--- a/app/(web)/london/page.tsx
+++ b/app/(web)/london/page.tsx
@@ -1,0 +1,428 @@
+/**
+ * CATALYST - London Investor Meetings Landing Page
+ *
+ * Private in-person invitation for London-based investors considering Dubai
+ * property. Uses Ahmed's existing booking calendar and CRM routing.
+ */
+
+import type { Metadata } from "next"
+import Image from "next/image"
+import Link from "next/link"
+import {
+  ArrowRightIcon,
+  BarChart3Icon,
+  Building2Icon,
+  CalendarDaysIcon,
+  CheckIcon,
+  CompassIcon,
+  MapPinIcon,
+  ShieldCheckIcon,
+} from "lucide-react"
+import { Container, Grid, Stack, Text, Title } from "@/components/core"
+import { LeadForm } from "@/components/shared/lead-form"
+import { config } from "@/lib/config"
+import { AHMED_TEAM_MEMBER_SLUG } from "../ahmed-ashfaq/_components/ahmed-funnel"
+
+export const revalidate = 300
+
+export const metadata: Metadata = {
+  title: "Dubai Property Investor Meetings in London",
+  description:
+    "Meet Prime Capital Dubai advisors Ahmed Ashfaq and Ruhaan Chawla in Central London on 1 or 2 August 2026 for a free, no-obligation 30–45 minute discussion about Dubai property investment.",
+  alternates: {
+    canonical: "/london",
+  },
+  openGraph: {
+    title: "Dubai, beyond the headlines — London investor meetings",
+    description:
+      "Private, in-person meetings with Prime Capital Dubai advisors Ahmed Ashfaq and Ruhaan Chawla in Central London on 1 and 2 August 2026.",
+    url: "/london",
+    images: [
+      {
+        url: "/images/hero/prime-capital-hero.jpg",
+        width: 1200,
+        height: 630,
+        alt: "Prime Capital Dubai investor meetings in London",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Dubai, beyond the headlines — London investor meetings",
+    description:
+      "Private, in-person meetings with Prime Capital Dubai advisors Ahmed Ashfaq and Ruhaan Chawla in Central London on 1 and 2 August 2026.",
+    images: ["/images/hero/prime-capital-hero.jpg"],
+  },
+}
+
+const meetingReasons = [
+  {
+    icon: BarChart3Icon,
+    number: "01",
+    title: "See the market clearly",
+    body: "Separate durable demand, supply, pricing and rental fundamentals from the stories that dominate the headlines.",
+  },
+  {
+    icon: CompassIcon,
+    number: "02",
+    title: "Find your route in",
+    body: "Compare ready, off-plan, income-led and long-term growth strategies against your capital, timeline and risk appetite.",
+  },
+  {
+    icon: Building2Icon,
+    number: "03",
+    title: "Access what comes next",
+    body: "Discuss projects and early-stage opportunities before the next phase of Dubai's growth becomes yesterday's news.",
+  },
+]
+
+const investorGoals = [
+  "Assess whether Dubai belongs in your wider investment portfolio",
+  "Diversify beyond UK property and traditional home-market exposure",
+  "Compare realistic capital-growth and rental-income opportunities",
+  "Explore a future relocation or residency strategy with greater clarity",
+  "Shortlist the right property route for your budget, goals and time horizon",
+]
+
+const meetingSteps = [
+  {
+    number: "01",
+    title: "Choose a time",
+    body: "Select an available appointment on Saturday 1 or Sunday 2 August.",
+  },
+  {
+    number: "02",
+    title: "Name the place",
+    body: "Tell us where in Central London is most convenient for you.",
+  },
+  {
+    number: "03",
+    title: "We come to you",
+    body: "Meet Ahmed and Ruhaan for a focused, private conversation in person.",
+  },
+]
+
+export default function LondonInvestorMeetingsPage() {
+  return (
+    <div className="london-page">
+      <section className="london-hero">
+        <div className="london-hero__media" aria-hidden>
+          <Image
+            src="/images/hero/prime-capital-hero.jpg"
+            alt=""
+            fill
+            priority
+            sizes="100vw"
+            className="london-hero__image"
+          />
+          <div className="london-hero__veil" />
+        </div>
+
+        <Container size="xl" className="relative z-10 w-full">
+          <Grid cols={1} className="london-hero__grid">
+            <Stack gap="lg" className="london-hero__copy">
+              <Text className="london-eyebrow">
+                Private investor meetings · Central London
+              </Text>
+
+              <h1 className="london-display">
+                Dubai, beyond
+                <br />
+                <em>the headlines.</em>
+              </h1>
+
+              <Text className="london-hero__lead">
+                Meet Prime Capital advisors Ahmed Ashfaq and Ruhaan Chawla in London and get
+                a candid, data-led view of the opportunities, risks and on-the-ground
+                reality shaping Dubai property now.
+              </Text>
+
+              <div className="london-event-details" aria-label="Meeting details">
+                <div className="london-event-detail">
+                  <CalendarDaysIcon aria-hidden />
+                  <div>
+                    <Text className="london-event-detail__label">When</Text>
+                    <Text className="london-event-detail__value">
+                      Saturday 1 &amp; Sunday 2 August 2026
+                    </Text>
+                  </div>
+                </div>
+                <div className="london-event-detail">
+                  <MapPinIcon aria-hidden />
+                  <div>
+                    <Text className="london-event-detail__label">Where</Text>
+                    <Text className="london-event-detail__value">
+                      Central London — you choose the location
+                    </Text>
+                  </div>
+                </div>
+              </div>
+
+              <div className="london-hero__assurance">
+                <ShieldCheckIcon aria-hidden />
+                <Text>Free, private and entirely without obligation.</Text>
+              </div>
+            </Stack>
+
+            <aside id="book" className="london-booking-card">
+              <div className="london-booking-card__header">
+                <Text className="london-booking-card__eyebrow">By invitation</Text>
+                <Title as="h2" className="london-booking-card__title">
+                  Reserve your London meeting
+                </Title>
+              <Text className="london-booking-card__intro">
+                  Share your details, then choose an available 30–45 minute meeting
+                  from Ahmed&rsquo;s booking calendar.
+                </Text>
+              </div>
+              <div className="london-booking-card__rule" />
+              <div className="london-booking-card__form">
+                <LeadForm
+                  mode="event"
+                  theme="light"
+                  autoFocus={false}
+                  tag="london-investor-meetings-august-2026"
+                  calendlyUrl={config.links.ahmedBooking}
+                  initialData={{ referringTeamMember: AHMED_TEAM_MEMBER_SLUG }}
+                  propertyLabel="Preferred Central London meeting location"
+                  propertyPlaceholder="Hotel, members' club, office or neighbourhood"
+                  contactSubmitLabel="View available times"
+                  successMessage="Choose a time that works and add your preferred Central London meeting point."
+                />
+              </div>
+              <Text className="london-booking-card__note">
+                Two dates only. Your details stay private.
+              </Text>
+            </aside>
+          </Grid>
+        </Container>
+      </section>
+
+      <section className="london-proof-strip" aria-label="Meeting credentials">
+        <Container size="lg">
+          <Grid cols={1} className="md:grid-cols-3 london-proof-strip__grid">
+            <div className="london-proof-strip__item">
+              <Text className="london-proof-strip__value">2</Text>
+              <Text className="london-proof-strip__label">Dubai advisors, in person</Text>
+            </div>
+            <div className="london-proof-strip__item">
+              <Text className="london-proof-strip__value">20+</Text>
+              <Text className="london-proof-strip__label">Years across market cycles</Text>
+            </div>
+            <div className="london-proof-strip__item">
+              <Text className="london-proof-strip__value">30–45</Text>
+              <Text className="london-proof-strip__label">Minutes, shaped around you</Text>
+            </div>
+          </Grid>
+        </Container>
+      </section>
+
+      <section className="london-section london-section--paper">
+        <Container size="lg">
+          <Grid cols={1} className="london-intro-grid">
+            <Stack gap="md">
+              <Text className="london-section-kicker">Why meet now</Text>
+              <Title as="h2" className="london-section-title">
+                Stop wondering whether Dubai is viable. Start with the evidence.
+              </Title>
+            </Stack>
+            <Stack gap="md" className="london-prose">
+              <Text>
+                Dubai property attracts no shortage of attention. What investors
+                need is not another headline, but a clear view of what is actually
+                happening on the ground — where the market is supported, where the
+                risks sit, and which opportunities deserve conviction.
+              </Text>
+              <Text>
+                This is an unhurried, private conversation with people working in
+                the market every day. Bring your questions, assumptions and concerns.
+                Leave with a better framework for deciding what to do next.
+              </Text>
+            </Stack>
+          </Grid>
+        </Container>
+      </section>
+
+      <section className="london-section london-section--dark">
+        <Container size="lg">
+          <div className="london-section-heading london-section-heading--light">
+            <Text align="center" className="london-section-kicker london-section-kicker--light">
+              What you will gain
+            </Text>
+            <Title
+              as="h2"
+              align="center"
+              className="london-section-title london-section-title--light"
+            >
+              The signal beneath the noise.
+            </Title>
+            <Text align="center" className="london-section-heading__lead">
+              A practical market conversation designed to increase decision quality,
+              not pressure you into a purchase.
+            </Text>
+          </div>
+
+          <Grid cols={1} className="md:grid-cols-3 london-reason-grid">
+            {meetingReasons.map((reason) => {
+              const Icon = reason.icon
+              return (
+                <article key={reason.title} className="london-reason-card">
+                  <div className="london-reason-card__topline">
+                    <Icon className="london-reason-card__icon" aria-hidden />
+                    <Text className="london-reason-card__number">{reason.number}</Text>
+                  </div>
+                  <Title as="h3" className="london-reason-card__title">
+                    {reason.title}
+                  </Title>
+                  <Text className="london-reason-card__body">{reason.body}</Text>
+                </article>
+              )
+            })}
+          </Grid>
+        </Container>
+      </section>
+
+      <section className="london-section london-section--white">
+        <Container size="lg">
+          <Grid cols={1} className="london-fit-grid">
+            <Stack gap="md">
+              <Text className="london-section-kicker">A useful conversation if you want to</Text>
+              <Title as="h2" className="london-section-title">
+                Make a considered move, not a speculative one.
+              </Title>
+              <Text className="london-prose-text">
+                You do not need to be ready to buy. You only need a serious question
+                about whether Dubai can support the next chapter of your investment or
+                relocation plans.
+              </Text>
+            </Stack>
+
+            <div className="london-goal-list">
+              {investorGoals.map((goal) => (
+                <div key={goal} className="london-goal-list__item">
+                  <span className="london-goal-list__icon" aria-hidden>
+                    <CheckIcon />
+                  </span>
+                  <Text>{goal}</Text>
+                </div>
+              ))}
+            </div>
+          </Grid>
+        </Container>
+      </section>
+
+      <section className="london-section london-team-section">
+        <Container size="lg">
+          <div className="london-section-heading">
+            <Text align="center" className="london-section-kicker">Meet the team</Text>
+            <Title as="h2" align="center" className="london-section-title">
+              Ahmed and Ruhaan. One honest conversation.
+            </Title>
+            <Text
+              align="center"
+              className="london-section-heading__lead london-section-heading__lead--dark"
+            >
+              Direct access to the people who assess the market, negotiate with
+              developers and guide international investors through real decisions.
+            </Text>
+          </div>
+
+          <Grid cols={1} className="md:grid-cols-2 london-team-grid">
+            <article className="london-team-card">
+              <div className="london-team-card__portrait">
+                <Image
+                  src="/images/team/Ruhaan Chawla .JPG"
+                  alt="Ruhaan Chawla"
+                  fill
+                  sizes="(min-width: 768px) 40vw, calc(100vw - 3rem)"
+                  className="london-team-card__image london-team-card__image--ruhaan"
+                />
+              </div>
+              <div className="london-team-card__copy">
+                <Text className="london-team-card__role">Property Advisor</Text>
+                <Title as="h3" className="london-team-card__name">Ruhaan Chawla</Title>
+                <Text className="london-team-card__bio">
+                  A Prime Capital advisor focused on helping international investors
+                  navigate Dubai property with clear, practical guidance from the first conversation.
+                </Text>
+              </div>
+            </article>
+
+            <article className="london-team-card">
+              <div className="london-team-card__portrait">
+                <Image
+                  src="/images/team/ahmed-ashfaq.jpg"
+                  alt="Ahmed Ashfaq"
+                  fill
+                  sizes="(min-width: 768px) 40vw, calc(100vw - 3rem)"
+                  className="london-team-card__image london-team-card__image--ahmed"
+                />
+              </div>
+              <div className="london-team-card__copy">
+                <Text className="london-team-card__role">Senior Property Advisor</Text>
+                <Title as="h3" className="london-team-card__name">Ahmed Ashfaq</Title>
+                <Text className="london-team-card__bio">
+                  A Dubai-based advisor with more than 20 years of real estate
+                  experience, specialising in data-led investment strategy and luxury property.
+                </Text>
+              </div>
+            </article>
+          </Grid>
+        </Container>
+      </section>
+
+      <section className="london-section london-section--paper">
+        <Container size="lg">
+          <Grid cols={1} className="london-process-grid">
+            <Stack gap="md">
+              <Text className="london-section-kicker">How it works</Text>
+              <Title as="h2" className="london-section-title">
+                Your meeting, on your terms.
+              </Title>
+              <Text className="london-prose-text">
+                No seminar. No group presentation. Just a private meeting arranged
+                around your diary and a Central London location that suits you.
+              </Text>
+            </Stack>
+
+            <div className="london-step-list">
+              {meetingSteps.map((step) => (
+                <div key={step.number} className="london-step">
+                  <Text className="london-step__number">{step.number}</Text>
+                  <div>
+                    <Title as="h3" className="london-step__title">{step.title}</Title>
+                    <Text className="london-step__body">{step.body}</Text>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Grid>
+        </Container>
+      </section>
+
+      <section className="london-final-cta">
+        <Container size="lg">
+          <Grid cols={1} className="london-final-cta__grid">
+            <Stack gap="sm">
+              <Text className="london-section-kicker london-section-kicker--light">
+                1 &amp; 2 August · Central London
+              </Text>
+              <Title as="h2" className="london-final-cta__title">
+                Get the clarity to invest with conviction.
+              </Title>
+              <Text className="london-final-cta__body">
+                Reserve a free, no-obligation meeting with Ahmed and Ruhaan.
+              </Text>
+            </Stack>
+            <div className="london-final-cta__action">
+              <Link href="#book" className="london-button">
+                Reserve your meeting
+                <ArrowRightIcon aria-hidden />
+              </Link>
+            </div>
+          </Grid>
+        </Container>
+      </section>
+    </div>
+  )
+}

--- a/app/(web)/web.css
+++ b/app/(web)/web.css
@@ -3888,3 +3888,699 @@
   letter-spacing: 0.18em;
   color: var(--web-spruce);
 }
+
+/* =============================================================================
+   LONDON INVESTOR MEETINGS
+   Private, in-person Dubai property invitation. Prefix: london-
+   ============================================================================= */
+
+.london-page {
+  background: var(--web-off-white);
+  color: var(--web-ash);
+}
+
+.london-hero {
+  position: relative;
+  overflow: hidden;
+  background: var(--web-ash);
+}
+
+.london-hero__media,
+.london-hero__veil {
+  position: absolute;
+  inset: 0;
+}
+
+.london-hero__image {
+  object-fit: cover;
+  object-position: center;
+  filter: saturate(0.72) contrast(1.04);
+}
+
+.london-hero__veil {
+  background:
+    linear-gradient(90deg, oklch(from var(--web-ash) l c h / 0.97) 0%, oklch(from var(--web-ash) l c h / 0.91) 48%, oklch(from var(--web-ash) l c h / 0.78) 100%),
+    linear-gradient(180deg, oklch(0 0 0 / 0.08), oklch(0 0 0 / 0.46));
+}
+
+.london-hero__grid {
+  align-items: start;
+  gap: clamp(2.5rem, 6vw, 5.5rem);
+  padding-block: clamp(5.5rem, 11vw, 9rem) clamp(3.5rem, 7vw, 6rem);
+}
+
+.london-hero__copy {
+  max-width: 46rem;
+}
+
+.london-eyebrow,
+.london-section-kicker,
+.london-booking-card__eyebrow {
+  margin: 0;
+  color: var(--web-spruce);
+  font-size: 0.6875rem;
+  font-weight: 400;
+  letter-spacing: 0.2em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.london-eyebrow,
+.london-section-kicker--light {
+  color: var(--web-serenity);
+}
+
+.london-display {
+  margin: 0;
+  color: var(--web-off-white);
+  font-family: var(--font-headline, serif);
+  font-size: clamp(2.75rem, 7.2vw, 6.6rem);
+  font-weight: 400;
+  letter-spacing: -0.035em;
+  line-height: 0.94;
+  text-wrap: balance;
+}
+
+.london-display em {
+  color: var(--web-serenity);
+  font-weight: 400;
+}
+
+.london-hero__lead {
+  max-width: 40rem;
+  margin: 0;
+  color: oklch(from var(--web-off-white) l c h / 0.82);
+  font-size: clamp(1rem, 1.5vw, 1.2rem);
+  font-weight: 300;
+  line-height: 1.75;
+}
+
+.london-event-details {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+  padding-top: 0.25rem;
+}
+
+.london-event-detail {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.875rem;
+  padding: 1rem;
+  border: 1px solid oklch(from var(--web-off-white) l c h / 0.13);
+  background: oklch(from var(--web-off-white) l c h / 0.055);
+  backdrop-filter: blur(12px);
+}
+
+.london-event-detail > svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  margin-top: 0.1rem;
+  flex: 0 0 auto;
+  color: var(--web-serenity);
+  stroke-width: 1.5;
+}
+
+.london-event-detail__label {
+  margin: 0 0 0.2rem;
+  color: oklch(from var(--web-off-white) l c h / 0.52);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.london-event-detail__value {
+  margin: 0;
+  color: var(--web-off-white);
+  font-size: 0.875rem;
+  font-weight: 350;
+  line-height: 1.5;
+}
+
+.london-hero__assurance {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  color: oklch(from var(--web-off-white) l c h / 0.66);
+}
+
+.london-hero__assurance svg {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+  color: var(--web-serenity);
+}
+
+.london-hero__assurance p {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.london-booking-card {
+  overflow: hidden;
+  width: 100%;
+  scroll-margin-top: calc(var(--web-header-height) + 1rem);
+  border: 1px solid oklch(from var(--web-off-white) l c h / 0.13);
+  border-radius: 2px;
+  background: var(--web-off-white);
+  box-shadow: 0 2rem 5rem oklch(0 0 0 / 0.32);
+}
+
+.london-booking-card__header {
+  padding: 1.75rem 1.5rem 1.5rem;
+}
+
+.london-booking-card__title {
+  margin: 0.65rem 0 0.75rem;
+  color: var(--web-ash);
+  font-family: var(--font-headline, serif);
+  font-size: clamp(1.5rem, 2.4vw, 2rem);
+  font-weight: 400;
+  letter-spacing: -0.015em;
+  line-height: 1.15;
+}
+
+.london-booking-card__intro,
+.london-booking-card__note {
+  margin: 0;
+  color: var(--web-spruce);
+  font-size: 0.8rem;
+  font-weight: 300;
+  line-height: 1.6;
+}
+
+.london-booking-card__rule {
+  height: 1px;
+  margin-inline: 1.5rem;
+  background: oklch(from var(--web-serenity) l c h / 0.28);
+}
+
+.london-booking-card__form {
+  padding: 1.5rem;
+}
+
+.london-booking-card__note {
+  padding: 0 1.5rem 1.5rem;
+  font-size: 0.6875rem;
+  letter-spacing: 0.04em;
+}
+
+.london-booking-card .lead-form__question {
+  font-family: var(--font-headline, serif);
+  letter-spacing: -0.01em;
+}
+
+.london-booking-card .lead-form__submit {
+  min-height: 3rem;
+  border-radius: 2px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.london-proof-strip {
+  padding-block: 1.25rem;
+  border-bottom: 1px solid oklch(from var(--web-serenity) l c h / 0.22);
+  background: white;
+}
+
+.london-proof-strip__grid {
+  gap: 0;
+}
+
+.london-proof-strip__item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid oklch(from var(--web-serenity) l c h / 0.2);
+}
+
+.london-proof-strip__item:last-child {
+  border-bottom: 0;
+}
+
+.london-proof-strip__value {
+  margin: 0;
+  color: var(--web-ash);
+  font-family: var(--font-headline, serif);
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.london-proof-strip__label {
+  margin: 0;
+  color: var(--web-spruce);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.london-section {
+  padding-block: clamp(4rem, 8vw, 7rem);
+}
+
+.london-section--paper,
+.london-team-section {
+  background: var(--web-off-white);
+}
+
+.london-section--white {
+  background: white;
+}
+
+.london-section--dark,
+.london-final-cta {
+  background: var(--web-ash);
+}
+
+.london-intro-grid,
+.london-fit-grid,
+.london-process-grid,
+.london-final-cta__grid {
+  gap: clamp(2rem, 6vw, 5rem);
+  align-items: start;
+}
+
+.london-section-title {
+  margin: 0;
+  max-width: 42rem;
+  color: var(--web-ash);
+  font-family: var(--font-headline, serif);
+  font-size: clamp(2rem, 4.3vw, 3.75rem);
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+  text-wrap: balance;
+}
+
+.london-section-title--light {
+  color: var(--web-off-white);
+}
+
+.london-prose,
+.london-prose-text,
+.london-section-heading__lead,
+.london-reason-card__body,
+.london-team-card__bio,
+.london-step__body,
+.london-final-cta__body {
+  color: var(--web-spruce);
+  font-size: 1rem;
+  font-weight: 300;
+  line-height: 1.78;
+}
+
+.london-prose p,
+.london-prose-text,
+.london-section-heading__lead,
+.london-team-card__bio,
+.london-step__body,
+.london-final-cta__body {
+  margin: 0;
+}
+
+.london-section-heading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 48rem;
+  margin: 0 auto clamp(2.5rem, 5vw, 4.5rem);
+  text-align: center;
+}
+
+.london-section-heading .london-section-kicker {
+  margin-bottom: 0.875rem;
+}
+
+.london-section-heading .london-section-title {
+  margin-inline: auto;
+}
+
+.london-section-heading__lead {
+  max-width: 39rem;
+  margin: 1.25rem auto 0;
+  color: oklch(from var(--web-off-white) l c h / 0.68);
+  text-wrap: balance;
+}
+
+.london-section-heading__lead--dark {
+  color: var(--web-spruce);
+}
+
+.london-reason-grid {
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid oklch(from var(--web-off-white) l c h / 0.12);
+  background: oklch(from var(--web-off-white) l c h / 0.12);
+}
+
+.london-reason-card {
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  background: var(--web-ash);
+}
+
+.london-reason-card__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 3.5rem;
+}
+
+.london-reason-card__icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  color: var(--web-serenity);
+  stroke-width: 1.25;
+}
+
+.london-reason-card__number {
+  margin: 0;
+  color: oklch(from var(--web-off-white) l c h / 0.4);
+  font-size: 0.6875rem;
+  letter-spacing: 0.16em;
+}
+
+.london-reason-card__title {
+  margin: 0 0 0.9rem;
+  color: var(--web-off-white);
+  font-family: var(--font-headline, serif);
+  font-size: 1.55rem;
+  font-weight: 400;
+  line-height: 1.15;
+}
+
+.london-reason-card__body {
+  margin: 0;
+  color: oklch(from var(--web-off-white) l c h / 0.64);
+  font-size: 0.9rem;
+  line-height: 1.7;
+}
+
+.london-goal-list {
+  border-top: 1px solid oklch(from var(--web-serenity) l c h / 0.32);
+}
+
+.london-goal-list__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding-block: 1rem;
+  border-bottom: 1px solid oklch(from var(--web-serenity) l c h / 0.32);
+}
+
+.london-goal-list__item p {
+  margin: 0;
+  color: var(--web-ash);
+  font-size: 0.95rem;
+  font-weight: 350;
+  line-height: 1.55;
+}
+
+.london-goal-list__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  margin-top: 0.05rem;
+  flex: 0 0 auto;
+  background: var(--web-spruce);
+  color: var(--web-off-white);
+  border-radius: 999px;
+}
+
+.london-goal-list__icon svg {
+  width: 0.75rem;
+  height: 0.75rem;
+  stroke-width: 2;
+}
+
+.london-team-grid {
+  gap: 1.25rem;
+}
+
+.london-team-card {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 0.42fr) minmax(0, 0.58fr);
+  min-height: 24rem;
+  overflow: hidden;
+  border: 1px solid oklch(from var(--web-serenity) l c h / 0.25);
+  background: white;
+  transition:
+    border-color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out),
+    transform var(--duration-normal) var(--ease-out);
+}
+
+.london-team-card:hover {
+  border-color: oklch(from var(--web-serenity) l c h / 0.62);
+  box-shadow: 0 1rem 2.5rem oklch(0 0 0 / 0.055);
+  transform: translateY(-2px);
+}
+
+.london-team-card__portrait {
+  position: relative;
+  min-height: 20rem;
+  overflow: hidden;
+  background: var(--web-serenity);
+}
+
+.london-team-card__image {
+  object-fit: cover;
+  filter: saturate(0.82);
+}
+
+.london-team-card__image--ruhaan {
+  object-position: 50% 28%;
+  filter: saturate(0.72) brightness(0.82);
+  transform: translateY(5%) scale(1.06);
+}
+
+.london-team-card__image--ahmed {
+  object-position: 50% 20%;
+  filter: saturate(0.78) brightness(1.05);
+  transform: translateY(-7%) scale(1.18);
+}
+
+.london-team-card__copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.london-team-card__role {
+  margin: 0 0 0.65rem;
+  color: var(--web-spruce);
+  font-size: 0.625rem;
+  letter-spacing: 0.16em;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
+.london-team-card__name {
+  margin: 0 0 1rem;
+  color: var(--web-ash);
+  font-family: var(--font-headline, serif);
+  font-size: clamp(1.55rem, 2.7vw, 2.3rem);
+  font-weight: 400;
+  line-height: 1.1;
+}
+
+.london-team-card__bio {
+  font-size: 0.86rem;
+  line-height: 1.68;
+}
+
+.london-step-list {
+  border-top: 1px solid oklch(from var(--web-serenity) l c h / 0.3);
+}
+
+.london-step {
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr);
+  gap: 1rem;
+  padding-block: 1.35rem;
+  border-bottom: 1px solid oklch(from var(--web-serenity) l c h / 0.3);
+}
+
+.london-step__number {
+  margin: 0.2rem 0 0;
+  color: var(--web-serenity);
+  font-size: 0.6875rem;
+  letter-spacing: 0.14em;
+}
+
+.london-step__title {
+  margin: 0 0 0.35rem;
+  color: var(--web-ash);
+  font-family: var(--font-headline, serif);
+  font-size: 1.25rem;
+  font-weight: 400;
+}
+
+.london-step__body {
+  font-size: 0.9rem;
+  line-height: 1.62;
+}
+
+.london-final-cta {
+  padding-block: clamp(3.5rem, 7vw, 5.5rem);
+}
+
+.london-final-cta__grid {
+  align-items: center;
+}
+
+.london-final-cta__title {
+  margin: 0;
+  max-width: 42rem;
+  color: var(--web-off-white);
+  font-family: var(--font-headline, serif);
+  font-size: clamp(2rem, 4vw, 3.5rem);
+  font-weight: 400;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+}
+
+.london-final-cta__body {
+  color: oklch(from var(--web-off-white) l c h / 0.65);
+}
+
+.london-final-cta__action {
+  display: flex;
+}
+
+.london-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 3.5rem;
+  padding-inline: 1.75rem;
+  border: 1px solid var(--web-off-white);
+  border-radius: 2px;
+  background: var(--web-off-white);
+  color: var(--web-ash);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition:
+    background var(--duration-normal) var(--ease-out),
+    color var(--duration-normal) var(--ease-out),
+    transform var(--duration-normal) var(--ease-out);
+}
+
+.london-button svg {
+  width: 1rem;
+  height: 1rem;
+  transition: transform var(--duration-normal) var(--ease-out);
+}
+
+.london-button:hover {
+  background: white;
+  transform: translateY(-1px);
+}
+
+.london-button:hover svg {
+  transform: translateX(2px);
+}
+
+.london-button:focus-visible {
+  outline: 2px solid var(--web-serenity);
+  outline-offset: 4px;
+}
+
+@media (min-width: 640px) {
+  .london-event-details {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 768px) {
+  .london-proof-strip__item {
+    justify-content: center;
+    border-right: 1px solid oklch(from var(--web-serenity) l c h / 0.25);
+    border-bottom: 0;
+  }
+
+  .london-proof-strip__item:last-child {
+    border-right: 0;
+  }
+
+  .london-intro-grid,
+  .london-fit-grid,
+  .london-process-grid,
+  .london-final-cta__grid {
+    grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+  }
+
+  .london-final-cta__action {
+    justify-content: flex-end;
+  }
+}
+
+@media (min-width: 1024px) {
+  .london-hero__grid {
+    grid-template-columns: minmax(0, 1fr) minmax(24rem, 30rem);
+  }
+
+  .london-booking-card {
+    position: sticky;
+    top: 6.5rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .london-hero__veil {
+    background:
+      linear-gradient(180deg, oklch(from var(--web-ash) l c h / 0.92), oklch(from var(--web-ash) l c h / 0.97)),
+      linear-gradient(180deg, oklch(0 0 0 / 0.08), oklch(0 0 0 / 0.38));
+  }
+
+  .london-section-heading {
+    text-align: center;
+  }
+
+  .london-team-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .london-team-card__portrait {
+    min-height: 24rem;
+  }
+
+  .london-final-cta__action,
+  .london-button {
+    width: 100%;
+  }
+}
+
+@media (max-width: 420px) {
+  .london-booking-card__header,
+  .london-booking-card__form {
+    padding-inline: 1.15rem;
+  }
+
+  .london-booking-card__rule {
+    margin-inline: 1.15rem;
+  }
+
+  .london-booking-card__note {
+    padding-inline: 1.15rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .london-team-card:hover,
+  .london-button:hover,
+  .london-button:hover svg {
+    transform: none;
+  }
+}

--- a/catalyst/project-state.md
+++ b/catalyst/project-state.md
@@ -15,7 +15,7 @@
 
 ## Focus
 
-Website launch readiness, including the AgentCRM property-agent display and property-interest routing update. Implementation is ready for review but release remains gated on the upstream CRM deployment.
+Website launch readiness, including review of the new London investor-meetings invitation at `/london` and the AgentCRM property-agent routing update. The property release remains gated on the upstream CRM deployment.
 
 ## Target
 

--- a/components/shared/lead-form/lead-form.tsx
+++ b/components/shared/lead-form/lead-form.tsx
@@ -43,6 +43,8 @@ export function LeadForm({
   downloadAsset,
   calendlyUrl,
   propertyLabel,
+  propertyPlaceholder,
+  contactSubmitLabel,
   showPropertyFields,
   showConcerns,
   autoFocus = true,
@@ -152,9 +154,10 @@ export function LeadForm({
             isSubmitting={isSubmitting}
             onSubmit={submit}
             propertyLabel={propertyLabel}
+            propertyPlaceholder={propertyPlaceholder}
             showPropertyFields={showPropertyFields}
             showConcerns={showConcerns}
-            submitLabel={calendlyUrl ? "Book Call" : undefined}
+            submitLabel={contactSubmitLabel ?? (calendlyUrl ? "Book Call" : undefined)}
             autoFocus={autoFocus}
             onBack={prevStep}
             canGoBack={canGoBack}

--- a/components/shared/lead-form/steps/contact-step.tsx
+++ b/components/shared/lead-form/steps/contact-step.tsx
@@ -25,6 +25,8 @@ interface ContactStepProps {
   onSubmit?: (data: Partial<LeadFormData>) => void
   /** Optional: show a combined property name/location field with this label */
   propertyLabel?: string
+  /** Optional: placeholder for the combined property/location field */
+  propertyPlaceholder?: string
   /** Optional: show separate property name and location fields */
   showPropertyFields?: boolean
   /** Optional: show a concerns/notes textarea */
@@ -46,6 +48,7 @@ export function ContactStep({
   isSubmitting = false,
   onSubmit,
   propertyLabel,
+  propertyPlaceholder,
   showPropertyFields,
   showConcerns,
   submitLabel,
@@ -203,7 +206,7 @@ export function ContactStep({
               type="text"
               value={propertyLocation}
               onChange={(e) => setPropertyLocation(e.target.value)}
-              placeholder="e.g. Marina Gate Tower 2, Dubai Marina"
+              placeholder={propertyPlaceholder ?? "e.g. Marina Gate Tower 2, Dubai Marina"}
               className="lead-form__input"
               autoComplete="off"
             />

--- a/components/shared/lead-form/types.ts
+++ b/components/shared/lead-form/types.ts
@@ -219,6 +219,12 @@ export interface LeadFormProps {
   /** Optional: Show a property name/location field on the contact step with this label */
   propertyLabel?: string
 
+  /** Optional: Placeholder for the combined property/location field */
+  propertyPlaceholder?: string
+
+  /** Optional: Custom contact-step submit label when it opens a booking calendar */
+  contactSubmitLabel?: string
+
   /** Optional: Show separate property name and location fields instead of a single combined field */
   showPropertyFields?: boolean
 


### PR DESCRIPTION
Adds a branded /london landing page for private Dubai property investor meetings in Central London on 1–2 August 2026, with responsive sections, advisor profiles, and Ahmed's existing booking calendar embedded after lead capture.

Extends shared LeadForm contact options so campaign-specific location placeholders and booking CTA labels can be supplied without changing other forms. Routes submissions as tagged event prospects to Ahmed and updates the Catalyst project focus.

Validation: pnpm typecheck, pnpm lint, and pnpm build.