### PR TITLE
Migrate conductor.json to .conductor/settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,11 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+archive = ""
+setup = "cp $CONDUCTOR_ROOT_PATH/.env.local .env.local; pnpm install"
+
+[scripts.run.run]
+available_in = "local"
+command = "pnpm run dev"
+default = true
+icon = "play"

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,0 @@
-{
-  "scripts": {
-    "setup": "cp $CONDUCTOR_ROOT_PATH/.env.local .env.local; pnpm install",
-    "run": "pnpm run dev",
-    "archive": ""
-  }
-}


### PR DESCRIPTION
This PR migrates the legacy `conductor.json` configuration to the new `.conductor/settings.toml` format.

Generated by Conductor.