### PR TITLE
Update London Google booking handoff

### DIFF
--- a/components/shared/lead-form/lead-form.css
+++ b/components/shared/lead-form/lead-form.css
@@ -900,3 +900,10 @@
 .lead-form__combo-option--custom.lead-form__combo-option--active {
   color: var(--lf-text);
 }
+
+.lead-form__booking-note {
+  margin: 0 0 1rem;
+  color: var(--lf-text-muted);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}

--- a/components/shared/lead-form/steps/success-step.tsx
+++ b/components/shared/lead-form/steps/success-step.tsx
@@ -4,7 +4,8 @@
  * For download mode: shows success then redirects after a brief delay.
  * For Calendly URLs: embeds Calendly's official widget with prefill + booking
  * postMessage hook. For Google Calendar appointment URLs: embeds the booking
- * page in an iframe with name/email/phone prefilled via query params.
+ * page in an iframe. Google does not support URL-based contact prefill, so the
+ * lead remains captured in CRM while Google asks the visitor to confirm it.
  */
 
 "use client"
@@ -67,19 +68,25 @@ export function SuccessStep({
     const vendor = detectBookingVendor(calendlyUrl)
 
     if (vendor === "google") {
-      const embedUrl = buildGoogleCalendarUrl(calendlyUrl, data)
+      const embedUrl = buildGoogleCalendarUrl(calendlyUrl)
       return (
-        <iframe
-          src={embedUrl}
-          title="Book your call"
-          className="lead-form__booking-iframe"
-          style={{
-            width: "100%",
-            minWidth: "320px",
-            height: "780px",
-            border: 0,
-          }}
-        />
+        <>
+          <p className="lead-form__booking-note">
+            Your details have been saved. Choose a time below and confirm them with
+            Google to complete your booking.
+          </p>
+          <iframe
+            src={embedUrl}
+            title="Choose your meeting time"
+            className="lead-form__booking-iframe"
+            style={{
+              width: "100%",
+              minWidth: "320px",
+              height: "780px",
+              border: 0,
+            }}
+          />
+        </>
       )
     }
 
@@ -295,27 +302,10 @@ function detectBookingVendor(url: string): "calendly" | "google" | "unknown" {
   return "unknown"
 }
 
-/**
- * Build Google Calendar appointment URL with prefill params.
- * Google decodes %20 for spaces in name; we keep it explicit to match Calendly's
- * pattern and avoid the `+` ambiguity that URLSearchParams introduces.
- */
-function buildGoogleCalendarUrl(
-  baseUrl: string,
-  data: Partial<LeadFormData>,
-): string {
-  const parts: string[] = ["gv=true"]
-  const add = (key: string, value: string) => {
-    parts.push(`${key}=${encodeURIComponent(value)}`)
-  }
-
-  const fullName = [data.firstName, data.lastName].filter(Boolean).join(" ")
-  if (fullName) add("name", fullName)
-  if (data.email) add("email", data.email)
-  if (data.whatsapp) add("phone", data.whatsapp)
-
+/** Build Google's supported inline appointment-schedule URL. */
+function buildGoogleCalendarUrl(baseUrl: string): string {
   const separator = baseUrl.includes("?") ? "&" : "?"
-  return `${baseUrl}${separator}${parts.join("&")}`
+  return `${baseUrl}${separator}gv=true`
 }
 
 /**

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -125,7 +125,7 @@ export const config = {
      */
     ahmedBooking:
       process.env.NEXT_PUBLIC_AHMED_BOOKING_URL ||
-      "https://calendar.google.com/calendar/appointments/schedules/AcZssZ3wD-uT_GoWbEW82SGuRGEi7UNl4oZZTR_FXfHsgwKmny033KkjDLNcSmobJy2onjr5DDJBPcl_",
+      "https://calendar.google.com/calendar/appointments/schedules/AcZssZ0RaVlRjUT7NTlWU7O78n_xyuFyks8eNIFCYtqJz3o2326VPbBWzJMYM2r-4Ioo31rUpp6gp9Gx",
     /** Calendly scheduling link (15-minute seller consultation) */
     calendlySeller: "https://calendly.com/tahirmajithia/15min",
     /**


### PR DESCRIPTION
Updates the London investor meeting page to use Ahmed's new Google appointment schedule. Keeps the website lead form and CRM capture before showing Google's booking form. Removes unsupported contact prefill parameters and adds clear copy explaining that details must be confirmed with Google. Typecheck and lint pass.